### PR TITLE
JBTM-2540 Can't build BlackTie subsystem since update to WFLY 10 CR4-SNAPSHOT

### DIFF
--- a/blacktie/wildfly-blacktie/build/server-provisioning.xml
+++ b/blacktie/wildfly-blacktie/build/server-provisioning.xml
@@ -19,7 +19,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" extract-schemas="true" copy-module-artifacts="true">
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true" copy-module-artifacts="true">
     <feature-packs>
         <feature-pack groupId="org.jboss.narayana.blacktie" artifactId="wildfly-blacktie-feature-pack" version="${project.version}"/>
     </feature-packs>

--- a/blacktie/wildfly-blacktie/feature-pack/feature-pack-build.xml
+++ b/blacktie/wildfly-blacktie/feature-pack/feature-pack-build.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:1.0">
+<build xmlns="urn:wildfly:feature-pack-build:1.1">
     <dependencies>
         <artifact name="org.wildfly:wildfly-feature-pack" />        
     </dependencies>

--- a/blacktie/wildfly-blacktie/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/blacktie/wildfly-blacktie/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -69,12 +69,9 @@
         <interface name="public">
             <inet-address value="${jboss.bind.address:127.0.0.1}"/>
         </interface>
-        <!-- TODO - only show this if the jacorb subsystem is added  -->
-        <interface name="unsecure">
-            <!-- Used for IIOP sockets in the standard configuration.
-                 To secure IIOP connections you need to setup SSL -->
-            <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
-        </interface>
+
+        <?INTERFACES?>
+
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">


### PR DESCRIPTION
!XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JST_OPENJDKORD !PERF