### PR TITLE
[JBTM-2128] Enhance trace logging of CommitMarkableResourceRecord

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/CommitMarkableResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/CommitMarkableResourceRecord.java
@@ -141,6 +141,10 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 	 * For recovery
 	 */
 	public CommitMarkableResourceRecord() {
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecord.CommitMarkableResourceRecord (), record id=" + order());
+		}
+
 		tableName = null;
 	}
 
@@ -149,6 +153,11 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 			BasicAction basicAction) throws IllegalStateException,
 			RollbackException, SystemException {
 		super(new Uid(), null, ObjectType.ANDPERSISTENT);
+
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecord.CommitMarkableResourceRecord ( " + tx + ", " + xaResource + ", " 
+			+ xid + ", " + basicAction + " ), record id=" + order());
+		}
 
 		this.connectableResource = xaResource;
 		XAResourceWrapper xaResourceWrapper = ((XAResourceWrapper) xaResource);
@@ -363,6 +372,10 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 	 * mode, we do not need to persist this information.
 	 */
 	public int topLevelPrepare() {
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecord.topLevelPrepare for " + this + ", record id=" + order());
+		}
+
 		try {
 			preparedConnection = (Connection) connectableResource
 					.getConnection();
@@ -402,6 +415,10 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 	}
 
 	public int topLevelAbort() {
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecord.topLevelAbort for " + this + ", record id=" + order());
+		}
+
 		try {
 			try {
 				// This can never be null as it can only ever be called before
@@ -433,10 +450,18 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 	}
 
 	public int topLevelCommit() {
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecord.topLevelCommit for " + this + ", record id=" + order());
+		}
+
 		return commit(false);
 	}
 
 	public int topLevelOnePhaseCommit() {
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecord.topLevelOnePhaseCommit for " + this + ", record id=" + order());
+		}
+
 		return commit(true);
 	}
 


### PR DESCRIPTION
More talk-active trace logging for CommitMarkableResourceRecord to have better knowledge what's happening on investigation.

If you don't mind I would do pull request to master as well.

!BLACKTIE !XTS !QA_JTA !QA_JTS_JACORB
