### PR TITLE
JBTM-1032 XTS SimplifyLogs fails if the output directory is a child of t...

### DIFF
--- a/XTS/sar/crash-recovery-tests/src/main/java/com/arjuna/qa/simplifylogs/SimplifyLogs.java
+++ b/XTS/sar/crash-recovery-tests/src/main/java/com/arjuna/qa/simplifylogs/SimplifyLogs.java
@@ -23,6 +23,12 @@ public class SimplifyLogs
 
         for (File file : logDir.listFiles())
         {
+            if (file.isDirectory())
+            {
+                continue;
+            }
+
+            System.out.println("Processing: '" + file.getName() + "'");
             List<String> log = loadLog(file);
             
             if (log.size() == 0)


### PR DESCRIPTION
...he input directory
