### PR TITLE
[JBTM-2633] Update arquillian.xml in tests to configure startup timeout

### DIFF
--- a/ArjunaJTA/cdi/tests/resources/arquillian.xml
+++ b/ArjunaJTA/cdi/tests/resources/arquillian.xml
@@ -30,6 +30,7 @@
             <property name="serverConfig">standalone.xml</property>
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 

--- a/ArjunaJTA/jta/src/test/resources/arquillian.xml
+++ b/ArjunaJTA/jta/src/test/resources/arquillian.xml
@@ -32,6 +32,7 @@ cp /home/mmusgrov/source/forks/narayana/tom/jboss-as/build/target/wildfly-8.0.0.
             <property name="serverConfig">standalone-cmr.xml</property>
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration> 
    </container>
 

--- a/XTS/localjunit/WSTFSC07-interop/src/test/resources/arquillian.xml
+++ b/XTS/localjunit/WSTFSC07-interop/src/test/resources/arquillian.xml
@@ -8,6 +8,7 @@
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">standalone-xts.xml</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 </arquillian>

--- a/XTS/localjunit/WSTX11-interop/src/test/resources/arquillian.xml
+++ b/XTS/localjunit/WSTX11-interop/src/test/resources/arquillian.xml
@@ -8,6 +8,7 @@
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">standalone-xts.xml</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 </arquillian>

--- a/XTS/localjunit/crash-recovery-tests/src/test/resources/arquillian.xml
+++ b/XTS/localjunit/crash-recovery-tests/src/test/resources/arquillian.xml
@@ -8,6 +8,7 @@
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">standalone-xts.xml</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 </arquillian>

--- a/XTS/localjunit/disabled-context-propagation/src/test/resources/arquillian.xml
+++ b/XTS/localjunit/disabled-context-propagation/src/test/resources/arquillian.xml
@@ -30,6 +30,7 @@
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">test-disabled-context-propagation-standalone-xts.xml</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 

--- a/XTS/localjunit/unit/src/test/resources/arquillian.xml
+++ b/XTS/localjunit/unit/src/test/resources/arquillian.xml
@@ -30,6 +30,7 @@
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">standalone-xts.xml</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
     

--- a/blacktie/blacktie-admin-services/src/test/resources/arquillian.xml
+++ b/blacktie/blacktie-admin-services/src/test/resources/arquillian.xml
@@ -22,6 +22,7 @@
 	<container qualifier="jboss" default="true">
         <configuration>
             <property name="managementAddress">${jbossas.ip.addr}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
 	</container>
 

--- a/compensations/src/test/resources/arquillian.xml
+++ b/compensations/src/test/resources/arquillian.xml
@@ -34,6 +34,7 @@
             <property name="serverConfig">${server.config}</property>
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 

--- a/rts/at/bridge/src/test/resources/arquillian.xml
+++ b/rts/at/bridge/src/test/resources/arquillian.xml
@@ -29,6 +29,7 @@
             <property name="serverConfig">standalone-rts.xml</property>
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 

--- a/rts/at/integration/src/test/resources/arquillian.xml
+++ b/rts/at/integration/src/test/resources/arquillian.xml
@@ -17,6 +17,7 @@
             <property name="serverConfig">standalone-rts.xml</property>
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 

--- a/rts/at/webservice/src/test/resources/arquillian.xml
+++ b/rts/at/webservice/src/test/resources/arquillian.xml
@@ -26,6 +26,7 @@
         <!-- If you want to use the JBOSS_HOME environment variable, just delete the jbossHome property -->
         <configuration>
             <property name="jbossHome">/path/to/jboss/as</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 

--- a/txbridge/src/test/resources/arquillian.xml
+++ b/txbridge/src/test/resources/arquillian.xml
@@ -6,6 +6,7 @@
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">standalone-xts.xml</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 </arquillian>

--- a/txframework/src/test/resources/arquillian.xml
+++ b/txframework/src/test/resources/arquillian.xml
@@ -34,6 +34,7 @@
             <property name="serverConfig">${server.config}</property>
             <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="managementAddress">${node.address}</property>
+            <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>
         </configuration>
     </container>
 


### PR DESCRIPTION
In case that test is run against some slow database on a slow machine when jdbc  object store is used then server could not be started on time of 60 seconds and test start to fail.
This change adds configurable option to increase the arquillian settings of server startup timeout if necessary.

Adding configurable option `<property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>` for user could use `-Dserver.startup.timeout` with arbitrary value to change the server startup timeout for his use.

!BLACKTIE !PERF !QA_JTA !QA_JTS_JACORB