### PR TITLE
JBTM-1790. Check if xaNodeName received from TXControl is not null.

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
@@ -394,7 +394,9 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
 							XidImple loadedXid = (XidImple) saa.getXid();
 							if (loadedXid.getFormatId() == XATxConverter.FORMAT_ID) {
 								String loadedXidSubordinateNodeName = XATxConverter.getSubordinateNodeName(loadedXid.getXID());
-								if (TxControl.getXANodeName().equals(loadedXidSubordinateNodeName)) {
+                                if ((loadedXidSubordinateNodeName == null && loadedXidSubordinateNodeName == TxControl.getXANodeName())
+                                        || loadedXidSubordinateNodeName.equals(TxControl.getXANodeName())) {
+
 									if (parentNodeName.equals(saa.getParentNodeName())) {
 										if (jtaLogger.logger.isDebugEnabled()) {
 											jtaLogger.logger.debug("Found record for " + saa);

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -451,6 +451,9 @@ public interface jtaI18NLogger {
     @Message(id = 16110, value = "Transaction is required for invocation", format = MESSAGE_FORMAT)
    	public String get_tx_required();
 
+    @Message(id = 16111, value = "The node identifier cannot be null", format = MESSAGE_FORMAT)
+    public String get_nodename_null();
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in sequence. Don't reuse ids.

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XATxConverter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XATxConverter.java
@@ -40,6 +40,7 @@ import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecordWrappingPlugin;
 import com.arjuna.ats.internal.jta.xa.XID;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
+import com.arjuna.ats.jta.logging.jtaLogger;
 
 /**
  * @author Mark Little (mark.little@arjuna.com)
@@ -89,6 +90,11 @@ public class XATxConverter
         }
 
         String nodeName = TxControl.getXANodeName();
+
+        if (nodeName == null) {
+            throw new IllegalStateException(jtaLogger.i18NLogger.get_nodename_null());
+        }
+
         int nodeNameLengthToUse =  nodeName.getBytes().length;
         xid.gtrid_length = gtridUid.length+nodeNameLengthToUse;
 

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/logging/jtsI18NLogger.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/logging/jtsI18NLogger.java
@@ -1067,6 +1067,9 @@ public interface jtsI18NLogger {
     @LogMessage(level = WARN)
     public void warn_server_top_level_action_inactive();
 
+    @Message(id = 22262, value = "The node identifier cannot be null", format = MESSAGE_FORMAT)
+    public String get_nodename_null();
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in sequence. Don't reuse ids.

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/utils/Utility.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/utils/Utility.java
@@ -33,6 +33,7 @@ package com.arjuna.ats.jts.utils;
 
 import java.io.PrintWriter;
 
+import com.arjuna.ats.jts.logging.jtsLogger;
 import org.omg.CORBA.BAD_PARAM;
 import org.omg.CosTransactions.PropagationContext;
 import org.omg.CosTransactions.Status;
@@ -250,6 +251,11 @@ public class Utility
 
 	otid_t otid = new otid_t();
 	byte[] b = theUid.getBytes();
+
+	if (TxControl.getXANodeName() == null) {
+		throw new IllegalStateException(jtsLogger.i18NLogger.get_nodename_null());
+	}
+
 	byte[] nodeName = TxControl.getXANodeName().getBytes();
 
 	otid.formatID = 0;


### PR DESCRIPTION
I've added simple checking or exceptions in the places where null pointer exception can be thrown by using TxControl.getXANodeName(). It works for all JTS tests which throw NullPointerException after setting node name to null.

However, there are other places which utilise node names as null, but they do the checking for that, so I didn't touch them.
