### PR TITLE
Fixing parent version at qa/pom.xml

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -10,7 +10,7 @@
     <parent>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>narayana-all</artifactId>
-      <version>5.0.0.M3-SNAPSHOT</version>
+      <version>4.17.8.Final-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Fixing incorrect parent version of pom.xml in qa folder. The pom.xml is used for getting netty archive which is needed for testing with hornetq object store.
