### PR TITLE
narayana.sh script - JBOSS_HOME creation fix

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -203,7 +203,8 @@ function build_as {
 
 function init_jboss_home {
   cd $WORKSPACE
-  export JBOSS_HOME=${WORKSPACE}/jboss-as/build/target/wildfly-${WILDFLY_MASTER_VERSION}
+  JBOSS_HOME=${WORKSPACE}/jboss-as/build/target/wildfly-${WILDFLY_MASTER_VERSION}
+  export JBOSS_HOME=`echo  $JBOSS_HOME`
   [ -d $JBOSS_HOME ] || fatal "missing AS - $JBOSS_HOME is not a directory"
   echo "JBOSS_HOME=$JBOSS_HOME"
   cp ${JBOSS_HOME}/docs/examples/configs/standalone-xts.xml ${JBOSS_HOME}/standalone/configuration


### PR DESCRIPTION
The reason for this change is that I would like to have possibility to let the version of wildfly being expanded from asterix. I mean to set the property in this way:
export WILDFLY_MASTER_VERSION=8.0.0*
the wildcard is currently not usable as the JBOSS_HOME has to be already exapanded when it's passed to arquillian (at least it was the point where I have problems with current state)
