### PR TITLE
[JBTM-2303] Exclude apache-karaf from the jacoco report

### DIFF
--- a/qa/run-tests.xml
+++ b/qa/run-tests.xml
@@ -562,6 +562,7 @@
             <exclude name="**/narayana-full/**"/>
             <exclude name="**/qa/**"/>
             <exclude name="**/tools/**"/>
+            <exclude name="**/apache-karaf*/**"/>
           </fileset>
         </classfiles>
         <sourcefiles encoding="UTF-8">


### PR DESCRIPTION
NO_TEST
