### PR TITLE
[BZ-1129143] Mark commons-httpclient as provided scope

### DIFF
--- a/txbridge/pom.xml
+++ b/txbridge/pom.xml
@@ -163,7 +163,7 @@
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
             <version>${version.commons-httpclient}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
The jakarta commons httpclient project has moved to the apache
httpcomponents project, and the groupId/artifactId has changed.
The older commons-httpclient jar should be marked as provided scope
so that it is not included in transitive dependency resolution.
Because of the change in groupId, Maven cannot automatically
exclude the older httpclient library when the newer one is used.
