### PR TITLE
BZ1169671 Updated to not shutdown the CORBA object for the XAResourceRecord until forget is called

### DIFF
--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATestXARMERR.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATestXARMERR.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ *
+ * (C) 2005-2006,
+ * @author JBoss Inc.
+ */
+/*
+ * Copyright (C) 2001, 2002,
+ *
+ * Hewlett-Packard Arjuna Labs,
+ * Newcastle upon Tyne,
+ * Tyne and Wear,
+ * UK.
+ *
+ * $Id: JTATest.java 2342 2006-03-30 13:06:17Z  $
+ */
+
+package com.hp.mwtests.ts.jta.xa;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import javax.transaction.RollbackException;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.junit.Test;
+
+import com.arjuna.ats.arjuna.AtomicAction;
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.objectstore.StateStatus;
+import com.arjuna.ats.arjuna.objectstore.StoreManager;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
+
+public class JTATestXARMERR {
+
+	@Test
+	public void test() throws Exception {
+
+		javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager
+				.transactionManager();
+		tm.setTransactionTimeout(0);
+		tm.begin();
+		javax.transaction.Transaction theTransaction = tm.getTransaction();
+		TransactionImple txImple =((TransactionImple) theTransaction); 
+		Uid get_uid = txImple.get_uid();
+		XARMERRXAResource xar1 = new XARMERRXAResource(true);
+		assertTrue(theTransaction.enlistResource(xar1));
+		XARMERRXAResource xar2 = new XARMERRXAResource(false);
+		assertTrue(theTransaction.enlistResource(xar2));
+
+		try {
+			tm.commit();
+			fail("Expected RollbackException");
+		} catch (RollbackException e) {
+			// Expected
+			assertTrue(xar2.getRollbackCalled());
+			assertTrue(xar1.getForgetCalled());
+			assertTrue(StoreManager.getRecoveryStore().currentState(get_uid, new AtomicAction().type()) == StateStatus.OS_UNKNOWN);
+		}
+	}
+
+	private class XARMERRXAResource implements XAResource {
+
+		private boolean returnRMERR;
+		private boolean rollbackCalled;
+		private boolean forgetCalled;
+
+		public XARMERRXAResource(boolean returnRMERR) {
+			this.returnRMERR = returnRMERR;
+		}
+
+		@Override
+		public void commit(Xid xid, boolean onePhase) throws XAException {
+			if (returnRMERR) {
+				throw new XAException(XAException.XAER_RMERR);
+			}
+		}
+
+		@Override
+		public void rollback(Xid xid) throws XAException {
+			rollbackCalled = true;
+		}
+
+		public boolean getRollbackCalled() {
+			return rollbackCalled;
+		}
+
+		@Override
+		public void forget(Xid xid) throws XAException {
+			forgetCalled = true;
+		}
+
+		public boolean getForgetCalled() {
+			return forgetCalled;
+		}
+
+		@Override
+		public void end(Xid xid, int flags) throws XAException {
+		}
+
+		@Override
+		public int getTransactionTimeout() throws XAException {
+			return 0;
+		}
+
+		@Override
+		public boolean isSameRM(XAResource xares) throws XAException {
+			return false;
+		}
+
+		@Override
+		public int prepare(Xid xid) throws XAException {
+			return 0;
+		}
+
+		@Override
+		public Xid[] recover(int flag) throws XAException {
+			return null;
+		}
+
+		@Override
+		public boolean setTransactionTimeout(int seconds) throws XAException {
+			return false;
+		}
+
+		@Override
+		public void start(Xid xid, int flags) throws XAException {
+		}
+	}
+}

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
@@ -479,6 +479,8 @@ public class XAResourceRecord extends com.arjuna.ArjunaOTS.OTSAbstractRecordPOA
 				if (!_prepared)
 					throw new NotPrepared();
 
+				boolean dontRemoveConnection = false;
+				
 				try
 				{
 					if (!_committed)
@@ -539,6 +541,7 @@ public class XAResourceRecord extends com.arjuna.ArjunaOTS.OTSAbstractRecordPOA
 						case XAException.XA_RBTIMEOUT:
 						case XAException.XA_RBTRANSIENT:
 						case XAException.XAER_RMERR:
+							dontRemoveConnection = true;
 							updateState(TwoPhaseOutcome.HEURISTIC_ROLLBACK);
 
 							throw new org.omg.CosTransactions.HeuristicRollback();
@@ -576,7 +579,8 @@ public class XAResourceRecord extends com.arjuna.ArjunaOTS.OTSAbstractRecordPOA
 				}
 				finally
 				{
-					removeConnection();
+					if (!dontRemoveConnection)
+						removeConnection();
 				}
 			}
 		}

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/basic/JTATestXARMERR.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/basic/JTATestXARMERR.java
@@ -1,0 +1,177 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. 
+ * See the copyright.txt in the distribution for a full listing 
+ * of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ * 
+ * (C) 2005-2006,
+ * @author JBoss Inc.
+ */
+/*
+ * Copyright (C) 2001, 2002,
+ *
+ * Hewlett-Packard Arjuna Labs,
+ * Newcastle upon Tyne,
+ * Tyne and Wear,
+ * UK.
+ *
+ * $Id: JTATest.java 2342 2006-03-30 13:06:17Z  $
+ */
+
+package com.hp.mwtests.ts.jta.jts.basic;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import javax.transaction.RollbackException;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.junit.Test;
+
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.objectstore.RecoveryStore;
+import com.arjuna.ats.arjuna.objectstore.StateStatus;
+import com.arjuna.ats.arjuna.objectstore.StoreManager;
+import com.arjuna.ats.internal.jta.transaction.jts.AtomicTransaction;
+import com.arjuna.ats.internal.jta.transaction.jts.TransactionImple;
+import com.arjuna.ats.internal.jts.ORBManager;
+import com.arjuna.ats.internal.jts.orbspecific.coordinator.ArjunaTransactionImple;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import com.arjuna.orbportability.OA;
+import com.arjuna.orbportability.ORB;
+import com.arjuna.orbportability.RootOA;
+
+public class JTATestXARMERR {
+	@Test
+	public void test() throws Exception {
+		ORB myORB = null;
+		RootOA myOA = null;
+
+		myORB = ORB.getInstance("test");
+		myOA = OA.getRootOA(myORB);
+
+		myORB.initORB(new String[] {}, null);
+		myOA.initOA();
+
+		ORBManager.setORB(myORB);
+		ORBManager.setPOA(myOA);
+
+		jtaPropertyManager
+				.getJTAEnvironmentBean()
+				.setTransactionManagerClassName(
+						com.arjuna.ats.internal.jta.transaction.jts.TransactionManagerImple.class
+								.getName());
+		jtaPropertyManager
+				.getJTAEnvironmentBean()
+				.setUserTransactionClassName(
+						com.arjuna.ats.internal.jta.transaction.jts.UserTransactionImple.class
+								.getName());
+
+		javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager
+				.transactionManager();
+		tm.setTransactionTimeout(0);
+		tm.begin();
+		javax.transaction.Transaction theTransaction = tm.getTransaction();
+		TransactionImple txImple =((TransactionImple) theTransaction); 
+		Uid get_uid = txImple.get_uid();
+		XARMERRXAResource xar1 = new XARMERRXAResource(true);
+		assertTrue(theTransaction.enlistResource(xar1));
+		XARMERRXAResource xar2 = new XARMERRXAResource(false);
+		assertTrue(theTransaction.enlistResource(xar2));
+		try {
+			tm.commit();
+			fail("Expected RollbackException");
+		} catch (RollbackException e) {
+			// Expected
+			assertTrue(xar2.getRollbackCalled());
+			assertTrue(xar1.getForgetCalled());
+			assertTrue(StoreManager.getRecoveryStore().currentState(get_uid, ArjunaTransactionImple.typeName()) == StateStatus.OS_UNKNOWN);
+		}
+
+		myOA.destroy();
+		myORB.shutdown();
+	}
+
+	private class XARMERRXAResource implements XAResource {
+
+		private boolean returnRMERR;
+		private boolean rollbackCalled;
+		private boolean forgetCalled;
+
+		public XARMERRXAResource(boolean returnRMERR) {
+			this.returnRMERR = returnRMERR;
+		}
+
+		@Override
+		public void commit(Xid xid, boolean onePhase) throws XAException {
+			if (returnRMERR) {
+				throw new XAException(XAException.XAER_RMERR);
+			}
+		}
+
+		@Override
+		public void rollback(Xid xid) throws XAException {
+			rollbackCalled = true;
+		}
+
+		public boolean getRollbackCalled() {
+			return rollbackCalled;
+		}
+
+		@Override
+		public void forget(Xid xid) throws XAException {
+			forgetCalled = true;
+		}
+
+		public boolean getForgetCalled() {
+			return forgetCalled;
+		}
+
+		@Override
+		public void end(Xid xid, int flags) throws XAException {
+		}
+
+		@Override
+		public int getTransactionTimeout() throws XAException {
+			return 0;
+		}
+
+		@Override
+		public boolean isSameRM(XAResource xares) throws XAException {
+			return false;
+		}
+
+		@Override
+		public int prepare(Xid xid) throws XAException {
+			return 0;
+		}
+
+		@Override
+		public Xid[] recover(int flag) throws XAException {
+			return null;
+		}
+
+		@Override
+		public boolean setTransactionTimeout(int seconds) throws XAException {
+			return false;
+		}
+
+		@Override
+		public void start(Xid xid, int flags) throws XAException {
+		}
+	}
+}


### PR DESCRIPTION
This is just to get a CI test - I don't think the bug is real because with JTS we can't know whether or not the XAR is the first in the list and therefore whether or not forget will be called.
!BLACKTIE !XTS !QA_JTA
