### PR TITLE
use static private EnvironmentBean

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxStats.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxStats.java
@@ -33,6 +33,7 @@ package com.arjuna.ats.arjuna.coordinator;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 
 /**
@@ -49,11 +50,17 @@ public class TxStats implements TxStatsMBean
 {
     private static TxStats _instance = new TxStats();
 
+    private static CoordinatorEnvironmentBean _environmentBean;
+
     private TxStats() {
     }
 
     public static boolean enabled() {
-        return arjPropertyManager.getCoordinatorEnvironmentBean().isEnableStatistics();
+      //not thread safe but not sure we require thread safety as long as eventually all threads stop setting the bean
+      if(_environmentBean==null){
+        _environmentBean=arjPropertyManager.getCoordinatorEnvironmentBean();
+      }
+        return _environmentBean.isEnableStatistics();
     }
 
     public static TxStats getInstance() {


### PR DESCRIPTION
TxStats.enable generates 1.61GB of GC overhead during a 20 minute performance test. Saving the Bean reference decreases the GC overhead to 20KB.

!XTS !BLACKTIE
