### PR TITLE
Fixed JBTM-2350 - CDI Transactional interceptors are not thread safe. (previousUserTransactionAvailability)

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorMandatory.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorMandatory.java
@@ -42,22 +42,20 @@ import javax.transaction.TransactionalException;
 @Transactional(Transactional.TxType.MANDATORY)
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
 public class TransactionalInterceptorMandatory extends TransactionalInterceptorBase {
+    public TransactionalInterceptorMandatory() {
+        super(false);
+    }
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        return super.intercept(ic);
+    }
 
-        final TransactionManager tm = getTransactionManager();
-        final Transaction tx = tm.getTransaction();
-
-        try {
-            setUserTransactionAvailable(false);
-
-            if (tx == null) {
-                throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new TransactionRequiredException());
-            }
-            return invokeInCallerTx(ic, tx);
-        } finally {
-            resetUserTransactionAvailability();
+    @Override
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+        if (tx == null) {
+            throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new TransactionRequiredException());
         }
+        return invokeInCallerTx(ic, tx);
     }
 }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNever.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNever.java
@@ -42,23 +42,20 @@ import javax.transaction.TransactionalException;
 @Transactional(Transactional.TxType.NEVER)
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
 public class TransactionalInterceptorNever extends TransactionalInterceptorBase {
+    public TransactionalInterceptorNever() {
+        super(true);
+    }
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        return super.intercept(ic);
+    }
 
-        final TransactionManager tm = getTransactionManager();
-        final Transaction tx = tm.getTransaction();
-
-        try {
-            setUserTransactionAvailable(true);
-
-            if (tx != null) {
-                throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new InvalidTransactionException());
-            }
-            return invokeInNoTx(ic);
-        } finally {
-            resetUserTransactionAvailability();
+    @Override
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+        if (tx != null) {
+            throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new InvalidTransactionException());
         }
-
+        return invokeInNoTx(ic);
     }
 }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNotSupported.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNotSupported.java
@@ -38,28 +38,26 @@ import javax.transaction.Transactional;
 @Transactional(Transactional.TxType.NOT_SUPPORTED)
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
 public class TransactionalInterceptorNotSupported extends TransactionalInterceptorBase {
+    public TransactionalInterceptorNotSupported() {
+        super(true);
+    }
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        return super.intercept(ic);
+    }
 
-        final TransactionManager tm = getTransactionManager();
-        final Transaction tx = tm.getTransaction();
-
-        try {
-            setUserTransactionAvailable(true);
-
-            if (tx != null) {
-                tm.suspend();
-                try {
-                    return invokeInNoTx(ic);
-                } finally {
-                    tm.resume(tx);
-                }
-            } else {
+    @Override
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+        if (tx != null) {
+            tm.suspend();
+            try {
                 return invokeInNoTx(ic);
+            } finally {
+                tm.resume(tx);
             }
-        } finally {
-            resetUserTransactionAvailability();
+        } else {
+            return invokeInNoTx(ic);
         }
     }
 }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequiresNew.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequiresNew.java
@@ -38,28 +38,26 @@ import javax.transaction.Transactional;
 @Transactional(Transactional.TxType.REQUIRES_NEW)
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
 public class TransactionalInterceptorRequiresNew extends TransactionalInterceptorBase {
+    public TransactionalInterceptorRequiresNew() {
+        super(false);
+    }
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        return super.intercept(ic);
+    }
 
-        final TransactionManager tm = getTransactionManager();
-        final Transaction tx = tm.getTransaction();
-
-        try {
-            setUserTransactionAvailable(false);
-
-            if (tx != null) {
-                tm.suspend();
-                try {
-                    return invokeInOurTx(ic, tm);
-                } finally {
-                    tm.resume(tx);
-                }
-            } else {
+    @Override
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+        if (tx != null) {
+            tm.suspend();
+            try {
                 return invokeInOurTx(ic, tm);
+            } finally {
+                tm.resume(tx);
             }
-        } finally {
-            resetUserTransactionAvailability();
+        } else {
+            return invokeInOurTx(ic, tm);
         }
     }
 }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorSupports.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorSupports.java
@@ -28,9 +28,7 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
-import javax.transaction.TransactionRequiredException;
 import javax.transaction.Transactional;
-import javax.transaction.TransactionalException;
 
 /**
  * @author paul.robinson@redhat.com 25/05/2013
@@ -40,23 +38,21 @@ import javax.transaction.TransactionalException;
 @Transactional(Transactional.TxType.SUPPORTS)
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
 public class TransactionalInterceptorSupports extends TransactionalInterceptorBase {
+    public TransactionalInterceptorSupports() {
+        super(false);
+    }
 
     @AroundInvoke
     public Object intercept(InvocationContext ic) throws Exception {
+        return super.intercept(ic);
+    }
 
-        final TransactionManager tm = getTransactionManager();
-        final Transaction tx = tm.getTransaction();
-
-        try {
-            setUserTransactionAvailable(false);
-
-            if (tx == null) {
-                return invokeInNoTx(ic);
-            } else {
-                return invokeInCallerTx(ic, tx);
-            }
-        } finally {
-            resetUserTransactionAvailability();
+    @Override
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+        if (tx == null) {
+            return invokeInNoTx(ic);
+        } else {
+            return invokeInCallerTx(ic, tx);
         }
     }
 }

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/ConcurrentTransactionalTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/ConcurrentTransactionalTest.java
@@ -1,0 +1,283 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import javax.annotation.Resource;
+import javax.ejb.TransactionManagementType;
+import javax.inject.Inject;
+import javax.transaction.Transactional.TxType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.tm.usertx.client.ServerVMClientUserTransaction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>
+ * Implements various scenarios reproducing bug
+ * <a href="https://issues.jboss.org/browse/JBTM-2350">JBTM-2350</a>.
+ * </p>
+ * <p>
+ * Tests weather previousUserTransactionAvailability leaks between threads in certain race condition when
+ * same method annotated transactional is invoked from two threads with different transaction management type
+ * (user transaction availability).
+ * </p>
+ *
+ * @author <a href="mailto:Tomasz%20Krakowiak%20%3ctomasz.krakowiak@efish.pl%3c">Tomasz Krakowiak
+ *         &lt;tomasz.krakowiak@efish.pl&gt;</a>
+ */
+@RunWith(Arquillian.class)
+public class ConcurrentTransactionalTest {
+	@Inject
+	TestTransactionalInvokerHelper helper;
+
+	@Resource(name = "java:comp/DefaultManagedExecutorService")
+	ExecutorService executorService;
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return ShrinkWrap.create(WebArchive.class, "test.war")
+				.addPackage("com.hp.mwtests.ts.jta.cdi.transactional")
+				.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+	}
+
+	@Test
+	public void testTxRequiredFromCmt() {
+		doTest(TransactionManagementType.CONTAINER, TxType.REQUIRED);
+	}
+
+	@Test
+	public void testTxRequiredFromBmt() {
+		doTest(TransactionManagementType.BEAN, TxType.REQUIRED);
+	}
+
+	@Test
+	public void testTxRequiresNewFromCmt() {
+		doTest(TransactionManagementType.CONTAINER, TxType.REQUIRES_NEW);
+	}
+
+	@Test
+	public void testTxRequiresNewFromBmt() {
+		doTest(TransactionManagementType.BEAN, TxType.REQUIRES_NEW);
+	}
+
+	@Test
+	public void testTxMandatoryFromCmt() {
+		doTest(TransactionManagementType.CONTAINER, TxType.MANDATORY);
+	}
+
+	@Test
+	public void testTxMandatoryFromBmt() {
+		doTest(TransactionManagementType.BEAN, TxType.MANDATORY);
+	}
+
+	@Test
+	public void testTxSupportsFromCmt() {
+		doTest(TransactionManagementType.CONTAINER, TxType.SUPPORTS);
+	}
+
+	@Test
+	public void testTxSupportsFromBmt() {
+		doTest(TransactionManagementType.BEAN, TxType.SUPPORTS);
+	}
+
+	@Test
+	public void testTxNotSupportedFromCmt() {
+		doTest(TransactionManagementType.CONTAINER, TxType.NOT_SUPPORTED);
+	}
+
+	@Test
+	public void testTxNotSupportedFromBmt() {
+		doTest(TransactionManagementType.BEAN, TxType.NOT_SUPPORTED);
+	}
+
+	@Test
+	public void testTxNeverFromCmt() {
+		doTest(TransactionManagementType.CONTAINER, TxType.NEVER);
+	}
+
+	@Test
+	public void testTxNeverFromBmt() {
+		doTest(TransactionManagementType.BEAN, TxType.NEVER);
+	}
+
+	/**
+	 * <p>
+	 * Following description referees to narayana implementation from version 5.0.0 to 5.0.4.
+	 * </p>
+	 * <p>
+	 * We have a bean - {@link TestTransactionalInvokerBean testTransactionalInvokerBean} -
+	 * with a method annotated transactional using tx type txType.
+	 * </p>
+	 * <p>
+	 * This method is being called from two threads, where:
+	 * </p>
+	 * <ul>
+	 * <li>
+	 * Thread 1 is participating in transactionManagementType, therefore it's
+	 * {@link ServerVMClientUserTransaction#isAvailables} value is true if it's value is
+	 * {@link TransactionManagementType#BEAN BEAN}.
+	 * </li>
+	 * <li>
+	 * Thread 2 is participating in transaction management type opposite to transactionManagementType,
+	 * therefore it's {@link ServerVMClientUserTransaction#isAvailables} value is different than for Thread 1.
+	 * </li>
+	 * </ul>
+	 * <p>
+	 * Both threads call {@link TestTransactionalInvokerBean testTransactionalInvokerBean}'s method with
+	 * appropriate tx type at the same time.
+	 * </p>
+	 * <p>
+	 * What may happen:
+	 * </p>
+	 * <ol>
+	 * <li>
+	 * 1. Thread 1 - enters {@link TestTransactionalInvokerBean testTransactionalInvokerBean}'s method.<br/>
+	 * Interceptor sets previousUserTransactionAvailability.
+	 * </li>
+	 * <li>
+	 * 2. Thread 2 - enters {@link TestTransactionalInvokerBean testTransactionalInvokerBean}'s method.<br/>
+	 * Interceptor sets previousUserTransactionAvailability to opposite value that it was set in Thread 1.
+	 * </li>
+	 * <li>
+	 * 3. Thread 1 - exits method {@link TestTransactionalInvokerBean testTransactionalInvokerBean}'s and
+	 * {@link ServerVMClientUserTransaction#isAvailables} thread local value is set to incorrect value.
+	 * </li>
+	 * </ol>
+	 *
+	 * @param transactionManagementType transaction management type
+	 * @param txType tx type to which related interceptor test to run.
+	 */
+	private void doTest(TransactionManagementType transactionManagementType, TxType txType) {
+		CountDownLatch thread1EnterLatch = new CountDownLatch(1);
+		CountDownLatch thread2StartLatch = thread1EnterLatch;
+		CountDownLatch thread2EnterLatch = new CountDownLatch(1);
+		CountDownLatch thread1ExitLatch = thread2EnterLatch;
+		CountDownLatch thread2ExitLatch = new CountDownLatch(0);
+
+		boolean startTransaction = txType == TxType.MANDATORY;
+
+		TransactionManagementType otherTransactionManagementType = otherTransactionManagementType(transactionManagementType);
+		boolean expectedUserTransactionAvailable = transactionManagementType == TransactionManagementType.BEAN;
+
+		Runnable thread1Runnable = helper.runWithTransactionManagement(transactionManagementType, startTransaction,
+				helper.runAndCheckUserTransactionAvailability(
+						helper.runInTxType(txType,
+								new DeterminingRaceRunnable(thread1EnterLatch, thread1ExitLatch)
+						),
+						expectedUserTransactionAvailable
+				)
+		);
+		Runnable thread2Runnable = new AwaitAndRun(thread2StartLatch,
+				helper.runWithTransactionManagement(otherTransactionManagementType, startTransaction,
+						helper.runInTxType(txType,
+								new DeterminingRaceRunnable(thread2EnterLatch, thread2ExitLatch)
+						)
+				)
+		);
+
+		Future<?> thread2Future = executorService.submit(thread2Runnable);
+		thread1Runnable.run();
+		try {
+			thread2Future.get();
+		} catch (InterruptedException | ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * <p>
+	 * Returns opposite transaction management type to transactionManagementType:
+	 * </p>
+	 * <ul>
+	 * <li>{@link TransactionManagementType#BEAN} for {@link TransactionManagementType#CONTAINER}</li>
+	 * <li>{@link TransactionManagementType#CONTAINER} for {@link TransactionManagementType#BEAN}</li>
+	 * </ul>
+	 *
+	 * @param transactionManagementType transactionManagementType
+	 * @return Opposite transaction management type to transactionManagementType
+	 */
+	private TransactionManagementType otherTransactionManagementType(TransactionManagementType transactionManagementType) {
+		switch (transactionManagementType) {
+			case CONTAINER:
+				return TransactionManagementType.BEAN;
+			case BEAN:
+				return TransactionManagementType.CONTAINER;
+			default:
+				throw new RuntimeException("Unexpected transaction management type " + transactionManagementType);
+		}
+	}
+
+	/**
+	 * Waits for startLatch to be released and then invokes runnable.
+	 */
+	private class AwaitAndRun implements Runnable {
+		private final CountDownLatch startLatch;
+		private final Runnable runnable;
+
+		public AwaitAndRun(CountDownLatch startLatch, Runnable runnable) {
+			this.startLatch = startLatch;
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			try {
+				startLatch.await();
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+			runnable.run();
+		}
+	}
+
+	/**
+	 * Releases enterLatch and waits for exitLatch to be released.
+	 */
+	private class DeterminingRaceRunnable implements Runnable {
+		CountDownLatch enterLatch;
+		CountDownLatch exitLatch;
+
+		public DeterminingRaceRunnable(CountDownLatch enterLatch, CountDownLatch exitLatch) {
+			this.enterLatch = enterLatch;
+			this.exitLatch = exitLatch;
+		}
+
+		@Override
+		public void run() {
+			enterLatch.countDown();
+			try {
+				exitLatch.await();
+			} catch (InterruptedException e) {
+				throw new RuntimeException("Test was interrupted.", e);
+			}
+		}
+	}
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/RecursiveTransactionalTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/RecursiveTransactionalTest.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional;
+
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Resource;
+import javax.ejb.TransactionManagementType;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>
+ * Implements various scenarios reproducing bug
+ * <a href="https://issues.jboss.org/browse/JBTM-2350">JBTM-2350</a>.
+ * </p>
+ * <p>
+ * Test weather transaction management type(user transaction availability) is correctly restored when method
+ * annotated {@link Transactional @Transactional} is invoked recursively.
+ * </p>
+ *
+ * @author <a href="mailto:Tomasz%20Krakowiak%20%3ctomasz.krakowiak@efish.pl%3c">Tomasz Krakowiak
+ *         &lt;tomasz.krakowiak@efish.pl&gt;</a>
+ */
+@RunWith(Arquillian.class)
+public class RecursiveTransactionalTest {
+
+	public static final Runnable DO_NOTHING = new Runnable() {
+		@Override
+		public void run() {
+		}
+	};
+
+	@Inject
+	TestTransactionalInvokerHelper helper;
+
+	@Resource(name = "java:comp/DefaultManagedExecutorService")
+	ExecutorService executorService;
+
+	@Deployment
+	public static WebArchive createTestArchive() {
+		return ShrinkWrap.create(WebArchive.class, "test.war")
+				.addPackage("com.hp.mwtests.ts.jta.cdi.transactional")
+				.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+	}
+
+	@Test
+	public void testRecursiveTxRequired() {
+		doTest(TxType.REQUIRED);
+	}
+
+	@Test
+	public void testRecursiveTxRequiresNew() {
+		doTest(TxType.REQUIRES_NEW);
+	}
+
+	@Test
+	public void testRecursiveTxMandatory() {
+		doTest(TxType.MANDATORY);
+	}
+
+	@Test
+	public void testRecursiveTxSupports() {
+		doTest(TxType.SUPPORTS);
+	}
+
+	@Test
+	public void testRecursiveTxNotSupported() {
+		doTest(TxType.NOT_SUPPORTED);
+	}
+
+	@Test
+	public void testRecursiveTxNever() {
+		doTest(TxType.NEVER);
+	}
+
+	private void doTest(TxType txType) {
+		TransactionManagementType oppositeTransactionManagementType = oppositeTransactionManagementType(txType);
+		boolean startTransaction = txType == TxType.MANDATORY;
+		boolean expectedAvailable = oppositeTransactionManagementType == TransactionManagementType.BEAN;
+		Runnable runnable = helper.runWithTransactionManagement(oppositeTransactionManagementType, startTransaction,
+				helper.runAndCheckUserTransactionAvailability(
+						helper.runInTxType(txType,
+								helper.runInTxType(txType, DO_NOTHING)
+						),
+						expectedAvailable
+				)
+		);
+		runnable.run();
+	}
+
+	private TransactionManagementType oppositeTransactionManagementType(TxType txType) {
+		switch (txType) {
+			case REQUIRED:
+			case REQUIRES_NEW:
+			case MANDATORY:
+			case SUPPORTS:
+				return TransactionManagementType.BEAN;
+			case NOT_SUPPORTED:
+			case NEVER:
+				return TransactionManagementType.CONTAINER;
+			default:
+				throw new RuntimeException("Unexpected tx type " + txType);
+		}
+	}
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalInvokerBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalInvokerBean.java
@@ -20,39 +20,43 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package com.arjuna.ats.jta.cdi.transactional;
+package com.hp.mwtests.ts.jta.cdi.transactional;
 
-import javax.annotation.Priority;
-import javax.interceptor.AroundInvoke;
-import javax.interceptor.Interceptor;
-import javax.interceptor.InvocationContext;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
 
 /**
- * @author paul.robinson@redhat.com 25/05/2013
+ * @author <a href="mailto:Tomasz%20Krakowiak%20%3ctomasz.krakowiak@efish.pl%3c">Tomasz Krakowiak
+ *         &lt;tomasz.krakowiak@efish.pl&gt;</a>
  */
+@ApplicationScoped
+public class TestTransactionalInvokerBean {
+	@Transactional(Transactional.TxType.REQUIRED)
+	public void invokeInTxRequired(Runnable runnable) {
+		runnable.run();
+	}
 
-@Interceptor
-@Transactional(Transactional.TxType.REQUIRED)
-@Priority(Interceptor.Priority.PLATFORM_BEFORE + 200)
-public class TransactionalInterceptorRequired extends TransactionalInterceptorBase {
-    public TransactionalInterceptorRequired() {
-        super(false);
-    }
+	@Transactional(Transactional.TxType.REQUIRES_NEW)
+	public void invokeInTxRequiresNew(Runnable runnable) {
+		runnable.run();
+	}
 
-    @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
-        return super.intercept(ic);
-    }
+	@Transactional(Transactional.TxType.MANDATORY)
+	public void invokeInTxMandatory(Runnable runnable) {
+		runnable.run();
+	}
 
-    @Override
-    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
-        if (tx == null) {
-            return invokeInOurTx(ic, tm);
-        } else {
-            return invokeInCallerTx(ic, tx);
-        }
-    }
+	@Transactional(Transactional.TxType.NOT_SUPPORTED)
+	public void invokeInTxNotSupported(Runnable runnable) {
+		runnable.run();
+	}
+
+	@Transactional(Transactional.TxType.SUPPORTS)
+	public void invokeInTxSupports(Runnable runnable) {
+		runnable.run();
+	}
+	@Transactional(Transactional.TxType.NEVER)
+	public void invokeInTxNever(Runnable runnable) {
+		runnable.run();
+	}
 }

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalInvokerHelper.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalInvokerHelper.java
@@ -1,0 +1,221 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional;
+
+import javax.ejb.TransactionManagementType;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.transaction.NotSupportedException;
+import javax.transaction.SystemException;
+import javax.transaction.Transactional.TxType;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author <a href="mailto:Tomasz%20Krakowiak%20%3ctomasz.krakowiak@efish.pl%3c">Tomasz Krakowiak
+ *         &lt;tomasz.krakowiak@efish.pl&gt;</a>
+ */
+@ApplicationScoped
+public class TestTransactionalInvokerHelper {
+
+	@Inject
+	private UserTransaction userTransaction;
+
+	@Inject
+	private TestTransactionalInvokerBean bean;
+
+	public Runnable runWithTransactionManagement(TransactionManagementType transactionManagementType, boolean startTransaction, Runnable runnable) {
+		switch (transactionManagementType) {
+			case CONTAINER:
+				if (startTransaction) {
+					return new RunInTxRequired(runnable);
+				} else {
+					return new RunInTxSupports(runnable);
+				}
+			case BEAN:
+				if (startTransaction) {
+					return new RunInTxNotSupported(new RunInBmtTransaction(runnable));
+				} else {
+					return new RunInTxNotSupported(runnable);
+				}
+			default:
+				throw new RuntimeException("Unexpected transaction management type " + transactionManagementType);
+		}
+	}
+
+	public Runnable runInTxType(TxType txType, Runnable runnable) {
+		switch (txType) {
+			case REQUIRED:
+				return new RunInTxRequired(runnable);
+			case REQUIRES_NEW:
+				return new RunInTxRequiresNew(runnable);
+			case MANDATORY:
+				return new RunInTxMandatory(runnable);
+			case NOT_SUPPORTED:
+				return new RunInTxNotSupported(runnable);
+			case SUPPORTS:
+				return new RunInTxSupports(runnable);
+			case NEVER:
+				return new RunInTxNever(runnable);
+			default:
+				throw new RuntimeException("Unexpected tx type " + txType);
+		}
+	}
+
+	public Runnable runAndCheckUserTransactionAvailability(Runnable runnable, boolean expectedAvailable) {
+		return new RunAndCheckUserTransactionAvailability(runnable, expectedAvailable);
+	}
+
+	private class RunAndCheckUserTransactionAvailability implements Runnable {
+		Runnable runnable;
+		boolean expectedAvailable;
+
+		public RunAndCheckUserTransactionAvailability(Runnable runnable, boolean expectedAvailable) {
+			this.runnable = runnable;
+			this.expectedAvailable = expectedAvailable;
+		}
+
+		@Override
+		public void run() {
+			runnable.run();
+			try {
+				userTransaction.getStatus();
+				if (!expectedAvailable) {
+					throw new AssertionError("Expected user transaction to be not available.");
+				}
+			} catch (IllegalStateException e) {
+				if (expectedAvailable) {
+					throw new AssertionError("Expected user transaction to be available.");
+				}
+			} catch (SystemException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	private class RunInTxRequired implements Runnable {
+		Runnable runnable;
+
+		public RunInTxRequired(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			bean.invokeInTxRequired(runnable);
+		}
+	}
+
+
+	private class RunInTxRequiresNew implements Runnable {
+		Runnable runnable;
+
+		public RunInTxRequiresNew(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			bean.invokeInTxRequiresNew(runnable);
+		}
+	}
+
+
+	private class RunInTxMandatory implements Runnable {
+		Runnable runnable;
+
+		public RunInTxMandatory(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			bean.invokeInTxMandatory(runnable);
+		}
+	}
+
+	private class RunInTxNotSupported implements Runnable {
+		Runnable runnable;
+
+		public RunInTxNotSupported(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			bean.invokeInTxNotSupported(runnable);
+		}
+	}
+
+	private class RunInTxSupports implements Runnable {
+		Runnable runnable;
+
+		public RunInTxSupports(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			bean.invokeInTxSupports(runnable);
+		}
+	}
+
+	private class RunInTxNever implements Runnable {
+		Runnable runnable;
+
+		public RunInTxNever(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+		@Override
+		public void run() {
+			bean.invokeInTxNever(runnable);
+		}
+	}
+
+	private class RunInBmtTransaction implements Runnable {
+		Runnable runnable;
+
+		public RunInBmtTransaction(Runnable runnable) {
+			this.runnable = runnable;
+		}
+
+
+		@Override
+		public void run() {
+			try {
+				userTransaction.begin();
+				try {
+					runnable.run();
+				} catch (RuntimeException e) {
+					try {
+						userTransaction.rollback();
+					} catch (Throwable e1) {
+						e.addSuppressed(e1);
+					}
+				}
+			} catch (NotSupportedException | SystemException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}


### PR DESCRIPTION
!XTS !QA_JTA !QA_JTS_JACORB !BLACKTIE !PERF

Do you need unit tests for it? They seems easy to write, harder to launch `-Parq`.