### PR TITLE
[JBTM-1920] Pass enlist link header in req body (temp hack)

### DIFF
--- a/blacktie/transport/src/main/cpp/HttpClient.cxx
+++ b/blacktie/transport/src/main/cpp/HttpClient.cxx
@@ -136,6 +136,7 @@ int HttpClient::send(apr_pool_t* pool, http_request_info* ri, const char* method
         int i = 0;
 
 		for (; headers[i]; i++) {
+			LOG4CXX_DEBUG(logger, "Header: " << headers[i]);
 			http_print(conn, "%s\r\n", headers[i]);
 		}
 	}

--- a/blacktie/tx/src/main/cpp/HttpTxManager.cxx
+++ b/blacktie/tx/src/main/cpp/HttpTxManager.cxx
@@ -134,6 +134,7 @@ char *HttpTxManager::enlist(XAWrapper* resource, TxControl *tx, const char * xid
 		int port = _ws->get_port();
 
     	char hdr[BUFSZ];
+    	char body[BUFSZ];
 	char *hdrp[] = {hdr, 0};
     	const char *fmt = "Link: <http://%s:%d/xid/%s/terminate>;rel=\"%s\",<http://%s:%d/xid/%s/status>;rel=\"%s\"";
     	http_request_info ri;
@@ -143,11 +144,17 @@ char *HttpTxManager::enlist(XAWrapper* resource, TxControl *tx, const char * xid
 			host, port, xid,
 			HttpControl::PARTICIPANT_RESOURCE);
 
-		if (_wc.send(_pool, &ri, "POST", enlistUrl, HttpControl::POST_MEDIA_TYPE,
-			(const char **)hdrp, NULL, 0, NULL, NULL) != 0) {
-			LOG4CXX_DEBUG(httptxlogger, "enlist POST error");
-			return NULL;
-		}
+		// TODO HACK latest wildfly no longer parses the Link header
+		// correctly (when JBTM-1920 is resolved remove the hack)
+		(void) ACE_OS::snprintf(body, BUFSZ, "%s", hdr);
+
+                if (_wc.send(_pool, &ri, "POST", enlistUrl,
+                        HttpControl::POST_MEDIA_TYPE,
+                        (const char **)hdrp,
+                        (const char *)body, strlen(body), NULL, NULL) != 0) {
+                        LOG4CXX_DEBUG(httptxlogger, "enlist POST error");
+                        return NULL;
+                }
 
 		const char *rurl = _wc.get_header(&ri, HttpControl::LOCATION);
 


### PR DESCRIPTION
wildfly commit 9a3b000767c018a681a4858a84aae20a0b8c7310 (or a close earlier commit) seems to have changed the way Link headers are parsed. The PR includes a temporary hack which allows BlackTie Link headers to be passed in the enlist HTTP request body. This temporary hack is justified since the bug breaks all narayana builds and the PR allows us to investigate the problem at our leisure.
