### PR TITLE
JBTM-2120 Updated to provide the suppressed exception in the case that the transaction reaches an atomic outcome even though first resource threw a HEURISTIC rollback during commit

### DIFF
--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
@@ -34,6 +34,11 @@ package com.hp.mwtests.ts.jta.xa;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -43,6 +48,9 @@ import org.junit.Test;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
 
 public class JTATest {
+
+    private XAException exception;
+    
     @Test
     public void testRMFAILcommit1PC() throws Exception
     {
@@ -127,6 +135,150 @@ public class JTATest {
 
 		tm.rollback();
 		assertTrue(rollbackCalled.getRollbackCalled());
+	}
+	
+	
+	@Test
+	public void testHeuristicRollbackSuppressedException() throws NotSupportedException, SystemException, IllegalStateException, RollbackException, SecurityException, HeuristicMixedException, HeuristicRollbackException {
+
+        javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager
+                .transactionManager();
+
+        tm.begin();
+
+        javax.transaction.Transaction theTransaction = tm.getTransaction();
+
+        assertTrue(theTransaction.enlistResource(new XAResource() {
+
+            @Override
+            public void start(Xid xid, int flags) throws XAException {
+
+                
+            }
+
+            @Override
+            public void end(Xid xid, int flags) throws XAException {
+
+                
+            }
+
+            @Override
+            public int prepare(Xid xid) throws XAException {
+
+                return 0;
+            }
+
+            @Override
+            public void commit(Xid xid, boolean onePhase) throws XAException {
+                exception = new XAException(XAException.XA_HEURRB);
+                throw exception;
+            }
+
+            @Override
+            public void rollback(Xid xid) throws XAException {
+
+                
+            }
+
+            @Override
+            public void forget(Xid xid) throws XAException {
+
+                
+            }
+
+            @Override
+            public Xid[] recover(int flag) throws XAException {
+
+                return null;
+            }
+
+            @Override
+            public boolean isSameRM(XAResource xaRes) throws XAException {
+
+                return false;
+            }
+
+            @Override
+            public int getTransactionTimeout() throws XAException {
+
+                return 0;
+            }
+
+            @Override
+            public boolean setTransactionTimeout(int seconds) throws XAException {
+
+                return false;
+            }}));
+        assertTrue(theTransaction.enlistResource(new XAResource() {
+
+            @Override
+            public void start(Xid xid, int flags) throws XAException {
+
+                
+            }
+
+            @Override
+            public void end(Xid xid, int flags) throws XAException {
+
+                
+            }
+
+            @Override
+            public int prepare(Xid xid) throws XAException {
+
+                return 0;
+            }
+
+            @Override
+            public void commit(Xid xid, boolean onePhase) throws XAException {
+
+                
+            }
+
+            @Override
+            public void rollback(Xid xid) throws XAException {
+
+                
+            }
+
+            @Override
+            public void forget(Xid xid) throws XAException {
+
+                
+            }
+
+            @Override
+            public Xid[] recover(int flag) throws XAException {
+
+                return null;
+            }
+
+            @Override
+            public boolean isSameRM(XAResource xaRes) throws XAException {
+
+                return false;
+            }
+
+            @Override
+            public int getTransactionTimeout() throws XAException {
+
+                return 0;
+            }
+
+            @Override
+            public boolean setTransactionTimeout(int seconds) throws XAException {
+
+                return false;
+            }}));
+
+        try {
+            tm.commit();
+            fail();
+        } catch (RollbackException e) {
+            e.printStackTrace();
+            assertTrue(e.getSuppressed()[0] == exception);
+        }
+	    
 	}
 
 	private class XARMERRXAResource implements XAResource {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2120

!PERF !XTS !BLACKTIE !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB