### PR TITLE
[JBTM-1957] fixing XTS tests for IBM JDK

### DIFF
--- a/XTS/localjunit/crash-recovery-tests/src/main/java/com/arjuna/qa/extension/JBossAS7ServerKillProcessor.java
+++ b/XTS/localjunit/crash-recovery-tests/src/main/java/com/arjuna/qa/extension/JBossAS7ServerKillProcessor.java
@@ -12,9 +12,9 @@ import java.util.logging.Logger;
 public class JBossAS7ServerKillProcessor implements ServerKillProcessor {
 
     private static final Logger logger = Logger.getLogger(JBossAS7ServerKillProcessor.class.getName());
-    private static final String CHECK_JBOSS_ALIVE_CMD = "if [ \"$(jps | grep jboss-modules.jar)\" == \"\" ]; then exit 1; fi";
+    private static final String CHECK_JBOSS_ALIVE_CMD = "if [ \"$(ps aux | grep 'jboss-module[s]')\" == \"\" ]; then exit 1; fi";
     private static final String CHECK_FOR_DEFUNCT_JAVA_CMD = "if [ \"$(ps aux | grep '\\[java\\] <defunct>')\" == \"\" ]; then exit 1; fi";
-    private static final String SHUTDOWN_JBOSS_CMD = "jps | grep jboss-modules.jar | awk '{ print $1 }' | xargs kill";
+    private static final String SHUTDOWN_JBOSS_CMD = "ps axu | grep jboss-module[s] | awk '{print $2}' | xargs kill";
 
     private int checkPeriodMillis = 10 * 1000;
     private int numChecks = 60;
@@ -52,14 +52,13 @@ public class JBossAS7ServerKillProcessor implements ServerKillProcessor {
         //Command will 'exit 1' if jboss is not running and 'exit 0' if it is
         return exitCode == 0;
     }
-
+    
     private boolean isDefunctJavaProcess() throws Exception {
         int exitCode = runShellCommand(CHECK_FOR_DEFUNCT_JAVA_CMD);
 
         //Command will 'exit 1' if a defunct java process is not running and 'exit 0' if there is
         return exitCode == 0;
     }
-
 
     private void shutdownJBoss() throws Exception {
         runShellCommand(SHUTDOWN_JBOSS_CMD);


### PR DESCRIPTION
IBM JDK does not contain JPS tool. For that reason I added a ps variant of jboss running check.

!QA_JTA !QA_JTS_JACORB !BLACKTIE !MAIN
