### PR TITLE
Changing hornetq and netty version for Wildfly in qa tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
     <version.org.jboss.ws>1.0.2.Final</version.org.jboss.ws>
     <version.org.jboss.resteasy>3.0.5.Final</version.org.jboss.resteasy>
     <version.org.jboss.weld>2.1.0.Final</version.org.jboss.weld>
-    <version.org.hornetq>2.3.9.Final</version.org.hornetq>
+    <version.org.hornetq>2.4.1.Final</version.org.hornetq>
     <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
     <version.org.jboss.spec.javax.interceptor>1.0.0.Final</version.org.jboss.spec.javax.interceptor>
     <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
@@ -452,9 +452,6 @@
     <version.org.jboss.byteman>2.1.3</version.org.jboss.byteman>
     <version.org.jboss.arquillian.core>1.1.2.Final-wildfly-1</version.org.jboss.arquillian.core>
     <version.org.jboss.jboss-transaction-spi>7.1.0.Final</version.org.jboss.jboss-transaction-spi>
-
-    <!-- qa testsuite with hornetq store -->
-    <version.org.jboss.netty>3.2.6.Final</version.org.jboss.netty>
 
     <!-- Maven plugin versions -->
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>

--- a/qa/.gitignore
+++ b/qa/.gitignore
@@ -2,3 +2,7 @@ dbdrivers
 dist
 idl-compiler.*
 build
+TEST-*
+ext/netty-all.jar
+testoutput/
+transaction.log

--- a/qa/TaskImpl.properties
+++ b/qa/TaskImpl.properties
@@ -45,7 +45,7 @@ COMMAND_LINE_2=\
   ${path.separator}dbdrivers${file.separator}mysql-connector-java-5.1.8-bin.jar\
   ${path.separator}dbdrivers${file.separator}oracle_10_2_0_4${file.separator}ojdbc14.jar\
   ${path.separator}dbdrivers${file.separator}postgresql-8.3-605.jdbc4.jar\
-  ${path.separator}ext${file.separator}netty.jar
+  ${path.separator}ext${file.separator}netty-all.jar
 
 #
 # properties used by the tests or test framework:

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -7,18 +7,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <parent>
-      <groupId>org.jboss.narayana</groupId>
-      <artifactId>narayana-all</artifactId>
-      <version>5.0.2.Final-SNAPSHOT</version>
-      <relativePath>../pom.xml</relativePath>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.jbossts</groupId>
     <artifactId>jbossts-build</artifactId>
     <packaging>jar</packaging>
     <version>unknown</version>
     <name>Narayana: qa</name>
+    
+    <properties>
+        <version.netty>4.0.15.Final</version.netty>
+    </properties>
 
     <repositories>
         <repository>
@@ -38,6 +36,7 @@
         <plugins>
             <plugin>
                 <!-- run as: mvn dependency:copy-dependencies (narayana project had to be built) -->
+                <!-- or run as: ant get.maven.libs -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
 
@@ -57,9 +56,9 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.jboss.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>${version.org.jboss.netty}</version>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${version.netty}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Chaning hornetq and netty version to be the same which is used in WildFly. The HornetQ 2.4.1 release is reworked (it uses different api for clients) and depends on different netty version. Narayana uses just journal but depends on hornetq-commons which depends on netty in particular version. So the change is a bit bigger.

Tested like:
cd qa/
ant dist
ant get.maven.libs
ant -f run-tests.xml -Dtest.methods="CrashRecovery09_Test01" -Dtest=crashrecovery09 -Dprofile=hornetq test

Hornetq object store is used and the test is working.

!XTS !BLACKTIE
