### PR TITLE
JBTM-1751 fix for 4.17

### DIFF
--- a/XTS/byteman_support/src/main/java/org/jboss/jbossts/xts/bytemanSupport/participantReadOnly/ParticipantCompletionReadOnlyRules.java
+++ b/XTS/byteman_support/src/main/java/org/jboss/jbossts/xts/bytemanSupport/participantReadOnly/ParticipantCompletionReadOnlyRules.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.jbossts.xts.bytemanSupport.participantReadOnly;
+
+/**
+ * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ */
+public class ParticipantCompletionReadOnlyRules {
+
+    public static String RESOURCE_PATH= "org/jboss/jbossts/xts/bytemanSupport/participantReadOnly/participant_completion_coordinator_readonly_rules.btm";
+
+    public static void enableReadOnlyCheck() {
+        //Dummy method, detected by Byteman Rules
+    }
+}

--- a/XTS/byteman_support/src/main/resources/org/jboss/jbossts/xts/bytemanSupport/participantReadOnly/participant_completion_coordinator_readonly_rules.btm
+++ b/XTS/byteman_support/src/main/resources/org/jboss/jbossts/xts/bytemanSupport/participantReadOnly/participant_completion_coordinator_readonly_rules.btm
@@ -1,0 +1,39 @@
+RULE enable readonly check
+CLASS org.jboss.jbossts.xts.bytemanSupport.participantReadOnly.ParticipantCompletionReadOnlyRules
+METHOD enableReadOnlyCheck()
+BIND NOTHING
+IF TRUE
+DO debug("participant_completion_readonly.enable"),
+  flag("enabled")
+ENDRULE
+
+RULE readonly delay 3s for test
+CLASS com.arjuna.wst11.messaging.CoordinatorProcessorImpl
+METHOD readOnly(Notification, MAP, ArjunaContext)
+AT ENTRY
+IF TRUE
+DO debug("readonly delay 3s"),
+   Thread.sleep(3000)
+ENDRULE
+
+RULE readonly called
+CLASS com.arjuna.wst11.messaging.CoordinatorProcessorImpl
+METHOD readOnly(Notification, MAP, ArjunaContext)
+AT RETURN
+BIND NOTHING
+IF (flagged("enabled"))
+DO debug("coordinator_processor_readonly.called.waking"),
+   signalWake("readonly", true),
+   debug("coordinator_processor_readonly.called.donewake")
+ENDRULE
+
+RULE prepare called
+CLASS com.arjuna.wst11.messaging.ParticipantProcessorImpl
+METHOD prepare(Notification, MAP, ArjunaContext)
+BIND NOTHING
+IF (flagged("enabled"))
+DO debug("participant_processor.prepare.waiting"),
+   waitFor("readonly"),
+   debug("participant_processor.prepare.woken"),
+   clear("enabled")
+ENDRULE

--- a/XTS/localjunit/WSTFSC07-interop/src/test/java/com/jboss/transaction/wstf/interop/Sc007Test.java
+++ b/XTS/localjunit/WSTFSC07-interop/src/test/java/com/jboss/transaction/wstf/interop/Sc007Test.java
@@ -26,11 +26,15 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.jbossts.xts.bytemanSupport.BMScript;
+import org.jboss.jbossts.xts.bytemanSupport.participantReadOnly.ParticipantCompletionReadOnlyRules;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,6 +73,7 @@ public class Sc007Test {
                 .addPackage("com.jboss.transaction.wstf.webservices.sc007.server")
                 .addPackage("com.jboss.transaction.wstf.webservices.soapfault.client")
                 .addPackage("org.jboss.jbossts.xts.soapfault")
+                .addPackage("org.jboss.jbossts.xts.bytemanSupport.participantReadOnly")
                 .addAsResource("sc007/participanthandlers.xml", "com/jboss/transaction/wstf/webservices/sc007/sei/participanthandlers.xml")
                 .addAsWebInfResource("sc007/wsdl/sc007.wsdl", "classes/com/jboss/transaction/wstf/webservices/sc007/generated/wsdl/sc007.wsdl")                          
                 .addAsResource("soapfault/wsdl/soapfault.wsdl", "org/jboss/jbossts/xts/soapfault/soapfault.wsdl")
@@ -81,6 +86,16 @@ public class Sc007Test {
                 .addAsWebInfResource("web.xml")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts,org.jboss.ws.api,javax.xml.ws.api,org.jboss.xts,org.dom4j,org.jboss.ws.jaxws-client services export,org.jboss.ws.cxf.jbossws-cxf-client services export,com.sun.xml.bind services export\n"), "MANIFEST.MF");
+    }
+
+    @BeforeClass()
+    public static void submitBytemanScript() throws Exception {
+        BMScript.submit(ParticipantCompletionReadOnlyRules.RESOURCE_PATH);
+    }
+
+    @AfterClass()
+    public static void removeBytemanScript() {
+        BMScript.remove(ParticipantCompletionReadOnlyRules.RESOURCE_PATH);
     }
     
     @Before
@@ -127,6 +142,7 @@ public class Sc007Test {
     
     @Test
     public void test3_4() throws Exception {
+        ParticipantCompletionReadOnlyRules.enableReadOnlyCheck();
         test.test3_4();
     }
     

--- a/XTS/localjunit/WSTX11-interop/src/test/java/com/jboss/transaction/txinterop/interop/ATTest.java
+++ b/XTS/localjunit/WSTX11-interop/src/test/java/com/jboss/transaction/txinterop/interop/ATTest.java
@@ -26,10 +26,14 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.jbossts.xts.bytemanSupport.BMScript;
+import org.jboss.jbossts.xts.bytemanSupport.participantReadOnly.ParticipantCompletionReadOnlyRules;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 
 import com.jboss.transaction.txinterop.proxy.ProxyConversation;
@@ -52,6 +56,16 @@ public class ATTest {
     @Deployment
     public static WebArchive createDeployment() {
         return WarDeployment.getDeployment();
+    }
+
+    @BeforeClass
+    public static void submitBytemanScript() throws Exception {
+        BMScript.submit(ParticipantCompletionReadOnlyRules.RESOURCE_PATH);
+    }
+
+    @AfterClass
+    public static void removeBytemanScript() {
+        BMScript.remove(ParticipantCompletionReadOnlyRules.RESOURCE_PATH);
     }
     
     @Before
@@ -101,6 +115,7 @@ public class ATTest {
     
     @Test
     public void testAT4_1() throws Exception {
+        ParticipantCompletionReadOnlyRules.enableReadOnlyCheck();
         test.testAT4_1();
     }
     

--- a/XTS/localjunit/WSTX11-interop/src/test/java/com/jboss/transaction/txinterop/interop/WarDeployment.java
+++ b/XTS/localjunit/WSTX11-interop/src/test/java/com/jboss/transaction/txinterop/interop/WarDeployment.java
@@ -22,6 +22,7 @@
 
 package com.jboss.transaction.txinterop.interop;
 
+import org.jboss.jbossts.xts.bytemanSupport.participantReadOnly.ParticipantCompletionReadOnlyRules;
 import org.jboss.jbossts.xts.soapfault.SoapFaultPortType;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -82,6 +83,7 @@ public class WarDeployment {
                 .addPackage(CoordinationContextHandler.class.getPackage())
                 .addPackage(SoapFaultClient.class.getPackage())
                 .addPackage(SoapFaultPortType.class.getPackage())
+                .addPackage(ParticipantCompletionReadOnlyRules.class.getPackage())
                 .addAsResource("interop11/participanthandlers.xml", "com/jboss/transaction/txinterop/webservices/atinterop/sei/participanthandlers.xml")
                 .addAsResource("interop11/participanthandlers.xml", "com/jboss/transaction/txinterop/webservices/bainterop/sei/participanthandlers.xml")
                 .addAsWebInfResource("interop11/wsdl/interopat.wsdl", "classes/com/jboss/transaction/txinterop/webservices/atinterop/generated/wsdl/interopat.wsdl")


### PR DESCRIPTION
TransactionRolledBackException thrown during the test case of a participant initiated ReadOnly message occurring prior to the prepare phase
