### PR TITLE
JBTM-1854 Don't initialise two orbs

### DIFF
--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/local/async/AsyncTest.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/local/async/AsyncTest.java
@@ -36,9 +36,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.omg.CosTransactions.Current;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.jts.OTSManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.hp.mwtests.ts.jts.orbspecific.resources.DemoResource;
@@ -52,17 +51,9 @@ public class AsyncTest
         boolean errorp = false;
         boolean errorc = false;
 
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         try {
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/local/synchronizations/SynchTest.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/local/synchronizations/SynchTest.java
@@ -41,9 +41,8 @@ import org.omg.CosTransactions.Control;
 import org.omg.CosTransactions.Coordinator;
 import org.omg.CosTransactions.Status;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.jts.OTSManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.hp.mwtests.ts.jts.orbspecific.resources.demosync;
@@ -62,15 +61,10 @@ public class SynchTest
 
         try
         {
-            myORB = ORB.getInstance("test");
+            ServerORB orb = new ServerORB();
 
-            myOA = OA.getRootOA(myORB);
-
-            myORB.initORB(new String[] {}, null);
-            myOA.initOA();
-
-            ORBManager.setORB(myORB);
-            ORBManager.setPOA(myOA);
+            myORB = orb.getORB();
+            myOA = orb.getOA();
 
             Control myControl = null;
             org.omg.CosTransactions.Current current = OTSManager.get_current();

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/arjuna/ExplicitArjunaClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/arjuna/ExplicitArjunaClient.java
@@ -34,10 +34,9 @@ package com.hp.mwtests.ts.jts.remote.arjuna;
 import org.omg.CORBA.IntHolder;
 import org.omg.CosTransactions.Control;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.hp.mwtests.ts.jts.TestModule.ExplicitStack;
@@ -48,17 +47,9 @@ public class ExplicitArjunaClient
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         CurrentImple current = OTSImpleManager.current();
         String refFile = args[0];

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/arjuna/ImplicitArjunaClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/arjuna/ImplicitArjunaClient.java
@@ -33,10 +33,9 @@ package com.hp.mwtests.ts.jts.remote.arjuna;
 
 import org.omg.CORBA.IntHolder;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -48,17 +47,9 @@ public class ImplicitArjunaClient
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
         CurrentImple current = OTSImpleManager.current();

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/current/CurrentTest.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/current/CurrentTest.java
@@ -33,10 +33,9 @@ package com.hp.mwtests.ts.jts.remote.current;
 
 import org.omg.CosTransactions.Control;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -48,18 +47,9 @@ public class CurrentTest
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
-
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         CurrentImple current = OTSImpleManager.current();
         Control myControl = null;

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/explicitinterposition/ExplicitInterClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/explicitinterposition/ExplicitInterClient.java
@@ -33,10 +33,9 @@ package com.hp.mwtests.ts.jts.remote.explicitinterposition;
 
 import org.omg.CosTransactions.Control;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -48,18 +47,9 @@ public class ExplicitInterClient
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
-
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         CurrentImple current = OTSImpleManager.current();
         Control theControl = null;

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/DistributedHammer1.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/DistributedHammer1.java
@@ -33,8 +33,7 @@ package com.hp.mwtests.ts.jts.remote.hammer;
 
 import org.omg.CORBA.IntHolder;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -51,17 +50,9 @@ public class DistributedHammer1
 
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String server1 = args[0];
         String server2 = args[1];

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/DistributedHammer2.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/DistributedHammer2.java
@@ -35,8 +35,7 @@ import com.hp.mwtests.ts.jts.utils.TaskMonitor;
 import com.hp.mwtests.ts.jts.utils.TaskProgress;
 import org.omg.CORBA.IntHolder;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -54,17 +53,9 @@ public class DistributedHammer2
 
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String server1 = args[0];
         String server2 = args[1];

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/DistributedHammer3.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/DistributedHammer3.java
@@ -33,8 +33,7 @@ package com.hp.mwtests.ts.jts.remote.hammer;
 
 import org.omg.CORBA.IntHolder;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -52,17 +51,9 @@ public class DistributedHammer3
 
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String server1 = args[0];
         String server2 = args[1];

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/PerfHammer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/hammer/PerfHammer.java
@@ -31,8 +31,7 @@
 
 package com.hp.mwtests.ts.jts.remote.hammer;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import io.narayana.perf.Measurement;
@@ -59,14 +58,9 @@ public class PerfHammer
         int batchSize = 100;
         int warmUpCount = 0;
 
-        ORB myORB = ORB.getInstance("test");
-        RootOA myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String metricName = "JTSRemote_PerfTest_PerfHammer_" + System.getProperty("org.omg.CORBA.ORBClass",
                 myORB.orb().getClass().getName());

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/implicit/ImplicitClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/implicit/ImplicitClient.java
@@ -31,10 +31,9 @@
 
 package com.hp.mwtests.ts.jts.remote.implicit;
 
-import com.arjuna.ats.internal.jts.ORBManager;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -46,17 +45,9 @@ public class ImplicitClient
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/ExplicitStackServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/ExplicitStackServer.java
@@ -28,33 +28,23 @@
  *
  * $Id: ExplicitStackServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
 import com.hp.mwtests.ts.jts.TestModule.ExplicitStackPOATie;
 import com.hp.mwtests.ts.jts.orbspecific.resources.ExplicitStackImple;
 import com.hp.mwtests.ts.jts.resources.TestUtility;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 
 public class ExplicitStackServer
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/GridServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/GridServer.java
@@ -28,32 +28,22 @@
  *
  * $Id: GridServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
 import com.hp.mwtests.ts.jts.orbspecific.resources.grid_i;
 import com.hp.mwtests.ts.jts.resources.TestUtility;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 
 public class GridServer
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String gridReference = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/HammerServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/HammerServer.java
@@ -28,11 +28,8 @@
  *
  * $Id: HammerServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -40,23 +37,16 @@ import com.hp.mwtests.ts.jts.TestModule.HammerHelper;
 import com.hp.mwtests.ts.jts.TestModule.HammerPOATie;
 import com.hp.mwtests.ts.jts.orbspecific.resources.HammerObject;
 import com.hp.mwtests.ts.jts.resources.TestUtility;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 
 
 public class HammerServer
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/ImplGridServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/ImplGridServer.java
@@ -28,32 +28,22 @@
  *
  * $Id: ImplGridServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
 import com.hp.mwtests.ts.jts.orbspecific.resources.trangrid_i;
 import com.hp.mwtests.ts.jts.resources.TestUtility;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 
 public class ImplGridServer
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/SetGetServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/SetGetServer.java
@@ -28,32 +28,22 @@
  *
  * $Id: SetGetServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
 import com.hp.mwtests.ts.jts.orbspecific.resources.setget_i;
 import com.hp.mwtests.ts.jts.resources.TestUtility;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 
 public class SetGetServer
 {
     public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/StackServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/StackServer.java
@@ -28,11 +28,8 @@
  *
  * $Id: StackServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -40,22 +37,15 @@ import com.hp.mwtests.ts.jts.TestModule.stackHelper;
 import com.hp.mwtests.ts.jts.TestModule.stackPOATie;
 import com.hp.mwtests.ts.jts.orbspecific.resources.StackImple;
 import com.hp.mwtests.ts.jts.resources.TestUtility;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 
 public class StackServer
 {
    public static void main(String[] args) throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String refFile = args[0];
 

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/TranGridServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/TranGridServer.java
@@ -28,15 +28,13 @@
  *
  * $Id: TranGridServer.java 2342 2006-03-30 13:06:17Z  $
  */
-
 package com.hp.mwtests.ts.jts.remote.servers;
 
 import static org.junit.Assert.fail;
 
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import org.junit.Test;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -48,18 +46,9 @@ public class TranGridServer
     @Test
     public void test() throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
-
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         String serverName = "TranGrid";
         String refFile = "/tmp/trangrid.ref";

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/timeout/TimeoutClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/timeout/TimeoutClient.java
@@ -38,10 +38,9 @@ import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.Control;
 
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
-import com.arjuna.ats.internal.jts.ORBManager;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
-import com.arjuna.orbportability.OA;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -61,14 +60,9 @@ public class TimeoutClient
 
         try
         {
-            myORB = ORB.getInstance("test");
-            myOA = OA.getRootOA(myORB);
-
-            myORB.initORB(new String[] {}, null);
-            myOA.initOA();
-
-            ORBManager.setORB(myORB);
-            ORBManager.setPOA(myOA);
+            ServerORB orb = new ServerORB();
+            myORB = orb.getORB();
+            myOA = orb.getOA();
 
             CurrentImple current = OTSImpleManager.current();
             Control theControl = null;

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/transactionserver/TMTest.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/transactionserver/TMTest.java
@@ -38,8 +38,7 @@ import org.omg.CosTransactions.Control;
 import org.omg.CosTransactions.TransactionFactory;
 import org.omg.CosTransactions.TransactionFactoryHelper;
 
-import com.arjuna.ats.internal.jts.ORBManager;
-import com.arjuna.orbportability.OA;
+import com.hp.mwtests.ts.jts.utils.ServerORB;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 import com.arjuna.orbportability.Services;
@@ -56,17 +55,9 @@ public class TMTest
     @Test
     public void test() throws Exception
     {
-        ORB myORB = null;
-        RootOA myOA = null;
-
-        myORB = ORB.getInstance("test");
-        myOA = OA.getRootOA(myORB);
-
-        myORB.initORB(new String[] {}, null);
-        myOA.initOA();
-
-        ORBManager.setORB(myORB);
-        ORBManager.setPOA(myOA);
+        ServerORB orb = new ServerORB();
+        ORB myORB = orb.getORB();
+        RootOA myOA = orb.getOA();
 
         TransactionFactory theOTS = null;
         Control topLevelControl = null;

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/utils/ServerORB.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/utils/ServerORB.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.hp.mwtests.ts.jts.utils;
+
+import com.arjuna.ats.internal.jts.ORBManager;
+import com.arjuna.orbportability.OA;
+import com.arjuna.orbportability.ORB;
+import com.arjuna.orbportability.RootOA;
+import org.omg.CORBA.ORBPackage.InvalidName;
+
+public class ServerORB {
+    private ORB myORB = null;
+    private RootOA myOA = null;
+
+    public ServerORB() throws InvalidName {
+        if (!ORBManager.isInitialised()) {
+            myORB = ORB.getInstance("test");
+            myOA = OA.getRootOA(myORB);
+
+            myORB.initORB(new String[]{}, null);
+            myOA.initOA();
+
+            ORBManager.setORB(myORB);
+            ORBManager.setPOA(myOA);
+        } else {
+            myORB = ORBManager.getORB();
+            myOA = OA.getRootOA(myORB);
+        }
+    }
+
+    public ORB getORB() {
+        return myORB;
+    }
+
+    public RootOA getOA() {
+        return myOA;
+    }
+}

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -590,13 +590,13 @@ function qa_tests_once {
         ok=0
         for i in `seq 1 $QA_STRESS`; do
           echo run $i;
-          ant -f run-tests.xml -Dtest.name=$QA_TESTGROUP -Dtest.methods="$QA_TESTMETHODS" onetest -Dcode.coverage=$codeCoverage;
+          ant -f run-tests.xml $QA_PROFILE -Dtest.name=$QA_TESTGROUP -Dtest.methods="$QA_TESTMETHODS" onetest -Dcode.coverage=$codeCoverage;
           if [ $? -ne 0 ]; then
             ok=1; break;
           fi
         done
       else
-        ant -f run-tests.xml -Dtest.name=$QA_TESTGROUP -Dtest.methods="$QA_TESTMETHODS" onetest -Dcode.coverage=$codeCoverage;
+        ant -f run-tests.xml $QA_PROFILE -Dtest.name=$QA_TESTGROUP -Dtest.methods="$QA_TESTMETHODS" onetest -Dcode.coverage=$codeCoverage;
         ok=$?
       fi
     else


### PR DESCRIPTION
!JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF

(just test MAIN and QA_JTS_JDKORB)

https://issues.jboss.org/browse/JBTM-1854

The primary change is the new class ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/utils/ServerORB.java together with updates to all the test server classes that have main methods to use it.