### PR TITLE
4.17. JBTM-1925. Enable remote debugger in JBossAS/WildFly for all tests

### DIFF
--- a/XTS/localjunit/pom.xml
+++ b/XTS/localjunit/pom.xml
@@ -20,7 +20,6 @@
             <buildType>11</buildType>
             <ipv4.server.jvm.args></ipv4.server.jvm.args>
             <ipv6.server.jvm.args>-Djboss.bind.address=[::1] -Djboss.bind.address.management=[::1] -Djboss.bind.address.unsecure=[::1] -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</ipv6.server.jvm.args>
-            <server.debug.args>Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5006</server.debug.args>
         </properties>
     <build>
         <pluginManagement>
@@ -162,7 +161,7 @@
 							<!--
 							  Used in arquillian.xml
 							-->
-							  <server.jvm.args>${jvm.args.memory} ${jvm.args.byteman} ${ipv4.server.jvm.args}</server.jvm.args>
+							  <server.jvm.args>${jvm.args.memory} ${jvm.args.byteman} ${ipv4.server.jvm.args} ${jvm.args.debug}</server.jvm.args>
                               <node.address>127.0.0.1</node.address>
 							</systemPropertyVariables>
                             <skip>false</skip>
@@ -196,7 +195,7 @@
 							<!--
 							  Used in arquillian.xml
 							-->
-							  <server.jvm.args>${jvm.args.memory} ${jvm.args.byteman} ${ipv6.server.jvm.args}</server.jvm.args>
+							  <server.jvm.args>${jvm.args.memory} ${jvm.args.byteman} ${ipv6.server.jvm.args} ${jvm.args.debug}</server.jvm.args>
                                                           <node.address>[::1]</node.address>
 							</systemPropertyVariables>
                             <skip>false</skip>

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,7 @@
                         -javaagent:${project.build.directory}/lib/byteman.jar=listener:true
     </jvm.args.byteman>
     <jvm.args.memory>-Xms64m -Xmx1024m -XX:MaxPermSize=512m</jvm.args.memory>
+    <jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n</jvm.args.debug>
     
     <!-- External dependencies versions -->
     <jboss-as.version>7.2.0.Final</jboss-as.version>    

--- a/txbridge/pom.xml
+++ b/txbridge/pom.xml
@@ -251,7 +251,7 @@
 							<!-- System properties passed to test cases -->
 							<systemPropertyVariables>
 								<!-- Used in arquillian.xml - arguments for all JBoss AS instances. -->
-								<server.jvm.args>${jvm.args.memory} ${ipv4.server.jvm.args} ${byteman.server.jvm.args} ${jpda.server.jvm.args}</server.jvm.args>
+								<server.jvm.args>${jvm.args.memory} ${ipv4.server.jvm.args} ${byteman.server.jvm.args} ${jpda.server.jvm.args} ${jvm.args.debug}</server.jvm.args>
 								<java.rmi.server.codebase>file://target/test-classes/</java.rmi.server.codebase>
 								<node.address>localhost</node.address>
 							</systemPropertyVariables>
@@ -294,7 +294,7 @@
 							<!-- System properties passed to test cases -->
 							<systemPropertyVariables>
 								<!-- Used in arquillian.xml - arguments for all JBoss AS instances. -->
-								<server.jvm.args>${jvm.args.memory} ${ipv6.server.jvm.args} ${byteman.server.ipv6.jvm.args} ${jpda.server.jvm.args}</server.jvm.args>
+								<server.jvm.args>${jvm.args.memory} ${ipv6.server.jvm.args} ${byteman.server.ipv6.jvm.args} ${jpda.server.jvm.args} ${jvm.args.debug}</server.jvm.args>
 								<java.rmi.server.codebase>file://target/test-classes/</java.rmi.server.codebase>
 								<node.address>[::1]</node.address>
 							</systemPropertyVariables>

--- a/txframework/pom.xml
+++ b/txframework/pom.xml
@@ -193,6 +193,12 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <systemPropertyVariables combine.children="append">
+                                <!--
+                                    Used in arquillian.xml
+                                -->
+                                <server.jvm.args>${jvm.args.debug}</server.jvm.args>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -200,6 +206,12 @@
                         <version>2.7.2</version>
                         <configuration>
                             <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <!--
+                                    Used in arquillian.xml
+                                -->
+                                <server.jvm.args>${jvm.args.debug}</server.jvm.args>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -217,6 +229,12 @@
                         <version>2.7.2</version>
                         <configuration>
                             <skip>false</skip>
+                            <systemPropertyVariables combine.children="append">
+                                <!--
+                                    Used in arquillian.xml
+                                -->
+                                <server.jvm.args></server.jvm.args>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/txframework/src/test/resources/arquillian.xml
+++ b/txframework/src/test/resources/arquillian.xml
@@ -16,7 +16,7 @@
       <!-- If you want to use the JBOSS_HOME environment variable, just delete the jbossHome property -->
       <configuration>
 			<property name="serverConfig">standalone-xts.xml</property>
-            <property name="javaVmArguments">-Dorg.jboss.byteman.verbose
+            <property name="javaVmArguments">${server.jvm.args} -Dorg.jboss.byteman.verbose
                                     -Djboss.modules.system.pkgs=org.jboss.byteman
                                     -Dorg.jboss.byteman.transform.all
                                     -javaagent:../lib/byteman.jar=listener:true


### PR DESCRIPTION
Exclude test profiles: !BLACKTIE, !QA_JTA, !QA_JTS_JACORB, !MAIN
