### PR TITLE
JBTM-1127 tx-object-store not empty after running TestATSubordinateCrash...

### DIFF
--- a/XTS/sar/crash-recovery-tests/src/test/resources/scripts/ATSubordinateCrashDuringPrepare.txt
+++ b/XTS/sar/crash-recovery-tests/src/test/resources/scripts/ATSubordinateCrashDuringPrepare.txt
@@ -682,7 +682,6 @@ RULE trace delete participant and exit JVM
 CLASS org.jboss.jbossts.xts.recovery.participant.at.XTSATRecoveryManagerImple
 METHOD deleteParticipantRecoveryRecord
 AFTER CALL remove_committed
-BIND dummy = flag("tx removed")
 IF incrementCounter("participant deletes") == 3 &&
    flagged("tx removed")
 DO traceln("log", "JVM exit"),


### PR DESCRIPTION
...DuringPrepare XTS recovery test
