### PR TITLE
JBTM-1702

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
@@ -583,6 +583,7 @@ public class XAResourceRecord extends AbstractRecord
 	                return _heuristic;
 
 	            XAException endHeuristic = null;
+	            XAException endRBOnly = null;
 
 	            try
 	            {
@@ -626,6 +627,7 @@ public class XAResourceRecord extends AbstractRecord
 	                     * need to call rollback.
 	                     */
 
+	                	endRBOnly = e1;
 	                    commit = false;
 	                    break;
 	                case XAException.XAER_RMERR:
@@ -664,8 +666,10 @@ public class XAResourceRecord extends AbstractRecord
 
 	                if (commit)
 	                    _theXAResource.commit(_tranID, true);
-	                else
+	                else {
 	                    _theXAResource.rollback(_tranID);
+	                    throw endRBOnly;
+	                }
 	            }
 	            catch (XAException e1)
 	            {

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/common/FailureXAResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/common/FailureXAResource.java
@@ -27,7 +27,7 @@ import javax.transaction.xa.Xid;
 public class FailureXAResource implements XAResource
 {
     public enum FailLocation { none, prepare, commit, rollback, end, prepare_and_rollback };
-    public enum FailType { normal, timeout, heurcom, nota, inval, proto, rmfail, rollback };
+    public enum FailType { normal, timeout, heurcom, nota, inval, proto, rmfail, rollback, XA_RBCOMMFAIL };
     
     public FailureXAResource ()
     {
@@ -83,6 +83,9 @@ public class FailureXAResource implements XAResource
             
             if (_type == FailType.timeout)
                 throw new XAException(XAException.XA_RBTIMEOUT);
+            
+            if (_type == FailType.XA_RBCOMMFAIL)
+                throw new XAException(XAException.XA_RBCOMMFAIL);
         }
     }
 

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/twophase/XAResourceRecordUnitTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/twophase/XAResourceRecordUnitTest.java
@@ -174,7 +174,11 @@ public class XAResourceRecordUnitTest
         
         xares = new XAResourceRecord(tx, new FailureXAResource(FailLocation.end, FailType.timeout), tx.getTxId(), null);
         
-        assertEquals(xares.topLevelOnePhaseCommit(), TwoPhaseOutcome.FINISH_ERROR);
+        assertEquals(xares.topLevelOnePhaseCommit(), TwoPhaseOutcome.ONE_PHASE_ERROR);
+        
+        xares = new XAResourceRecord(tx, new FailureXAResource(FailLocation.end, FailType.XA_RBCOMMFAIL), tx.getTxId(), null);
+        
+        assertEquals(xares.topLevelOnePhaseCommit(), TwoPhaseOutcome.ONE_PHASE_ERROR);
         
         xares = new XAResourceRecord(tx, new FailureXAResource(FailLocation.commit, FailType.heurcom), tx.getTxId(), null);
         


### PR DESCRIPTION
updated to return TwoPhaseOutcome.ONE_PHASE_ERROR when a one phase commit fails to ensure the rollback exception is propagated to the client
