### PR TITLE
Make JCA txn import thread safe

### DIFF
--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/jca/XATerminatorUnitTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/jca/XATerminatorUnitTest.java
@@ -50,6 +50,14 @@ import com.hp.mwtests.ts.jta.common.FailureXAResource;
 import com.hp.mwtests.ts.jta.common.FailureXAResource.FailLocation;
 import com.hp.mwtests.ts.jta.common.FailureXAResource.FailType;
 
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
 public class XATerminatorUnitTest
 {
     @Test
@@ -373,5 +381,61 @@ public class XATerminatorUnitTest
         catch (IllegalArgumentException ex)
         {
         }
+    }
+
+    @Test
+    public void testConcurrentImport () throws Exception {
+        AtomicInteger completionCount = new AtomicInteger(0);
+        XidImple xid = new XidImple(new Uid());
+
+        final int TASK_COUNT = 400;
+        final int THREAD_COUNT = 200;
+        final CyclicBarrier gate = new CyclicBarrier(THREAD_COUNT + 1);
+
+        ArrayList<CompletableFuture<SubordinateTransaction>> futures = new ArrayList<>();
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+
+        for (int i = 0; i < TASK_COUNT; i++)
+            futures.add(doAsync(completionCount, gate, i < THREAD_COUNT, executor, xid));
+
+        gate.await();
+
+        SubordinateTransaction prevStx = null;
+
+        for (CompletableFuture<SubordinateTransaction> future : futures) {
+            SubordinateTransaction stx = future.get();
+            if (stx == null) {
+                fail("transaction import returned null for future ");
+            } else {
+                if (prevStx != null)
+                    assertEquals("transaction import for same xid returned a different instance", stx, prevStx);
+                else
+                    prevStx = stx;
+            }
+        }
+
+        assertEquals("some transaction import futures did not complete", completionCount.get(), TASK_COUNT);
+    }
+
+    /*
+     * import a transaction asynchronously to maximise the opportunity for concurrency errors in TransactionImporterImple
+     */
+    private CompletableFuture<SubordinateTransaction> doAsync(
+            final AtomicInteger completionCount, final CyclicBarrier gate, final boolean wait, ExecutorService executor, final XidImple xid) {
+        return CompletableFuture.supplyAsync(new Supplier<SubordinateTransaction>() {
+            @Override
+            public SubordinateTransaction get() {
+                try {
+                    if (wait)
+                        gate.await();
+                    SubordinateTransaction stx = SubordinationManager.getTransactionImporter().importTransaction(xid);
+                    completionCount.incrementAndGet();
+
+                    return stx;
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            }
+        }, executor);
     }
 }

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/jca/XATerminatorImpleUnitTest.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/jca/XATerminatorImpleUnitTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.fail;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 
+import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinateTransaction;
 import org.junit.Test;
 
 import com.arjuna.ats.arjuna.common.Uid;
@@ -46,6 +47,14 @@ import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporte
 import com.arjuna.ats.internal.jta.transaction.jts.jca.XATerminatorImple;
 import com.arjuna.ats.jta.xa.XidImple;
 import com.hp.mwtests.ts.jta.jts.common.TestBase;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 public class XATerminatorImpleUnitTest extends TestBase
 {
@@ -219,5 +228,63 @@ public class XATerminatorImpleUnitTest extends TestBase
         catch (final Exception ex)
         {
         }
+    }
+
+    @Test
+    public void testConcurrentImport () throws Exception {
+        AtomicInteger completionCount = new AtomicInteger(0);
+        XidImple xid = new XidImple(new Uid());
+
+        final int TASK_COUNT = 400;
+        final int THREAD_COUNT = 200;
+        final CyclicBarrier gate = new CyclicBarrier(THREAD_COUNT + 1);
+
+        ArrayList<CompletableFuture<SubordinateTransaction>> futures = new ArrayList<>();
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+
+        for (int i = 0; i < TASK_COUNT; i++)
+            futures.add(doAsync(completionCount, gate, i < THREAD_COUNT, executor, xid));
+
+        gate.await();
+
+        SubordinateTransaction prevStx = null;
+
+        for (CompletableFuture<SubordinateTransaction> future : futures) {
+            SubordinateTransaction stx = future.get();
+            if (stx == null) {
+                fail("transaction import returned null for future ");
+            } else {
+                if (prevStx != null)
+                    assertEquals("transaction import for same xid returned a different instance", stx, prevStx);
+                else
+                    prevStx = stx;
+            }
+        }
+
+        assertEquals("some transaction import futures did not complete", completionCount.get(), TASK_COUNT);
+    }
+
+    /*
+     * import a transaction asynchronously to maximise the opportunity for concurrency errors in TransactionImporterImple
+     */
+    private CompletableFuture<SubordinateTransaction> doAsync(
+            final AtomicInteger completionCount, final CyclicBarrier gate, final boolean wait, ExecutorService executor, final XidImple xid) {
+        return CompletableFuture.supplyAsync(new Supplier<SubordinateTransaction>() {
+            @Override
+            public SubordinateTransaction get() {
+                try {
+                    if (wait)
+                        gate.await();
+
+                    TransactionImporter imp = SubordinationManager.getTransactionImporter();
+                    SubordinateTransaction stx = imp.importTransaction(xid);
+                    completionCount.incrementAndGet();
+
+                    return stx;
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            }
+        }, executor);
     }
 }


### PR DESCRIPTION
!QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_IBMORB !BLACKTIE !PERF !XTS !MAIN

https://issues.jboss.org/browse/JBTM-2614

My solution is, instead of adding the TransactionImple directly to the list of known imported transactions I add a holder object using putIfAbsent (keyed by Xid). If the put returns null then I know this is the first time we have seen the imported transaction and I construct the transaction and add it to the holder object using a setter method. The getter and setter are protected from each other using the wait/notify idiom.