### PR TITLE
JBTM-2229 Prevent an issue when recovering CMR where they activate an AA...

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/CommitMarkableResourceRecordRecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/CommitMarkableResourceRecordRecoveryModule.java
@@ -349,6 +349,14 @@ public class CommitMarkableResourceRecordRecoveryModule implements
     										CONNECTABLE_ATOMIC_ACTION_TYPE,
     										ATOMIC_ACTION_TYPE);
     							}
+    						} else {
+    						    if (tsLogger.logger.isTraceEnabled()) {
+    						        tsLogger.logger.trace("Moving " + currentUid + " back to being an AA");
+    						    }
+                                // It is now safe to move it back to being an AA so that it can call getNewXAResourceRecord
+                                moveRecord(currentUid,
+                                        CONNECTABLE_ATOMIC_ACTION_TYPE,
+                                        ATOMIC_ACTION_TYPE);    						    
     						}
                         }
 					}
@@ -407,6 +415,10 @@ public class CommitMarkableResourceRecordRecoveryModule implements
     								// Update the completed outcome for the 1PC
     								// resource
                                     rcaa.updateCommitMarkableResourceRecord(committedXidsToJndiNames.get(rcaa.getXid()) != null);
+                                    // Swap the type to avoid the rest of recovery round processing this TX as it already called getNewXAResourceRecord
+                                    moveRecord(currentUid, ATOMIC_ACTION_TYPE,
+                                            CONNECTABLE_ATOMIC_ACTION_TYPE);
+                                    
     							}
     						}
 	                    }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/RecoverConnectableAtomicAction.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/RecoverConnectableAtomicAction.java
@@ -27,6 +27,7 @@ import com.arjuna.ats.arjuna.AtomicAction;
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.coordinator.RecordType;
 import com.arjuna.ats.arjuna.exceptions.ObjectStoreException;
+import com.arjuna.ats.arjuna.logging.tsLogger;
 import com.arjuna.ats.arjuna.objectstore.StoreManager;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.internal.arjuna.Header;
@@ -84,6 +85,9 @@ public class RecoverConnectableAtomicAction extends AtomicAction {
 		CommitMarkableResourceRecord peekFront = (CommitMarkableResourceRecord) preparedList
 				.peekFront();
 		peekFront.updateOutcome(committed);
+		if (tsLogger.logger.isTraceEnabled()) {
+		    tsLogger.logger.trace("Moving " + get_uid() + " to an AAR so it won't get processed this time");
+		}
 		deactivate();
 	}
 }

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/SimpleXAResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/SimpleXAResource.java
@@ -20,18 +20,23 @@
 package com.hp.mwtests.ts.jta.commitmarkable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-public class SimpleXAResource implements XAResource, Serializable {
+public class SimpleXAResource implements XAResource {
+    
+    private List<Xid> xids = new ArrayList<Xid>();
 
 	private static boolean rollbackCalled;
 	private static boolean commitCalled;
 
 	@Override
 	public void commit(Xid xid, boolean onePhase) throws XAException {
+	    xids.remove(xid);
 		commitCalled = true;
 	}
 
@@ -55,16 +60,18 @@ public class SimpleXAResource implements XAResource, Serializable {
 
 	@Override
 	public int prepare(Xid xid) throws XAException {
+	    xids.add(xid);
 		return 0;
 	}
 
 	@Override
 	public Xid[] recover(int flag) throws XAException {
-		return null;
+		return xids.toArray(new Xid[]{});
 	}
 
 	@Override
 	public void rollback(Xid xid) throws XAException {
+	    xids.remove(xid);
 		rollbackCalled = true;
 	}
 

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/SimpleXAResource2.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/SimpleXAResource2.java
@@ -19,14 +19,17 @@
  */
 package com.hp.mwtests.ts.jta.commitmarkable;
 
-import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-public class SimpleXAResource2 implements XAResource, Serializable {
+public class SimpleXAResource2 implements XAResource {
 
+    private List<Xid> xids = new ArrayList<Xid>();
+    
 	private static boolean rollbackCalled;
 	private static boolean commitCalled;
 	private static boolean errorOnNextRollback;
@@ -36,6 +39,7 @@ public class SimpleXAResource2 implements XAResource, Serializable {
 
 	@Override
 	public void commit(Xid xid, boolean onePhase) throws XAException {
+        xids.remove(xid);
 		commitCalled = true;
 	}
 
@@ -59,12 +63,13 @@ public class SimpleXAResource2 implements XAResource, Serializable {
 
 	@Override
 	public int prepare(Xid xid) throws XAException {
+        xids.add(xid);
 		return 0;
 	}
 
 	@Override
 	public Xid[] recover(int flag) throws XAException {
-		return null;
+        return xids.toArray(new Xid[]{});
 	}
 
 	@Override
@@ -73,6 +78,7 @@ public class SimpleXAResource2 implements XAResource, Serializable {
 			errorOnNextRollback = false;
 			throw new Error();
 		}
+        xids.remove(xid);
 		rollbackCalled = true;
 	}
 

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterCommitTwoXAResources.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterCommitTwoXAResources.java
@@ -29,6 +29,7 @@ import java.util.Vector;
 
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
+import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 import org.h2.jdbcx.JdbcDataSource;
@@ -40,6 +41,8 @@ import org.junit.runner.RunWith;
 
 import com.arjuna.ats.arjuna.recovery.RecoveryModule;
 import com.arjuna.ats.internal.jta.recovery.arjunacore.CommitMarkableResourceRecordRecoveryModule;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
+import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 
 @RunWith(BMUnitRunner.class)
 public class TestCommitMarkableResourceFailAfterCommitTwoXAResources extends
@@ -75,7 +78,18 @@ public class TestCommitMarkableResourceFailAfterCommitTwoXAResources extends
 
 				if (m instanceof CommitMarkableResourceRecordRecoveryModule) {
 					recoveryModule = (CommitMarkableResourceRecordRecoveryModule) m;
-				}
+				} else if (m instanceof XARecoveryModule) {
+                    XARecoveryModule  xarm = (XARecoveryModule) m;
+                    xarm.addXAResourceRecoveryHelper(new XAResourceRecoveryHelper() {
+                        public boolean initialise(String p) throws Exception {
+                            return true;
+                        }
+
+                        public XAResource[] getXAResources() throws Exception {
+                            return new XAResource[] {xaResource};
+                        }
+                    });
+                }
 			}
 		}
 		// final Object o = new Object();


### PR DESCRIPTION
... that does not have Serializable XAR which leads to the Xid being removed from XARM which when the AARM then tries to recover the AA means a corresponding XAR cannot be located for the Xid and an error message is reported
