### PR TITLE
JBTM-1979. REST-AT integration API recovery tests fix on IPv6

### DIFF
--- a/rts/at/integration/src/test/java/org/jboss/narayana/rest/integration/test/integration/RecoveryIntegrationTestCase.java
+++ b/rts/at/integration/src/test/java/org/jboss/narayana/rest/integration/test/integration/RecoveryIntegrationTestCase.java
@@ -34,8 +34,8 @@ public final class RecoveryIntegrationTestCase extends AbstractIntegrationTestCa
 
     private static final int RECOVERY_WAIT_CYCLES = 5;
 
-    private static final String VM_ARGUMENTS = "-Xms64m -Xmx512m -XX:MaxPermSize=256m -Dcom.arjuna.ats.arjuna.recovery.periodicRecoveryPeriod="
-            + RECOVERY_PERIOD;
+    private static final String VM_ARGUMENTS = System.getProperty("server.jvm.args").trim()
+            + " -Dcom.arjuna.ats.arjuna.recovery.periodicRecoveryPeriod=" + RECOVERY_PERIOD;
 
     private static final String BYTEMAN_ARGUMENTS = "-Dorg.jboss.byteman.verbose -Djboss.modules.system.pkgs=org.jboss.byteman -Dorg.jboss.byteman.transform.all -javaagent:lib/byteman.jar=script:scripts/@BMScript@.btm,boot:lib/byteman.jar,listener:true";
 


### PR DESCRIPTION
Exclude profiles: !BLACKTIE, !QA_JTA, !QA_JTS_JACORB, !XTS
