### PR TITLE
JBTM-1287 @DataManagement injection point is null on service invocation

### DIFF
--- a/txframework/src/test/java/org/jboss/narayana/txframework/functional/ATTest.java
+++ b/txframework/src/test/java/org/jboss/narayana/txframework/functional/ATTest.java
@@ -11,6 +11,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,6 +22,7 @@ import java.util.List;
 import static org.jboss.narayana.txframework.functional.common.ServiceCommand.*;
 
 @RunWith(Arquillian.class)
+@Ignore //JBTM-1287
 public class ATTest extends BaseFunctionalTestWar
 {
     private UserTransaction ut;


### PR DESCRIPTION
Ignoring the test until the dependent AS7 issue for JBTM-1287 is resolved.
