### PR TITLE
JBTM-1085 TestBACrashDuringCommit fail on XTS crash recovery

### DIFF
--- a/XTS/sar/crash-recovery-tests/src/main/java/com/arjuna/qa/extension/JBossAS7ServerKillProcessor.java
+++ b/XTS/sar/crash-recovery-tests/src/main/java/com/arjuna/qa/extension/JBossAS7ServerKillProcessor.java
@@ -60,12 +60,15 @@ public class JBossAS7ServerKillProcessor implements ServerKillProcessor {
 		int rc = p.exitValue();
 
 		if (rc != 0 && rc != 1) {
+			p.destroy();
 			throw new RuntimeException("Kill Sequence failed");
 		}
 		
 		InputStream out = p.getInputStream();
 		BufferedReader in = new BufferedReader(new InputStreamReader(out));
 		String result= in.readLine();
+		out.close();
+		p.destroy();
 		
 		return !(result != null && result.contains("The controller is not available"));
 	}

--- a/XTS/sar/crash-recovery-tests/src/test/java/com/arjuna/qa/junit/BaseCrashTest.java
+++ b/XTS/sar/crash-recovery-tests/src/test/java/com/arjuna/qa/junit/BaseCrashTest.java
@@ -128,8 +128,8 @@ public class BaseCrashTest
         controller.start("jboss-as", config.map());
 
         //redeploy xtstest
-        deployer.undeploy("xtstest");
-        deployer.deploy("xtstest");
+        //deployer.undeploy("xtstest");
+        //deployer.deploy("xtstest");
 
         //Waiting for recovery
         //Thread.sleep(waitForRecovery * 60 * 1000);


### PR DESCRIPTION
1. fix JBossAS7ServerKillProcessor.java to close file stream and destroy process after running check command.
2. fix BaseCrashTest.java to not redeploy war when the second booting as.
