### PR TITLE
Jbtm 2534

### DIFF
--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/recovery/contact/StatusChecker.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/recovery/contact/StatusChecker.java
@@ -285,6 +285,14 @@ private Status getStatus (Uid transactionUid, FactoryContactItem item, boolean c
 	    // no transaction
 	} catch ( SystemException ex_corba ) {
 	    // why did this happen ?
+        if (ORBInfo.getOrbEnumValue() == ORBType.JAVAIDL)
+        {
+            // the original application has (probably) died
+            if (jtsLogger.logger.isDebugEnabled()) {
+                jtsLogger.logger.debug("StatusChecker.getStatus("+transactionUid+") - COMM_FAILURE = dead");
+            }
+            originalDead = true;
+        }
         jtsLogger.i18NLogger.warn_recovery_contact_StatusChecker_11(ex_corba);
 	} catch ( Exception ex_other) {
 	    // this really shouldn't happen

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients1/ClientCrashBase.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients1/ClientCrashBase.java
@@ -7,21 +7,27 @@ public class ClientCrashBase {
     protected boolean correct = true;
     protected String serviceIOR = null;
     protected String id;
+    protected boolean didInitOrb;
 
     public ClientCrashBase(String id) {
         this.id = id;
     }
 
     public void initOrb(String[] args) throws Exception {
-        ORBInterface.initORB(args, null);
-        OAInterface.initOA();
+        if (ORBInterface.getORB() == null) {
+            didInitOrb = true;
+            ORBInterface.initORB(args, null);
+            OAInterface.initOA();
+        }
     }
 
     public void shutdownOrb() {
         try
         {
-            OAInterface.shutdownOA();
-            ORBInterface.shutdownORB();
+            if (didInitOrb) {
+                OAInterface.shutdownOA();
+                ORBInterface.shutdownORB();
+            }
         }
         catch (Exception exception)
         {

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client01a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client01a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client01a
+public class Client01a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client01a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client01b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client01b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client01b
+public class Client01b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client01b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client02a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client02a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client02a
+public class Client02a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client02a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client02b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client02b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client02b
+public class Client02b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client02b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client03a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client03a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client03a
+public class Client03a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -144,8 +143,7 @@ public class Client03a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client03b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client03b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client03b
+public class Client03b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client03b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client04a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client04a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client04a
+public class Client04a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client04a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client04b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client04b.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 
-public class Client04b
+public class Client04b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -116,8 +115,7 @@ public class Client04b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client05a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client05a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client05a
+public class Client05a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client05a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client05b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client05b.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 
-public class Client05b
+public class Client05b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -116,8 +115,7 @@ public class Client05b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client06a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client06a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client06a
+public class Client06a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -144,8 +143,7 @@ public class Client06a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client06b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client06b.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 
-public class Client06b
+public class Client06b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -116,8 +115,7 @@ public class Client06b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client07a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client07a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client07a
+public class Client07a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client07a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client07b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client07b.java
@@ -65,14 +65,13 @@ import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client07b
+public class Client07b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -128,8 +127,7 @@ public class Client07b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client08a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client08a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client08a
+public class Client08a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -144,8 +143,7 @@ public class Client08a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client08b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client08b.java
@@ -65,14 +65,13 @@ import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client08b
+public class Client08b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -128,8 +127,7 @@ public class Client08b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client09a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client09a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client09a
+public class Client09a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client09a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client09b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client09b.java
@@ -65,14 +65,13 @@ import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client09b
+public class Client09b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -128,8 +127,7 @@ public class Client09b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client10a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client10a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client10a
+public class Client10a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client10a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client10b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client10b.java
@@ -65,14 +65,13 @@ import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client10b
+public class Client10b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -128,8 +127,7 @@ public class Client10b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client11a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client11a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client11a
+public class Client11a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -133,8 +132,7 @@ public class Client11a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client11b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client11b.java
@@ -65,14 +65,13 @@ import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.HeuristicHazard;
 
-public class Client11b
+public class Client11b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -128,8 +127,7 @@ public class Client11b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client12a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client12a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client12a
+public class Client12a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client12a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client12b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client12b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client12b
+public class Client12b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client12b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client13a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client13a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client13a
+public class Client13a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client13a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client13b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client13b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client13b
+public class Client13b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client13b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client14a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client14a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client14a
+public class Client14a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client14a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client14b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client14b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client14b
+public class Client14b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client14b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client15a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client15a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client15a
+public class Client15a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client15a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client15b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client15b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client15b
+public class Client15b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client15b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client16a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client16a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client16a
+public class Client16a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -134,8 +133,7 @@ public class Client16a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client16b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client16b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client16b
+public class Client16b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -123,8 +122,7 @@ public class Client16b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client17a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client17a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client17a
+public class Client17a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client17a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client17b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client17b.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 
-public class Client17b
+public class Client17b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -116,8 +115,7 @@ public class Client17b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client18a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client18a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client18a
+public class Client18a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client18a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client18b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client18b.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 
-public class Client18b
+public class Client18b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -116,8 +115,7 @@ public class Client18b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client19a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client19a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client19a
+public class Client19a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client19a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client19b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client19b.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 
-public class Client19b
+public class Client19b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -116,8 +115,7 @@ public class Client19b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client20a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client20a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client20a
+public class Client20a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client20a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client20b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client20b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client20b
+public class Client20b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -126,8 +125,7 @@ public class Client20b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client21a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client21a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client21a
+public class Client21a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client21a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client21b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client21b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client21b
+public class Client21b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -126,8 +125,7 @@ public class Client21b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client22a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client22a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client22a
+public class Client22a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client22a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client22b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client22b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client22b
+public class Client22b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -126,8 +125,7 @@ public class Client22b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client23a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client23a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client23a
+public class Client23a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client23a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client23b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client23b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client23b
+public class Client23b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -126,8 +125,7 @@ public class Client23b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client24a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client24a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client24a
+public class Client24a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client24a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client24b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client24b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client24b
+public class Client24b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -126,8 +125,7 @@ public class Client24b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client25a.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client25a.java
@@ -63,14 +63,13 @@ import org.jboss.jbossts.qa.Utils.ORBInterface;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.jboss.jbossts.qa.Utils.CrashRecoveryDelays;
 
-public class Client25a
+public class Client25a extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			AfterCrashService service1 = AfterCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -132,8 +131,7 @@ public class Client25a
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client25b.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/Client25b.java
@@ -64,14 +64,13 @@ import org.jboss.jbossts.qa.Utils.OTS;
 import org.jboss.jbossts.qa.Utils.ServerIORStore;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 
-public class Client25b
+public class Client25b extends ClientBase
 {
 	public static void main(String[] args)
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			init(args, null);
 
 			String serviceIOR1 = ServerIORStore.loadIOR(args[args.length - 2]);
 			BeforeCrashService service1 = BeforeCrashServiceHelper.narrow(ORBInterface.orb().string_to_object(serviceIOR1));
@@ -126,8 +125,7 @@ public class Client25b
 
 		try
 		{
-			OAInterface.shutdownOA();
-			ORBInterface.shutdownORB();
+			fini();
 		}
 		catch (Exception exception)
 		{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/ClientBase.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Clients2/ClientBase.java
@@ -1,0 +1,24 @@
+package org.jboss.jbossts.qa.CrashRecovery05Clients2;
+
+import org.jboss.jbossts.qa.Utils.OAInterface;
+import org.jboss.jbossts.qa.Utils.ORBInterface;
+
+public class ClientBase {
+
+    private static boolean shutdown;
+
+    protected static void init(String[] args, Object o) {
+        if (ORBInterface.getORB() == null) {
+            shutdown = true;
+            ORBInterface.initORB(args, null);
+            OAInterface.initOA();
+        }
+    }
+
+    protected static void fini() {
+        if (shutdown) {
+            OAInterface.shutdownOA();
+            ORBInterface.shutdownORB();
+        }
+    }
+}

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl01.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl01.java
@@ -121,6 +121,7 @@ public class AfterCrashServiceImpl01 implements AfterCrashServiceOperations
 			{
 				System.err.println("AfterCrashServiceImpl01.check_oper [O" + _objectNumber + ".R" + index + "]: Done");
 				correct = correct && check_behaviors[index].allow_done;
+				break;
 			}
 			else
 			{
@@ -136,16 +137,24 @@ public class AfterCrashServiceImpl01 implements AfterCrashServiceOperations
 					 * Section 2.7.1 of the OTS spec says of the replay_completion operation on the RecoveryCoordinator:
 					 * "This non-blocking operation returns the current status of the transaction"
 					 */
-					Thread.sleep(200);
-					status = _resourceImpl[index].getStatus();
+					boolean ok = false;
 
-					correct = correct && (((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared) ||
-							((status == Status.StatusCommitting) && check_behaviors[index].allow_returned_committing) ||
-							((status == Status.StatusCommitted) && check_behaviors[index].allow_returned_committed) ||
-							((status == Status.StatusRolledBack) && check_behaviors[index].allow_returned_rolledback));
+					for (int i = 0; i < 10; i++) {
+						Thread.sleep(100);
+						status = _resourceImpl[index].getStatus();
 
-					if (!correct) {
-						System.out.printf("AfterCrashServiceImpl01#check_oper correct=%b%n", correct);
+						if (((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared) ||
+								((status == Status.StatusCommitting) && check_behaviors[index].allow_returned_committing) ||
+								((status == Status.StatusCommitted) && check_behaviors[index].allow_returned_committed) ||
+								((status == Status.StatusRolledBack) && check_behaviors[index].allow_returned_rolledback)) {
+							ok = true;
+							break;
+						}
+					}
+
+					if (!ok) {
+						correct = false;
+						System.out.printf("AfterCrashServiceImpl01#check_oper correct=false%n");
 
 						System.out.printf("REASON: %b %b %b %b (%d)%n",
 								((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared),

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl01.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl01.java
@@ -127,11 +127,33 @@ public class AfterCrashServiceImpl01 implements AfterCrashServiceOperations
 				try
 				{
 					Status status = _recoveryCoordinator[index].replay_completion(_resource[index]);
-					System.err.println("AfterCrashServiceImpl01.check_oper [O" + _objectNumber + ".R" + index + "]: replay_completion returned: " + status);
+					System.err.printf("AfterCrashServiceImpl01.check_oper [O%d.R%d]: replay_completion returned: %d%n",
+							_objectNumber, index, status.value());
+					/*
+					 * replay_completion is allowed to run in the background (see RecoveredTransactionReplayer) so the
+					 * resources are not guaranteed to have seen the request until the background replayer runs. Hence
+					 * wait a bit (an alternative would be to rendezvous with _resourceImpl[index]):
+					 * Section 2.7.1 of the OTS spec says of the replay_completion operation on the RecoveryCoordinator:
+					 * "This non-blocking operation returns the current status of the transaction"
+					 */
+					Thread.sleep(200);
+					status = _resourceImpl[index].getStatus();
+
 					correct = correct && (((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared) ||
 							((status == Status.StatusCommitting) && check_behaviors[index].allow_returned_committing) ||
 							((status == Status.StatusCommitted) && check_behaviors[index].allow_returned_committed) ||
 							((status == Status.StatusRolledBack) && check_behaviors[index].allow_returned_rolledback));
+
+					if (!correct) {
+						System.out.printf("AfterCrashServiceImpl01#check_oper correct=%b%n", correct);
+
+						System.out.printf("REASON: %b %b %b %b (%d)%n",
+								((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared),
+								((status == Status.StatusCommitting) && check_behaviors[index].allow_returned_committing),
+								((status == Status.StatusCommitted) && check_behaviors[index].allow_returned_committed),
+								((status == Status.StatusRolledBack) && check_behaviors[index].allow_returned_rolledback),
+								status.value());
+					}
 				}
 				catch (NotPrepared notPrepared)
 				{

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl02.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl02.java
@@ -136,16 +136,24 @@ public class AfterCrashServiceImpl02 implements AfterCrashServiceOperations
 					 * Section 2.7.1 of the OTS spec says of the replay_completion operation on the RecoveryCoordinator:
 					 * "This non-blocking operation returns the current status of the transaction"
 					 */
-					Thread.sleep(200);
-					status = _resourceImpl[index].getStatus();
+					boolean ok = false;
 
-					correct = correct && (((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared) ||
-							((status == Status.StatusCommitting) && check_behaviors[index].allow_returned_committing) ||
-							((status == Status.StatusCommitted) && check_behaviors[index].allow_returned_committed) ||
-							((status == Status.StatusRolledBack) && check_behaviors[index].allow_returned_rolledback));
+					for (int i = 0; i < 10; i++) {
+						Thread.sleep(100);
+						status = _resourceImpl[index].getStatus();
 
-					if (!correct) {
-						System.out.printf("AfterCrashServiceImpl02#check_oper correct=%b%n", correct);
+						if (((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared) ||
+								((status == Status.StatusCommitting) && check_behaviors[index].allow_returned_committing) ||
+								((status == Status.StatusCommitted) && check_behaviors[index].allow_returned_committed) ||
+								((status == Status.StatusRolledBack) && check_behaviors[index].allow_returned_rolledback)) {
+							ok = true;
+							break;
+						}
+					}
+
+					if (!ok) {
+						correct = false;
+						System.out.printf("AfterCrashServiceImpl01#check_oper correct=false%n");
 
 						System.out.printf("REASON: %b %b %b %b (%d)%n",
 								((status == Status.StatusPrepared) && check_behaviors[index].allow_returned_prepared),

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl01.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl01.java
@@ -71,6 +71,7 @@ public class ResourceImpl01 implements ResourceOperations
 		_objectNumber = objectNumber;
 		_resourceNumber = resourceNumber;
 		_resourceBehavior = resourceBehavior;
+		_status = Status.StatusNoTransaction;
 	}
 
 	public Vote prepare()
@@ -93,6 +94,8 @@ public class ResourceImpl01 implements ResourceOperations
 			System.exit(1);
 		}
 
+		_status = Status.StatusPrepared;
+
 		System.err.println("ReturnVoteCommit");
 
 		return Vote.VoteCommit;
@@ -102,6 +105,9 @@ public class ResourceImpl01 implements ResourceOperations
 			throws HeuristicCommit, HeuristicMixed, HeuristicHazard
 	{
 		System.err.print("ResourceImpl01.rollback [O" + _objectNumber + ".R" + _resourceNumber + "]: ");
+
+		if (isComplete())
+			return;
 
 		if (_resourceTrace == ResourceTrace.ResourceTraceNone)
 		{
@@ -132,6 +138,8 @@ public class ResourceImpl01 implements ResourceOperations
 			return;
 		}
 
+		_status = Status.StatusRolledBack;
+
 		System.err.println("Return");
 	}
 
@@ -139,6 +147,9 @@ public class ResourceImpl01 implements ResourceOperations
 			throws NotPrepared, HeuristicRollback, HeuristicMixed, HeuristicHazard
 	{
 		System.err.print("ResourceImpl01.commit [O" + _objectNumber + ".R" + _resourceNumber + "]: ");
+
+		if (isComplete())
+			return;
 
 		if (_resourceTrace == ResourceTrace.ResourceTraceNone)
 		{
@@ -159,6 +170,8 @@ public class ResourceImpl01 implements ResourceOperations
 			System.exit(1);
 		}
 
+		_status = Status.StatusCommitted;
+
 		try
 		{
 			ServerIORStore.removeIOR("RecoveryCoordinator_" + _serviceNumber + "_" + _objectNumber + "_" + _resourceNumber);
@@ -177,6 +190,9 @@ public class ResourceImpl01 implements ResourceOperations
 	{
 		System.err.print("ResourceImpl01.commit_one_phase [O" + _objectNumber + ".R" + _resourceNumber + "]: ");
 
+		if (isComplete())
+			return;
+
 		if (_resourceTrace == ResourceTrace.ResourceTraceNone)
 		{
 			_resourceTrace = ResourceTrace.ResourceTraceCommitOnePhase;
@@ -191,6 +207,8 @@ public class ResourceImpl01 implements ResourceOperations
 			System.err.println("Crash");
 			System.exit(1);
 		}
+
+		_status = Status.StatusCommitted;
 
 		try
 		{
@@ -249,6 +267,15 @@ public class ResourceImpl01 implements ResourceOperations
 		return _resourceTrace;
 	}
 
+		public boolean isComplete() {
+		return _status == Status.StatusCommitted || _status == Status.StatusRolledBack;
+	}
+
+	public Status getStatus() {
+		return _status;
+	}
+
+	private Status _status;
 	private int _serviceNumber;
 	private int _objectNumber;
 	private int _resourceNumber;

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl01.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl01.java
@@ -227,7 +227,7 @@ public class ResourceImpl01 implements ResourceOperations
 		}
 		else
 		{
-			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
+//			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
 		}
 
 		if (_resourceBehavior.crash_behavior == CrashBehavior.CrashBehaviorCrashInForget)

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl02.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl02.java
@@ -170,7 +170,7 @@ public class ResourceImpl02 implements ResourceOperations
 		}
 		else
 		{
-			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
+//			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
 		}
 
 		System.err.println("Return");

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl02.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl02.java
@@ -68,6 +68,7 @@ public class ResourceImpl02 implements ResourceOperations
 	{
 		_objectNumber = objectNumber;
 		_resourceNumber = resourceNumber;
+		_status = Status.StatusNoTransaction;
 	}
 
 	public Vote prepare()
@@ -84,6 +85,8 @@ public class ResourceImpl02 implements ResourceOperations
 			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
 		}
 
+		_status = Status.StatusPrepared;
+
 		System.err.println("ReturnVoteCommit");
 
 		return Vote.VoteCommit;
@@ -93,6 +96,9 @@ public class ResourceImpl02 implements ResourceOperations
 			throws HeuristicCommit, HeuristicMixed, HeuristicHazard
 	{
 		System.err.print("ResourceImpl02.rollback [O" + _objectNumber + ".R" + _resourceNumber + "]: ");
+
+		if (isComplete())
+			return;
 
 		if (_resourceTrace == ResourceTrace.ResourceTraceNone)
 		{
@@ -107,6 +113,8 @@ public class ResourceImpl02 implements ResourceOperations
 			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
 		}
 
+		_status = Status.StatusRolledBack;
+
 		System.err.println("Return");
 	}
 
@@ -114,6 +122,9 @@ public class ResourceImpl02 implements ResourceOperations
 			throws NotPrepared, HeuristicRollback, HeuristicMixed, HeuristicHazard
 	{
 		System.err.print("ResourceImpl02.commit [O" + _objectNumber + ".R" + _resourceNumber + "]: ");
+
+		if (isComplete())
+			return;
 
 		if (_resourceTrace == ResourceTrace.ResourceTraceNone)
 		{
@@ -128,6 +139,8 @@ public class ResourceImpl02 implements ResourceOperations
 			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
 		}
 
+		_status = Status.StatusCommitted;
+
 		System.err.println("Return");
 	}
 
@@ -135,6 +148,9 @@ public class ResourceImpl02 implements ResourceOperations
 			throws HeuristicHazard
 	{
 		System.err.print("ResourceImpl02.commit_one_phase [O" + _objectNumber + ".R" + _resourceNumber + "]: ");
+
+		if (isComplete())
+			return;
 
 		if (_resourceTrace == ResourceTrace.ResourceTraceNone)
 		{
@@ -144,6 +160,8 @@ public class ResourceImpl02 implements ResourceOperations
 		{
 			_resourceTrace = ResourceTrace.ResourceTraceUnknown;
 		}
+
+		_status = Status.StatusCommitted;
 
 		System.err.println("Return");
 	}
@@ -186,6 +204,15 @@ public class ResourceImpl02 implements ResourceOperations
 		return _resourceTrace;
 	}
 
+	public boolean isComplete() {
+		return _status == Status.StatusCommitted || _status == Status.StatusRolledBack;
+	}
+
+	public Status getStatus() {
+		return _status;
+	}
+
+	private Status _status;
 	private int _objectNumber;
 	private int _resourceNumber;
 	private ResourceBehavior _resourceBehavior;

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server01.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server01.java
@@ -69,8 +69,10 @@ public class Server01
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			BeforeCrashServiceImpl01 beforeCrashServiceImpl = new BeforeCrashServiceImpl01(args[args.length - 2].hashCode(), 0);
 			BeforeCrashServicePOATie servant = new BeforeCrashServicePOATie(beforeCrashServiceImpl);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server02.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server02.java
@@ -69,8 +69,10 @@ public class Server02
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			AfterCrashServiceImpl01 afterCrashServiceImpl = new AfterCrashServiceImpl01(args[args.length - 2].hashCode(), 0);
 			AfterCrashServicePOATie servant = new AfterCrashServicePOATie(afterCrashServiceImpl);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server03.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server03.java
@@ -69,8 +69,10 @@ public class Server03
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			BeforeCrashServiceImpl01 beforeCrashServiceImpl1 = new BeforeCrashServiceImpl01(args[args.length - 3].hashCode(), 0);
 			BeforeCrashServiceImpl01 beforeCrashServiceImpl2 = new BeforeCrashServiceImpl01(args[args.length - 3].hashCode(), 1);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server04.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server04.java
@@ -69,8 +69,10 @@ public class Server04
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			AfterCrashServiceImpl01 afterCrashServiceImpl1 = new AfterCrashServiceImpl01(args[args.length - 3].hashCode(), 0);
 			AfterCrashServiceImpl01 afterCrashServiceImpl2 = new AfterCrashServiceImpl01(args[args.length - 3].hashCode(), 1);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server05.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server05.java
@@ -69,8 +69,10 @@ public class Server05
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			BeforeCrashServiceImpl02 beforeCrashServiceImpl = new BeforeCrashServiceImpl02(args[args.length - 2].hashCode(), 0);
 			BeforeCrashServicePOATie servant = new BeforeCrashServicePOATie(beforeCrashServiceImpl);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server06.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server06.java
@@ -69,8 +69,10 @@ public class Server06
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			AfterCrashServiceImpl02 afterCrashServiceImpl = new AfterCrashServiceImpl02(args[args.length - 2].hashCode(), 0);
 			AfterCrashServicePOATie servant = new AfterCrashServicePOATie(afterCrashServiceImpl);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server07.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server07.java
@@ -69,8 +69,10 @@ public class Server07
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			BeforeCrashServiceImpl02 beforeCrashServiceImpl1 = new BeforeCrashServiceImpl02(args[args.length - 3].hashCode(), 0);
 			BeforeCrashServiceImpl02 beforeCrashServiceImpl2 = new BeforeCrashServiceImpl02(args[args.length - 3].hashCode(), 1);

--- a/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server08.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Servers/Server08.java
@@ -69,8 +69,10 @@ public class Server08
 	{
 		try
 		{
-			ORBInterface.initORB(args, null);
-			OAInterface.initOA();
+			if (ORBInterface.getORB() == null) {
+				ORBInterface.initORB(args, null);
+				OAInterface.initOA();
+			}
 
 			AfterCrashServiceImpl02 afterCrashServiceImpl1 = new AfterCrashServiceImpl02(args[args.length - 3].hashCode(), 0);
 			AfterCrashServiceImpl02 afterCrashServiceImpl2 = new AfterCrashServiceImpl02(args[args.length - 3].hashCode(), 1);


### PR DESCRIPTION
!BLACKTIE !QA_JTA !XTS !PERF 

This fixes multiple failures on the QA_JTS_JDKORB profile with the hornetq store:

JBTM-2534	HQStore crashrec failures on QA_JTS_JDKORB	
JBTM-2549	CrashRecovery05_2_Test002 failure
JBTM-2548	CrashRecovery05_2_Test076 (through CrashRecovery05_2_Test100) failures	
JBTM-2547	CrashRecovery02_2_Test01 failure

A PR will not exercise the failures so I have created the following job to verify it:
http://albany.eng.hst.ams2.redhat.com/job/narayana-hqstore-JBTM-2534/

A lot of the changes were to avoid initializing the ORB twice when running under the control of ExecutionWrapper so they don't really need reviewing in any depth. The significant fixes are:

commit 01406d4
    StatusChecker.java 
commit fbbc69b
    qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl01.java
    qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/AfterCrashServiceImpl02.java
    qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl01.java
    qa/tests/src/org/jboss/jbossts/qa/CrashRecovery05Impls/ResourceImpl02.java
commit 00b7f15
    ExecutionWrapper.java

