### PR TITLE
JBTM-2476 Updated to print out stack activity of multiple threads when cancelled (e.g. by reaper)

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -3363,6 +3363,19 @@ public class BasicAction extends StateManager
                     tsLogger.i18NLogger.warn_coordinator_BasicAction_57(get_uid());
                 } else {
                     tsLogger.i18NLogger.warn_coordinator_BasicAction_58(get_uid());
+
+                    // This was added for JBTM-2476 - it could be used during commit
+                    // but as the commit path needs to be optimum and getStackTrace is expensive
+                    // I did not include it
+                    for (Thread entry : _childThreads.values()) {
+                        StackTraceElement[] stackTrace = entry.getStackTrace();
+                        StringBuilder sb = new StringBuilder();
+                        for (StackTraceElement element : stackTrace) {
+                            sb.append(element.toString());
+                            sb.append("\n");
+                        }
+                        tsLogger.i18NLogger.warn_multiple_threads(objectUid, entry.getName(), sb.toString());
+                    }
                 }
 
                 if (_checkedAction != null)

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -1519,6 +1519,11 @@ public interface arjunaI18NLogger {
     @Message(id = 12380, value = "OSB: Error constructing record header reader", format = MESSAGE_FORMAT)
     @LogMessage(level = INFO)
     public void info_osb_HeaderStateCtorFail(@Cause() Throwable arg0);
+
+    @Message(id = 12381, value = "Action id {0} completed with multiple threads - thread {1} was in progress with {2}", format = MESSAGE_FORMAT)
+    @LogMessage(level = WARN)
+    public void warn_multiple_threads(Uid objectUid, String key, String string);
+    
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.


### PR DESCRIPTION
!XTS !BLACKTIE !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB
https://issues.jboss.org/browse/JBTM-2476

Can be verified in SimpleTest in the JTA surefire logs that a stack trace was printed