### PR TITLE
JBTM-1339 JBTM-2423 New profile to use openjdk-orb

### DIFF
--- a/ArjunaJTS/idl/pom.xml
+++ b/ArjunaJTS/idl/pom.xml
@@ -69,6 +69,17 @@
       </modules>
     </profile>
     <profile>
+      <id>jts-openjdk</id>
+      <activation>
+        <property>
+          <name>!openjdk-disabled</name>
+        </property>
+      </activation>
+      <modules>
+        <module>idlj</module>
+      </modules>
+    </profile>
+    <profile>
       <id>jts-ibmorb</id>
       <activation>
         <property>

--- a/ArjunaJTS/jtax/pom.xml
+++ b/ArjunaJTS/jtax/pom.xml
@@ -23,6 +23,12 @@
   <name>Narayana: ArjunaJTS jtax</name>
   <packaging>jar</packaging>
   <description>Narayana: ArjunaJTS jtax</description>
+
+  <properties>
+    <openjdk-orb.jar>${project.build.directory}/openjdk-orb-8.0.2.Final.jar</openjdk-orb.jar>
+    <idlj.boot.args>-Xbootclasspath/p:${openjdk-orb.jar}</idlj.boot.args>
+  </properties>
+
   <build>
     <sourceDirectory>classes</sourceDirectory>
     <testSourceDirectory>tests/classes</testSourceDirectory>
@@ -274,6 +280,107 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <!--
+       Use a fork of the jdk orb.
+       This profile builds on the jts-idlj profile and adds the openjdk orb classes to the bootclasspath
+       -->
+      <id>jts-openjdk</id>
+      <activation>
+        <property>
+          <name>!openjdk-disabled</name>
+        </property>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.openjdk-orb</groupId>
+          <artifactId>openjdk-orb</artifactId>
+          <version>8.0.2.Final</version>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>surefire-idlj</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <argLine>${idlj.boot.args}</argLine>
+                  <skip>false</skip>
+                  <systemProperties combine.children="append" />
+                  <excludes>
+                    <exclude>**/common/**</exclude>
+                    <exclude>**/ExampleXAResource.java</exclude>
+                    <exclude>**/JTSTestCase.java</exclude>
+                    <exclude>**/LastOnePhaseResource.java</exclude>
+                    <exclude>**/implicit/**</exclude>
+                  </excludes>
+                  <reportsDirectory>${project.build.directory}/idlj-surefire-reports</reportsDirectory>
+                  <classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:jacorb-idl</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:jacorb-idl:test-jar</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:ibmorb-idl</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:ibmorb-idl:test-jar</classpathDependencyExcludes>
+                  </classpathDependencyExcludes>
+                  <systemPropertyVariables
+                          combine.children="append">
+                    <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.orb.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.orbImpleClassName>
+                    <OrbPortabilityEnvironmentBean.poaImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.oa.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.poaImpleClassName>
+                    <OrbPortabilityEnvironmentBean.orbDataClassName>com.arjuna.orbportability.internal.orbspecific.versions.javaidl_1_4</OrbPortabilityEnvironmentBean.orbDataClassName>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.0</version>
+            <executions>
+              <execution>
+                <id>copy</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jboss.openjdk-orb</groupId>
+                      <artifactId>openjdk-orb</artifactId>
+                      <version>8.0.2.Final</version>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>jts-ibmorb</id>
       <activation>

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/ibmorb/recoverycoordinators/ORBRunner.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/ibmorb/recoverycoordinators/ORBRunner.java
@@ -52,21 +52,6 @@ public class ORBRunner extends Thread
         {
             e.printStackTrace();
         }
-
-        try
-        {
-            if (JavaIdlRCServiceInit._oa != null)
-                JavaIdlRCServiceInit._oa.destroy();
-
-            if (JavaIdlRCServiceInit._orb != null)
-                JavaIdlRCServiceInit._orb.shutdown();
-        }
-        catch (Exception ex)
-        {
-        }
-
-        //JavaIdlRCServiceInit.orbRunnerCompleted();
     }
-
 }
 

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/ORBRunner.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/ORBRunner.java
@@ -32,9 +32,7 @@
 
 package com.arjuna.ats.internal.jts.orbspecific.jacorb.recoverycoordinators;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-
-public class ORBRunner extends Thread 
+public class ORBRunner extends Thread
 {
     
     public ORBRunner ()
@@ -54,20 +52,7 @@ public class ORBRunner extends Thread
 	{
 	    e.printStackTrace();
 	}
-	
-	try
-	{
-	    if (JacOrbRCServiceInit._oa != null)
-		JacOrbRCServiceInit._oa.destroy();
-	
-	    if (JacOrbRCServiceInit._orb != null)
-		JacOrbRCServiceInit._orb.shutdown();
-	}
-	catch (Exception ex)
-	{
-	}
 	JacOrbRCServiceInit.orbRunnerCompleted();
     }
-    
 }
 

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/ORBRunner.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/ORBRunner.java
@@ -52,21 +52,6 @@ public class ORBRunner extends Thread
         {
             e.printStackTrace();
         }
-
-        try
-        {
-            if (JavaIdlRCServiceInit._oa != null)
-                JavaIdlRCServiceInit._oa.destroy();
-
-            if (JavaIdlRCServiceInit._orb != null)
-                JavaIdlRCServiceInit._orb.shutdown();
-        }
-        catch (Exception ex)
-        {
-        }
-
-        //JavaIdlRCServiceInit.orbRunnerCompleted();
     }
-
 }
 

--- a/ArjunaJTS/jts/pom.xml
+++ b/ArjunaJTS/jts/pom.xml
@@ -28,6 +28,8 @@
     <classesDirectoryWithJacorb>${project.build.directory}/jts-jacorb</classesDirectoryWithJacorb>
     <classesDirectoryWithIdlj>${project.build.directory}/jts-idlj</classesDirectoryWithIdlj>
     <classesDirectoryWithibmorb>${project.build.directory}/jts-ibmorb</classesDirectoryWithibmorb>
+    <openjdk-orb.jar>${project.build.directory}/openjdk-orb-8.0.2.Final.jar</openjdk-orb.jar>
+    <idlj.boot.args>-Xbootclasspath/p:${openjdk-orb.jar}</idlj.boot.args>
   </properties>
 
   <build>
@@ -389,6 +391,147 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <!--
+       Use a fork of the jdk orb.
+       This profile builds on the jts-idlj profile and adds the openjdk orb classes to the bootclasspath
+       -->
+      <id>jts-openjdk</id>
+      <activation>
+        <property>
+          <name>!openjdk-disabled</name>
+        </property>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.openjdk-orb</groupId>
+          <artifactId>openjdk-orb</artifactId>
+          <version>8.0.2.Final</version>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>idlj-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <excludes>
+                    <exclude>**/jacorb/**</exclude>
+                    <exclude>**/ibmorb/**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>idlj-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <testExcludes>
+                    <!-- TODO make sure all supported ORBs have "RecoveryCreator" tests -->
+                    <exclude>**/GenericRecoveryCreatorUnitTest.java</exclude>
+                    <exclude>**/JacORB*.java</exclude>
+                    <exclude>**/jacorb/**</exclude>
+                    <exclude>**/ibmorb/**</exclude>
+                  </testExcludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>surefire-idlj</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <argLine>${idlj.boot.args}</argLine>
+                  <skip>false</skip>
+                  <systemProperties combine.children="append" />
+                  <excludes>
+                    <exclude>**/common/**</exclude>
+                    <exclude>**/exceptions/**</exclude>
+                    <exclude>**/orbspecific/resources/**</exclude>
+                    <exclude>**/resources/**</exclude>
+                    <exclude>**/utils/ResourceTrace.java</exclude>
+                    <exclude>**/utils/Util.java</exclude>
+                    <exclude>**/TransactionTest2.java</exclude>
+                    <exclude>**/CheckedTransactions.java</exclude>
+                    <exclude>**/GridTest.java</exclude>
+                    <exclude>**/remote/**</exclude>
+                    <exclude>**/DefaultTimeout.java</exclude>
+                    <exclude>**/JacORB*.java</exclude>
+                    <exclude>**/jacorb/**</exclude>
+                    <exclude>**/ibmorb/**</exclude>
+                  </excludes>
+                  <reportsDirectory>${project.build.directory}/idlj-surefire-reports</reportsDirectory>
+                  <classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:jacorb-idl</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:jacorb-idl:test-jar</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:ibmorb-idl</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:ibmorb-idl:test-jar</classpathDependencyExcludes>
+                  </classpathDependencyExcludes>
+                  <systemPropertyVariables combine.children="append">
+                    <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.orb.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.orbImpleClassName>
+                    <OrbPortabilityEnvironmentBean.poaImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.oa.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.poaImpleClassName>
+                    <OrbPortabilityEnvironmentBean.orbDataClassName>com.arjuna.orbportability.internal.orbspecific.versions.javaidl_1_4</OrbPortabilityEnvironmentBean.orbDataClassName>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.0</version>
+            <executions>
+              <execution>
+                <id>copy</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jboss.openjdk-orb</groupId>
+                      <artifactId>openjdk-orb</artifactId>
+                      <version>8.0.2.Final</version>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>jts-ibmorb</id>
       <activation>

--- a/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/ORB.java
+++ b/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/ORB.java
@@ -263,6 +263,11 @@ public class ORB
             opLogger.logger.trace("ORB::shutdown ()");
         }
 
+        // Ensure destroy is called on the root OA so that any pre/post destroy hooks get called
+        // Normally we expect whoever called shutdown to have done this however destroy is
+        // safe to call multiple times
+        OA.getRootOA(this).destroy();
+
         /*
          * Do the cleanups first!
          */

--- a/ArjunaJTS/orbportability/pom.xml
+++ b/ArjunaJTS/orbportability/pom.xml
@@ -23,6 +23,11 @@
   <name>Narayana: ArjunaJTS orbportability</name>
   <description>orb portability harness</description>
   <packaging>jar</packaging>
+  <properties>
+    <openjdk-orb.jar>${project.build.directory}/openjdk-orb-8.0.2.Final.jar</openjdk-orb.jar>
+    <idlj.boot.args>-Xbootclasspath/p:${openjdk-orb.jar}</idlj.boot.args>
+  </properties>
+
   <build>
     <sourceDirectory>classes</sourceDirectory>
     <resources>
@@ -217,7 +222,6 @@
                     <exclude>**/initialisation/TestAttributeCallback.java</exclude>
                     <exclude>**/SimpleObjectImpl.java</exclude>
                     <exclude>**/TestAttributeCallback.java</exclude>
-                    <exclude>**/PrePostTestCallback.java</exclude>
                     <!-- these ones need fixing -->
                     <exclude>**/PropertyInitTest.java</exclude>
                     <exclude>**/PropertyInitTest3.java</exclude>
@@ -311,7 +315,6 @@
                     <exclude>**/initialisation/TestAttributeCallback.java</exclude>
                     <exclude>**/SimpleObjectImpl.java</exclude>
                     <exclude>**/TestAttributeCallback.java</exclude>
-                    <exclude>**/PrePostTestCallback.java</exclude>
                     <!-- these ones need fixing -->
                     <exclude>**/PropertyInitTest.java</exclude>
                     <exclude>**/PropertyInitTest3.java</exclude>
@@ -336,6 +339,132 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>jts-openjdk</id>
+      <activation>
+        <property>
+          <name>!openjdk-disabled</name>
+        </property>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.narayana.jts</groupId>
+          <artifactId>idlj-idl</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>idlj-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <excludes>
+                    <exclude>**/jacorb/**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>idlj-testCompile</id>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <testExcludes>
+                    <exclude>**/PropertyInitTest.java</exclude>
+                    <exclude>**/PropertyInitTest3.java</exclude>
+                  </testExcludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>surefire-idlj</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <argLine>${idlj.boot.args}</argLine>
+                  <skip>false</skip>
+                  <systemProperties combine.children="append" />
+                  <excludes>
+                    <!-- exclude tests which we don't want to run -->
+                    <exclude>**/common/**</exclude>
+                    <exclude>**/initialisation/postinit/**</exclude>
+                    <exclude>**/initialisation/postset/**</exclude>
+                    <exclude>**/initialisation/preinit/**</exclude>
+                    <exclude>**/initialisation/TestAttributeCallback.java</exclude>
+                    <exclude>**/SimpleObjectImpl.java</exclude>
+                    <exclude>**/TestAttributeCallback.java</exclude>
+                    <!-- these ones need fixing -->
+                    <exclude>**/PropertyInitTest.java</exclude>
+                    <exclude>**/PropertyInitTest3.java</exclude>
+                  </excludes>
+                  <reportsDirectory>${project.build.directory}/idlj-surefire-reports</reportsDirectory>
+                  <classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:jacorb-idl</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:jacorb-idl:test-jar</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:ibmorb-idl</classpathDependencyExcludes>
+                    <classpathDependencyExcludes>org.jboss.narayana.jts:ibmorb-idl:test-jar</classpathDependencyExcludes>
+                  </classpathDependencyExcludes>
+                  <systemPropertyVariables
+                          combine.children="append">
+                    <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.orb.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.orbImpleClassName>
+                    <OrbPortabilityEnvironmentBean.poaImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.oa.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.poaImpleClassName>
+                    <OrbPortabilityEnvironmentBean.orbDataClassName>com.arjuna.orbportability.internal.orbspecific.versions.javaidl_1_4</OrbPortabilityEnvironmentBean.orbDataClassName>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.0</version>
+            <executions>
+              <execution>
+                <id>copy</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.jboss.openjdk-orb</groupId>
+                      <artifactId>openjdk-orb</artifactId>
+                      <version>8.0.2.Final</version>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>jts-ibmorb</id>
       <activation>
@@ -411,7 +540,6 @@
                     <exclude>**/initialisation/TestAttributeCallback.java</exclude>
                     <exclude>**/SimpleObjectImpl.java</exclude>
                     <exclude>**/TestAttributeCallback.java</exclude>
-                    <exclude>**/PrePostTestCallback.java</exclude>
                     <!-- these ones need fixing -->
                     <exclude>**/PropertyInitTest.java</exclude>
                     <exclude>**/PropertyInitTest3.java</exclude>

--- a/ArjunaJTS/orbportability/tests/classes/com/hp/mwtests/orbportability/shutdown/OAPrePostShutdownTest.java
+++ b/ArjunaJTS/orbportability/tests/classes/com/hp/mwtests/orbportability/shutdown/OAPrePostShutdownTest.java
@@ -142,6 +142,37 @@ public class OAPrePostShutdownTest implements PrePostTestCallback
 
         assertEquals(POSTSHUTDOWN, _currentState);
     }
+
+	@Test
+	public void testOAShutdownCalled() throws Exception
+	{
+		ORB orb = ORB.getInstance("main_orb");
+		RootOA oa = RootOA.getRootOA(orb);
+
+		System.out.println("Initialising ORB and OA");
+
+		orb.initORB(new String[] {}, null);
+		oa.initOA();
+
+		_currentState = NONE;
+
+		/**
+		 * Register pre and post shutdown handlers
+		 */
+		oa.addPreShutdown( new TestPreShutdown( "PreShutdown", this ) );
+		oa.addPostShutdown( new TestPostShutdown( "PostShutdown", this ) );
+
+		System.out.println("Shutting down ORB (expecting OA to also be destroyed)");
+		orb.shutdown();
+
+        /*
+       * Ensure final state is correct
+       */
+		System.out.println("Final state: " + PrettyPrintState(_currentState) );
+
+		assertEquals(POSTSHUTDOWN, _currentState);
+	}
+
     /**
      *
      */

--- a/pom.xml
+++ b/pom.xml
@@ -425,6 +425,7 @@
     <version.org.jacorb.jacorb>2.3.2-jbossorg-5</version.org.jacorb.jacorb>
     <version.org.jacorb.jacorb-idl-compiler>2.3.1</version.org.jacorb.jacorb-idl-compiler>
     <version.jacorb>2.3.1jboss.patch01-brew</version.jacorb>
+    <version.org.jboss.openjdk-orb>8.0.2.Final</version.org.jboss.openjdk-orb>
     <version.javax.annotation>1.2</version.javax.annotation>
     <version.javax.enterprise>1.1</version.javax.enterprise>
     <version.javax.inject>1</version.javax.inject>


### PR DESCRIPTION
!BLACKTIE !PERF !XTS !QA_JTA !QA_JTS_JACORB

The changes are twofold:
- I add a jar to the bootclasspath for testing a particular profile - ie it is isolated and only kicks in during surefire tests.
- secondly, when we run an orb we do some clean up after the run loop completes and that is not (CORBA) spec compliant so I removed that code. This meant there was a risk that destroy on the root poa would not get called so I added that check to the shutdown method on our ORB portability layer wrapper.
