### PR TITLE
Bugfixed toString() implementation on XID class.

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/xa/XID.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/xa/XID.java
@@ -165,7 +165,7 @@ public class XID implements Serializable
         }
         stringBuilder.append(", ");
         for (int i = 0; i < bqual_length; i++) {
-            stringBuilder.append(gtrid_length+data[i]);
+            stringBuilder.append(data[gtrid_length+i]);
         }
 
         stringBuilder.append(" >");


### PR DESCRIPTION
As Tom Jenkinson suggested in https://community.jboss.org/message/855690#855690
I 'm asking for a pull request on the toString() method of the XID class

toString method was printing wrong the branch qualifier part of the XID, printing the same result for two different XID with the same baseXID (I mean if the only difference was the branch qualifier then the toString result would be the same).

The error was that the code was appending the sum of gtrid_length and
data[i] instead of appending data[i] with an offset of gtrid_length
_data[gtrid_length+i]_
