### PR TITLE
JBTM-2018. @Compensational not working correctly with @Stereotype wrt. Exception handling

### DIFF
--- a/txframework/src/test/java/org/jboss/narayana/compensations/functional/compensatable/CompensatableTest.java
+++ b/txframework/src/test/java/org/jboss/narayana/compensations/functional/compensatable/CompensatableTest.java
@@ -47,7 +47,6 @@ import org.jboss.narayana.compensations.impl.CompensationManagerState;
 import org.jboss.narayana.txframework.impl.TXDataMapImpl;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -69,6 +68,8 @@ public class CompensatableTest {
     @Inject
     CompensatableBean testTransactionalBean;
 
+    @Inject
+    StereotypeBean stereotypeBean;
 
     @Deployment
     public static WebArchive createTestArchive() {
@@ -508,6 +509,11 @@ public class CompensatableTest {
         Assert.assertTrue(DummyConfirmationHandler2.getCalled());
         Assert.assertTrue(DummyTransactionLoggedHandler2.getCalled());
         Assert.assertTrue(DummyTransactionLoggedHandler2.getSuccess());
+    }
+
+    @Test(expected = TestException.class)
+    public void testStereotype() throws TestException {
+        stereotypeBean.doSomething();
     }
 
     private void beginBusinessActivity() throws WrongStateException, SystemException {

--- a/txframework/src/test/java/org/jboss/narayana/compensations/functional/compensatable/StereotypeBean.java
+++ b/txframework/src/test/java/org/jboss/narayana/compensations/functional/compensatable/StereotypeBean.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.narayana.compensations.functional.compensatable;
+
+import com.arjuna.mw.wst.TxContext;
+import com.arjuna.mw.wst11.BusinessActivityManagerFactory;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@TestStereotype
+public class StereotypeBean {
+
+    public void doSomething() throws TestException {
+        try {
+            final TxContext txContext = BusinessActivityManagerFactory.businessActivityManager().currentTransaction();
+
+            if (txContext == null) {
+                throw new RuntimeException("No transaction is active");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected error looking up current transaction", e);
+        }
+
+        throw new TestException();
+    }
+
+}

--- a/txframework/src/test/java/org/jboss/narayana/compensations/functional/compensatable/TestStereotype.java
+++ b/txframework/src/test/java/org/jboss/narayana/compensations/functional/compensatable/TestStereotype.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.narayana.compensations.functional.compensatable;
+
+import org.jboss.narayana.compensations.api.Compensatable;
+import org.jboss.narayana.compensations.api.CompensationTransactionType;
+
+import javax.enterprise.inject.Stereotype;
+import javax.inject.Named;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@Named
+@Compensatable(CompensationTransactionType.REQUIRED)
+@Stereotype
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TestStereotype {
+}


### PR DESCRIPTION
Exclude: !BLACKTIE, !MAIN, !QA_JTA, !QA_JTS_JACORB
