### PR TITLE
JBTM-2443 Updated so that when a commit_one_phase gets an RMFAIL back we can throw

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
@@ -46,6 +46,7 @@ import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
 import com.arjuna.ats.internal.jta.resources.XAResourceErrorHandler;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
 import com.arjuna.ats.internal.jta.xa.TxInfo;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
 import com.arjuna.ats.jta.logging.jtaLogger;
 import com.arjuna.ats.jta.recovery.SerializableXAResourceDeserializer;
@@ -751,7 +752,8 @@ public class XAResourceRecord extends AbstractRecord implements ExceptionDeferre
 	                case XAException.XA_RETRY:  // XA does not allow this to be thrown for 1PC!
 	                case XAException.XAER_PROTO:
 	                    return TwoPhaseOutcome.ONE_PHASE_ERROR; // assume rollback
-	                case XAException.XAER_RMFAIL:
+	                case XAException.XAER_RMFAIL: // This was modified as part of JBTM-XYZ - although RMFAIL is not clear there is a rollback/commit we are flagging this to the user
+	                     return TwoPhaseOutcome.HEURISTIC_HAZARD;
 	                default:
 	                    _committed = true;  // will cause log to be rewritten
 	                    return TwoPhaseOutcome.FINISH_ERROR;  // recovery should retry

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/twophase/XAResourceRecordUnitTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/twophase/XAResourceRecordUnitTest.java
@@ -202,7 +202,7 @@ public class XAResourceRecordUnitTest
         
         xares = new XAResourceRecord(tx, new FailureXAResource(FailLocation.commit, FailType.rmfail), tx.getTxId(), null);
         
-        assertEquals(xares.topLevelOnePhaseCommit(), TwoPhaseOutcome.FINISH_ERROR);
+        assertEquals(xares.topLevelOnePhaseCommit(), TwoPhaseOutcome.HEURISTIC_HAZARD);
     }
     
     @Test

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
@@ -32,6 +32,7 @@
 package com.hp.mwtests.ts.jta.xa;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
@@ -39,7 +40,76 @@ import javax.transaction.xa.Xid;
 
 import org.junit.Test;
 
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+
 public class JTATest {
+    @Test
+    public void testRMFAILcommit1PC() throws Exception
+    {
+        XAResource theResource = new XAResource() {
+
+            @Override
+            public void start(Xid xid, int flags) throws XAException {
+            }
+
+            @Override
+            public void end(Xid xid, int flags) throws XAException {
+            }
+
+            @Override
+            public int prepare(Xid xid) throws XAException {
+                return 0;
+            }
+
+            @Override
+            public void commit(Xid xid, boolean onePhase) throws XAException {
+                throw new XAException(XAException.XAER_RMFAIL);
+            }
+
+            @Override
+            public void rollback(Xid xid) throws XAException {
+            }
+
+            @Override
+            public void forget(Xid xid) throws XAException {
+            }
+
+            @Override
+            public Xid[] recover(int flag) throws XAException {
+                return null;
+            }
+
+            @Override
+            public boolean isSameRM(XAResource xaRes) throws XAException {
+                return false;
+            }
+
+            @Override
+            public int getTransactionTimeout() throws XAException {
+                return 0;
+            }
+
+            @Override
+            public boolean setTransactionTimeout(int seconds) throws XAException {
+                return false;
+            }
+        };
+
+        javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+
+        tm.begin();
+
+        javax.transaction.Transaction theTransaction = tm.getTransaction();
+
+        assertTrue(theTransaction.enlistResource(theResource));
+
+        try {
+            tm.commit();
+            fail();
+        } catch (javax.transaction.HeuristicMixedException e) {
+            // Expected
+        }
+    }
 
 	@Test
 	public void test() throws Exception {

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
@@ -814,7 +814,8 @@ public class XAResourceRecord extends com.arjuna.ArjunaOTS.OTSAbstractRecordPOA
 
 	                case XAException.XAER_INVAL: // resource manager failed, did it rollback?
 	                    throw new org.omg.CosTransactions.HeuristicHazard();
-	                case XAException.XAER_RMFAIL:
+	                case XAException.XAER_RMFAIL: // This was modified as part of JBTM-XYZ - although RMFAIL is not clear there is a rollback/commit we are flagging this to the user
+                        throw new org.omg.CosTransactions.HeuristicHazard();
 	                default:
 	                    _committed = true;  // will cause log to be rewritten
 

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/xa/JTSTest.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/xa/JTSTest.java
@@ -32,12 +32,17 @@
 package com.hp.mwtests.ts.jta.jts.xa;
  
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.omg.CORBA.SystemException;
+import org.omg.CORBA.ORBPackage.InvalidName;
 
 import com.arjuna.ats.internal.jts.ORBManager;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
@@ -46,18 +51,104 @@ import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 
 public class JTSTest {
+    private ORB myORB;
+    private RootOA myOA;
+
+    @Before
+    public void setup() throws InvalidName, SystemException {
+        System.setProperty("OrbPortabilityEnvironmentBean.orbImpleClassName", System.getProperty("OrbPortabilityEnvironmentBean.orbImpleClassName", "com.arjuna.orbportability.internal.orbspecific.javaidl.orb.implementations.javaidl_1_4"));
+        System.setProperty("OrbPortabilityEnvironmentBean.poaImpleClassName", System.getProperty("OrbPortabilityEnvironmentBean.poaImpleClassName", "com.arjuna.orbportability.internal.orbspecific.javaidl.oa.implementations.javaidl_1_4"));
+        System.setProperty("OrbPortabilityEnvironmentBean.orbDataClassName", System.getProperty("OrbPortabilityEnvironmentBean.orbDataClassName", "com.arjuna.orbportability.internal.orbspecific.versions.javaidl_1_4"));
+        myORB = ORB.getInstance("test");
+        myOA = OA.getRootOA(myORB);
+        myORB.initORB(new String[] {}, null);
+        myOA.initOA();
+
+        ORBManager.setORB(myORB);
+        ORBManager.setPOA(myOA);
+        jtaPropertyManager.getJTAEnvironmentBean().setTransactionManagerClassName(com.arjuna.ats.internal.jta.transaction.jts.TransactionManagerImple.class.getName());
+        jtaPropertyManager.getJTAEnvironmentBean().setUserTransactionClassName(com.arjuna.ats.internal.jta.transaction.jts.UserTransactionImple.class.getName());
+    }
+    
+    @After
+    public void tearDown() {
+        if (myOA != null) {
+//            myOA.destroy();
+//            myORB.shutdown();
+        }
+    }
+    
+    @Test
+    public void testRMFAILcommit1PC() throws Exception
+    {
+        XAResource theResource = new XAResource() {
+
+            @Override
+            public void start(Xid xid, int flags) throws XAException {
+            }
+
+            @Override
+            public void end(Xid xid, int flags) throws XAException {
+            }
+
+            @Override
+            public int prepare(Xid xid) throws XAException {
+                return 0;
+            }
+
+            @Override
+            public void commit(Xid xid, boolean onePhase) throws XAException {
+                throw new XAException(XAException.XAER_RMFAIL);
+            }
+
+            @Override
+            public void rollback(Xid xid) throws XAException {
+            }
+
+            @Override
+            public void forget(Xid xid) throws XAException {
+            }
+
+            @Override
+            public Xid[] recover(int flag) throws XAException {
+                return null;
+            }
+
+            @Override
+            public boolean isSameRM(XAResource xaRes) throws XAException {
+                return false;
+            }
+
+            @Override
+            public int getTransactionTimeout() throws XAException {
+                return 0;
+            }
+
+            @Override
+            public boolean setTransactionTimeout(int seconds) throws XAException {
+                return false;
+            }
+        };
+
+        javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+
+        tm.begin();
+
+        javax.transaction.Transaction theTransaction = tm.getTransaction();
+
+        assertTrue(theTransaction.enlistResource(theResource));
+
+        try {
+            tm.commit();
+            fail();
+        } catch (javax.transaction.HeuristicMixedException e) {
+            // Expected
+        }
+    }
+    
 	@Test
 	public void test() throws Exception {
 
-		ORB myORB = ORB.getInstance("test");
-		RootOA myOA = OA.getRootOA(myORB);
-		myORB.initORB(new String[] {}, null);
-		myOA.initOA();
-
-		ORBManager.setORB(myORB);
-		ORBManager.setPOA(myOA);
-		jtaPropertyManager.getJTAEnvironmentBean().setTransactionManagerClassName(com.arjuna.ats.internal.jta.transaction.jts.TransactionManagerImple.class.getName());
-		jtaPropertyManager.getJTAEnvironmentBean().setUserTransactionClassName(com.arjuna.ats.internal.jta.transaction.jts.UserTransactionImple.class.getName());
 		javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
 
 		tm.begin();
@@ -68,9 +159,6 @@ public class JTSTest {
 		assertTrue(theTransaction.enlistResource(new XARMERRXAResource(true)));
 
 		tm.rollback();
-
-		myOA.destroy();
-		myORB.shutdown();
 	}
 
 	private class XARMERRXAResource implements XAResource {


### PR DESCRIPTION
an exception to the caller as we don't know the outcome and it may not be
able to be recovered by the recovery manager

!XTS !BLACKTIE !PERF !QA_JTA !QA_JTS_JACORB