### PR TITLE
JBTM-2460 spi method to get the transaction registry

### DIFF
--- a/ArjunaJTS/integration/pom.xml
+++ b/ArjunaJTS/integration/pom.xml
@@ -176,37 +176,6 @@
       </dependency>
   </dependencies>
   <profiles>
-    <profile>
-      <id>jts-ibmorb</id>
-      <activation>
-        <property>
-          <name>!ibmorb-disabled</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>surefire-ibmorb</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <configuration>
-                  <skip>false</skip>
-                  <excludes>
-                    <exclude>**/SimpleIsolatedServers.java</exclude>
-                  </excludes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
     <profile>
         <id>release</id>

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/TransactionListenerRegistryTest.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/TransactionListenerRegistryTest.java
@@ -36,6 +36,7 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
+import com.arjuna.ats.jta.distributed.spi.TxListener;
 import org.jboss.tm.listener.*;
 import org.jboss.tm.usertx.client.ServerVMClientUserTransaction;
 import org.junit.Test;

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/spi/SPIUnitTest.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/spi/SPIUnitTest.java
@@ -1,0 +1,229 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.arjuna.ats.jta.distributed.spi;
+
+import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
+
+import com.arjuna.ats.internal.jts.ORBManager;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import com.arjuna.ats.jta.distributed.JndiProvider;
+import com.arjuna.ats.jta.utils.JNDIManager;
+import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
+import com.arjuna.orbportability.common.OrbPortabilityEnvironmentBean;
+import com.arjuna.orbportability.internal.utils.PostInitLoader;
+import org.jboss.tm.TransactionManagerLocator;
+import org.jboss.tm.listener.EventType;
+import org.jboss.tm.listener.TransactionListenerRegistry;
+import org.jboss.tm.listener.TransactionListenerRegistryLocator;
+import org.jboss.tm.usertx.UserTransactionRegistry;
+import org.jboss.tm.usertx.client.ServerVMClientUserTransaction;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.naming.InitialContext;
+import javax.transaction.*;
+import java.util.*;
+import com.arjuna.orbportability.OA;
+import com.arjuna.orbportability.ORB;
+import com.arjuna.orbportability.RootOA;
+import org.omg.CORBA.ORBPackage.InvalidName;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+
+public class SPIUnitTest {
+    private static InitialContext initialContext;
+    private static ORB myORB = null;
+    private static RootOA myOA = null;
+
+    private static void initORB() throws InvalidName {
+        myORB = ORB.getInstance("test");
+        myOA = OA.getRootOA(myORB);
+
+        myORB.initORB(new String[]{}, null);
+        myOA.initOA();
+
+        ORBManager.setORB(myORB);
+        ORBManager.setPOA(myOA);
+
+        new PostInitLoader(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"), myORB);
+    }
+
+    public static void initJTS() throws Exception {
+        initORB();
+
+        JTAEnvironmentBean jtaEnvironmentBean = jtaPropertyManager.getJTAEnvironmentBean();
+
+        jtaEnvironmentBean.setTransactionManagerClassName(com.arjuna.ats.jbossatx.jts.TransactionManagerDelegate.class.getName());
+
+        JNDIManager.bindJTATransactionManagerImplementation(initialContext);
+
+        jtaEnvironmentBean.setTransactionSynchronizationRegistryClassName(com.arjuna.ats.internal.jta.transaction.jts.TransactionSynchronizationRegistryImple.class.getName());
+
+        JNDIManager.bindJTATransactionSynchronizationRegistryImplementation(initialContext);
+
+        final com.arjuna.ats.jbossatx.jts.TransactionManagerService service = new com.arjuna.ats.jbossatx.jts.TransactionManagerService();
+        final ServerVMClientUserTransaction userTransaction = new ServerVMClientUserTransaction(service.getTransactionManager());
+
+        jtaEnvironmentBean.setUserTransaction(userTransaction);
+
+        JNDIManager.bindJTAUserTransactionImplementation(initialContext);
+
+        UserTransactionRegistry userTransactionRegistry = new UserTransactionRegistry();
+        userTransactionRegistry.addProvider(userTransaction);
+    }
+
+    private UserTransaction getUserTransaction() {
+        return jtaPropertyManager.getJTAEnvironmentBean().getUserTransaction();
+    }
+
+    private TransactionManager getTransactionManager() {
+        return jtaPropertyManager.getJTAEnvironmentBean().getTransactionManager();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Hashtable props = JndiProvider.start();
+
+        initialContext =  new InitialContext(props);
+
+        initJTS();
+
+        BeanPopulator.getDefaultInstance(RecoveryEnvironmentBean.class).setRecoveryBackoffPeriod(1);
+    }
+
+    @After
+    public void cleanThread() {
+        TransactionManager tm = TransactionManagerLocator.locateTransactionManager();
+
+        try {
+            Transaction txn = tm.getTransaction();
+
+            if (txn != null)
+                txn.rollback();
+        } catch (SystemException e) {
+        } catch (Error error) {
+        }
+    }
+
+    @Test
+    public void testListener() {
+        TransactionManager tm = TransactionManagerLocator.locateTransactionManager();
+        Transaction prevTxn = null;
+
+        try {
+            TransactionListenerRegistry tlr = TransactionListenerRegistryLocator.getTransactionListenerRegistry();
+            TxListener listener = new TxListener(tlr);
+
+            try {
+                prevTxn = tm.suspend();
+            } catch (SystemException e) {
+            } catch (Error e) {
+                System.out.printf("Error %s%n", e.getMessage());
+            }
+            tm.begin();
+
+            tlr.addListener(tm.getTransaction(), listener, EnumSet.allOf(EventType.class));
+
+            tm.commit();
+
+            if (!listener.hasEvents())
+                throw new RuntimeException("listener did not get any events");
+        } catch (Throwable e) {
+            throw new RuntimeException("TransactionListenerRegistry test failure: ", e);
+        } finally {
+            if (prevTxn != null) {
+                try {
+                    tm.resume(prevTxn);
+                } catch (InvalidTransactionException | SystemException e) {
+                    throw new RuntimeException("testListener resume failed: ", e);
+                }
+            }
+        }
+    }
+
+    @Test(expected = RollbackException.class)
+    public void testTimeout() throws Exception {
+        final int timeout = 2;
+        UserTransaction txn = getUserTransaction();
+
+        txn.setTransactionTimeout(timeout);
+        txn.begin();
+
+        Thread.sleep(timeout * 1000 + 1000);
+        txn.commit();
+        fail("committing a timed out transaction should have thrown a RollbackException");
+    }
+
+    @Test
+    public void testTransaction() throws Exception {
+        UserTransaction txn = getUserTransaction();
+
+        txn.begin();
+
+        assertNotNull(txn);
+        assertEquals(Status.STATUS_ACTIVE, txn.getStatus());
+
+        txn.commit();
+
+        // the transaction should have been disassociated
+        assertEquals(Status.STATUS_NO_TRANSACTION, txn.getStatus());
+
+        txn.begin();
+        txn.commit();
+        assertEquals(Status.STATUS_NO_TRANSACTION, txn.getStatus());
+    }
+
+    @Test
+    public void testSynchronization() throws Exception {
+        TestSynchronization synch =  new TestSynchronization() ;
+
+        UserTransaction txn = getUserTransaction();
+        TransactionManager transactionManager = getTransactionManager();
+
+        txn.begin();
+
+        transactionManager.getTransaction().registerSynchronization(synch);
+
+        txn.commit();
+
+        assertTrue(synch.beforeCalled);
+        assertTrue(synch.afterCalled);
+    }
+
+    class TestSynchronization implements Synchronization {
+        boolean beforeCalled = false;
+        boolean afterCalled = false;
+
+        @Override
+        public void beforeCompletion() {
+            beforeCalled = true;
+        }
+
+        @Override
+        public void afterCompletion(int i) {
+            afterCalled = true;
+        }
+    }
+}

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/spi/TxListener.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/spi/TxListener.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package com.arjuna.ats;
+package com.arjuna.ats.jta.distributed.spi;
 
 import org.jboss.tm.listener.*;
 
@@ -32,6 +32,7 @@ public class TxListener implements Synchronization, TransactionListener {
     volatile int acCalled = 0;
     TransactionListenerRegistry registry;
     volatile int registrationCount = 2;
+    boolean hasEvents = false;
 
     public TxListener(TransactionListenerRegistry registry) {
         this.registry = registry;
@@ -51,6 +52,8 @@ public class TxListener implements Synchronization, TransactionListener {
 
     @Override
     public void onEvent(TransactionEvent transactionEvent) {
+        hasEvents = true;
+
         if (transactionEvent.getTypes().contains(EventType.ASSOCIATED)) {
             if (registry != null && registrationCount > 0) {
                 // test that callbacks can register listeners
@@ -88,14 +91,22 @@ public class TxListener implements Synchronization, TransactionListener {
     /**
      * @return true if the txn has been disassociated and the AC has been called just once
      */
-    protected boolean shouldDisassoc() {
+    public boolean shouldDisassoc() {
         return assoc == 0 && singleCallAC();
 
     }
 
-    protected boolean singleCallAC() {
+    public boolean singleCallAC() {
         return acCalled == 1;
 
+    }
+
+    public boolean hasEvents() {
+        return hasEvents;
+    }
+
+    public void clearEvents() {
+        hasEvents = false;
     }
 
     private static class L2 implements TransactionListener {

--- a/ArjunaJTS/pom.xml
+++ b/ArjunaJTS/pom.xml
@@ -54,6 +54,53 @@
           <modules>
               <module>narayana-jts-jacorb</module>
           </modules>
+        <dependencies>
+          <dependency>
+            <groupId>jacorb</groupId>
+            <artifactId>jacorb</artifactId>
+            <version>${version.jacorb}</version>
+            <scope>provided</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${version.org.slf4j}</version>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.org.slf4j}</version>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>surefire-jacorb</id>
+                  <phase>test</phase>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <skip>false</skip>
+                    <systemPropertyVariables
+                      combine.children="append">
+                      <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.jacorb.orb.implementations.jacorb_2_0</OrbPortabilityEnvironmentBean.orbImpleClassName>
+                      <OrbPortabilityEnvironmentBean.poaImpleClassName>com.arjuna.orbportability.internal.orbspecific.jacorb.oa.implementations.jacorb_2_0</OrbPortabilityEnvironmentBean.poaImpleClassName>
+                      <OrbPortabilityEnvironmentBean.orbDataClassName>com.arjuna.orbportability.internal.orbspecific.versions.jacorb_2_0</OrbPortabilityEnvironmentBean.orbDataClassName>
+                    </systemPropertyVariables>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
       </profile>
       <profile>
         <id>jts-idlj</id>
@@ -65,7 +112,72 @@
         <modules>
             <module>narayana-jts-idlj</module>
         </modules>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>surefire-idlj</id>
+                  <phase>test</phase>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <skip>false</skip>
+                    <systemPropertyVariables
+                      combine.children="append">
+                      <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.orb.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.orbImpleClassName>
+                      <OrbPortabilityEnvironmentBean.poaImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.oa.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.poaImpleClassName>
+                      <OrbPortabilityEnvironmentBean.orbDataClassName>com.arjuna.orbportability.internal.orbspecific.versions.javaidl_1_4</OrbPortabilityEnvironmentBean.orbDataClassName>
+                    </systemPropertyVariables>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
       </profile>
+      <profile>
+        <id>jts-ibmorb</id>
+        <activation>
+            <property>
+              <name>ibmorb-enabled</name>
+            </property>
+        </activation>
+        <modules>
+            <module>narayana-jts-ibmorb</module>
+        </modules>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>surefire-ibmorb</id>
+                  <phase>test</phase>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <skip>false</skip>
+                    <systemProperties combine.children="append" />
+                    <systemPropertyVariables
+                      combine.children="append">
+                      <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.ibmorb.orb.implementations.ibmorb_7_1</OrbPortabilityEnvironmentBean.orbImpleClassName>
+                      <OrbPortabilityEnvironmentBean.poaImpleClassName>com.arjuna.orbportability.internal.orbspecific.ibmorb.oa.implementations.ibmorb_7_1</OrbPortabilityEnvironmentBean.poaImpleClassName>
+                      <OrbPortabilityEnvironmentBean.orbDataClassName>com.arjuna.orbportability.internal.orbspecific.versions.ibmorb_7_1</OrbPortabilityEnvironmentBean.orbDataClassName>
+                    </systemPropertyVariables>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+
       <profile>
           <id>release</id>
           <build>
@@ -83,17 +195,6 @@
                 </plugin>
               </plugins>
           </build>
-      </profile>
-      <profile>
-        <id>jts-ibmorb</id>
-        <activation>
-            <property>
-              <name>ibmorb-enabled</name>
-            </property>
-        </activation>
-        <modules>
-            <module>narayana-jts-ibmorb</module>
-        </modules>
       </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
     <version.junit>4.11</version.junit>
     <version.org.jboss.byteman>2.1.3</version.org.jboss.byteman>
     <version.org.jboss.arquillian.core>1.1.7.Final</version.org.jboss.arquillian.core>
-    <version.org.jboss.jboss-transaction-spi>7.2.0.Final</version.org.jboss.jboss-transaction-spi>
+    <version.org.jboss.jboss-transaction-spi>7.3.0.Final</version.org.jboss.jboss-transaction-spi>
 
     <!-- Maven plugin versions -->
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>


### PR DESCRIPTION
NO_TEST

added no test for the last commit in the PR.

!XTS !BLACKTIE !QA_JTA !QA_JTS_JACORB !PERF !QA_JTS_JDKORB

The change tests the new SPI method TransactionListenerRegistryLocator.getTransactionListenerRegistry().

The pom changes are to ensure we test with the different ORBs - I needed to enable/add the various orb profiles in ArjunaJTS/integration/pom.xml so instead of adding them there I configured it in the parent ArjunaJTS/pom.xml