### PR TITLE
JBTM-1193 XTS unit tests: IllegalStateException: testSetStarting called twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.7.2</version>
+          <version>2.9</version>
             <configuration>
               <forkMode>pertest</forkMode>
               <workingDirectory>target/test-classes</workingDirectory>


### PR DESCRIPTION
Upgrade maven-surefire-plugin version to 2.9
