### PR TITLE
Netty version change for being the same as in EAP 6.3.0

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -6,13 +6,6 @@
 	Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <parent>
-      <groupId>org.jboss.narayana</groupId>
-      <artifactId>narayana-all</artifactId>
-      <version>4.17.18.Final-SNAPSHOT</version>
-      <relativePath>../pom.xml</relativePath>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.jbossts</groupId>
     <artifactId>jbossts-build</artifactId>
@@ -58,8 +51,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.jboss.netty</groupId>
+            <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
+            <version>3.6.7.Final</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hi,

I would like change the netty artifact which is downloaded for running narayana/qa tests. I've changed the version of netty to be the same as there is in EAP 6.3.0.DR2, just artifact here is that one from the community and the eap6 does have it's own productized version of the netty. In the same way the change contains deleting the parent tag as the qa directory is not mentioned as module from parent pom.xml and this pom.xml is not mean to be used for compilation but for artifact downloading - see ant get.maven.libs.

Thanks

!XTS !BLACKTIE
