### PR TITLE
JBTM-2317 disable the XMLReaders ability to validate the XML, this means

### DIFF
--- a/common/classes/com/arjuna/common/util/propertyservice/PropertiesFactorySax.java
+++ b/common/classes/com/arjuna/common/util/propertyservice/PropertiesFactorySax.java
@@ -30,6 +30,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 
 /**
@@ -49,6 +50,9 @@ public final class PropertiesFactorySax extends AbstractPropertiesFactory {
     protected Properties loadFromXML(final Properties p, final InputStream is) throws IOException {
         try {
             final SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
+            XMLReader xrdr = parser.getXMLReader();
+            xrdr.setFeature("http://xml.org/sax/features/validation", false);
+            xrdr.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             final SaxHandler handler = new SaxHandler();
 
             parser.parse(is, handler);


### PR DESCRIPTION
that we do not load in external DTDs and works more like the StAX parser
(default)

!BLACKTIE !XTS !QA_JTA !QA_JTS_JACORB
