### PR TITLE
[JBTM-2730] Static code analysis issue: default encoding

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
@@ -116,8 +116,8 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
 
         if (nodeIdentifier.getBytes().length > NODE_NAME_SIZE)
         {
-            tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier);
-            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_too_long(nodeIdentifier));
+            tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier, NODE_NAME_SIZE);
+            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_too_long(nodeIdentifier, NODE_NAME_SIZE));
         }
 
     	this.nodeIdentifier = nodeIdentifier;

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
@@ -21,7 +21,7 @@
 package com.arjuna.ats.arjuna.common;
 
 import java.io.File;
-
+import java.nio.charset.StandardCharsets;
 import com.arjuna.ats.arjuna.logging.tsLogger;
 import com.arjuna.ats.arjuna.utils.Process;
 import com.arjuna.ats.arjuna.utils.Utility;
@@ -114,7 +114,7 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
             throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_null());
         }
 
-        if (nodeIdentifier.getBytes().length > NODE_NAME_SIZE)
+        if (nodeIdentifier.getBytes(StandardCharsets.UTF_8).length > NODE_NAME_SIZE)
         {
             tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier, NODE_NAME_SIZE);
             throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_too_long(nodeIdentifier, NODE_NAME_SIZE));

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/Uid.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/Uid.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.arjuna.ats.arjuna.exceptions.FatalError;
@@ -370,7 +371,7 @@ public class Uid implements Cloneable, Serializable
                 ds.writeInt(process);
                 ds.writeInt(sec);
                 ds.writeInt(other);
-                //_byteForm = stringForm().getBytes("UTF-8");
+                //_byteForm = stringForm().getBytes(StandardCharsets.UTF_8);
                 
                 _byteForm = ba.toByteArray();
             }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxControl.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxControl.java
@@ -34,7 +34,6 @@ package com.arjuna.ats.arjuna.coordinator;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.logging.tsLogger;
 import com.arjuna.ats.arjuna.recovery.TransactionStatusManager;
-import com.arjuna.ats.arjuna.utils.Utility;
 
 /**
  * Transaction configuration object. We have a separate object for this so that
@@ -168,7 +167,7 @@ public class TxControl
 	public static void setXANodeName(String name)
 	{
 	    if (name.getBytes().length > NODE_NAME_SIZE) {
-            tsLogger.i18NLogger.warn_coordinator_toolong();
+            tsLogger.i18NLogger.warn_coordinator_toolong(NODE_NAME_SIZE);
 
             throw new IllegalArgumentException();
         }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxControl.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxControl.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.ats.arjuna.coordinator;
 
+import java.nio.charset.StandardCharsets;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.logging.tsLogger;
 import com.arjuna.ats.arjuna.recovery.TransactionStatusManager;
@@ -166,7 +167,7 @@ public class TxControl
 
 	public static void setXANodeName(String name)
 	{
-	    if (name.getBytes().length > NODE_NAME_SIZE) {
+	    if (name.getBytes(StandardCharsets.UTF_8).length > NODE_NAME_SIZE) {
             tsLogger.i18NLogger.warn_coordinator_toolong(NODE_NAME_SIZE);
 
             throw new IllegalArgumentException();

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -587,9 +587,9 @@ public interface arjunaI18NLogger {
 	@LogMessage(level = WARN)
 	public void warn_coordinator_notrunning();
 
-	@Message(id = 12138, value = "Node name cannot exceed 36 bytes!", format = MESSAGE_FORMAT)
+	@Message(id = 12138, value = "Node name cannot exceed {0} bytes!", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
-	public void warn_coordinator_toolong();
+	public void warn_coordinator_toolong(Integer arg0);
 
 	@Message(id = 12139, value = "You have chosen to disable the Multiple Last Resources warning. You will see it only once.", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
@@ -1491,12 +1491,12 @@ public interface arjunaI18NLogger {
 	public void warn_objectstore_JDBCImple_over_max_image_size(int imageSize,
 			int maxStateSize);
 
-    @Message(id = 12372, value = "The node identifier was too long {0}, aborting initialization", format = MESSAGE_FORMAT)
+    @Message(id = 12372, value = "The node identifier {0} was too long {1}, aborting initialization", format = MESSAGE_FORMAT)
     @LogMessage(level = FATAL)
-    public void fatal_nodename_too_long(String xaNodeName);
+    public void fatal_nodename_too_long(String xaNodeName, Integer nameLength);
 
-    @Message(id = 12373, value = "The node identifier was too long {0}, aborting initialization", format = MESSAGE_FORMAT)
-    public String get_fatal_nodename_too_long(String xaNodeName);
+    @Message(id = 12373, value = "The node identifier {0} was too long {1}, aborting initialization", format = MESSAGE_FORMAT)
+    public String get_fatal_nodename_too_long(String xaNodeName, Integer nameLength);
 
     @Message(id = 12374, value = "The node identifier cannot be null, aborting initialization", format = MESSAGE_FORMAT)
     @LogMessage(level = FATAL)

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -1546,7 +1546,14 @@ public interface arjunaI18NLogger {
 
 	@Message(id = 12386, value = "Unexpected state type {0}", format = MESSAGE_FORMAT)
 	String unexpected_state_type(int stateType);
+
+    @Message(id = 12387, value = "Encoding {0} is not supported", format = MESSAGE_FORMAT)
+    @LogMessage(level = FATAL)
+    public void fatal_encoding_not_supported(String encodingName);
     
+    @Message(id = 12388, value = "Encoding {0} is not supported", format = MESSAGE_FORMAT)
+    public String get_encoding_not_supported(String encodingName);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/ActionStatusService.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/ActionStatusService.java
@@ -38,6 +38,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Vector;
 
 import com.arjuna.ats.arjuna.common.Uid;
@@ -100,8 +101,8 @@ public class ActionStatusService implements Service
    public void doWork( InputStream is, OutputStream os )
       throws IOException
    {
-      BufferedReader in  = new BufferedReader ( new InputStreamReader(is) );
-      PrintWriter    out = new PrintWriter ( new OutputStreamWriter(os) );
+      BufferedReader in  = new BufferedReader ( new InputStreamReader(is, StandardCharsets.UTF_8) );
+      PrintWriter    out = new PrintWriter ( new OutputStreamWriter(os, StandardCharsets.UTF_8) );
 
       try
       {

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/RecoveryDriver.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/RecoveryDriver.java
@@ -38,6 +38,7 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.common.recoveryPropertyManager;
 
@@ -112,9 +113,9 @@ public class RecoveryDriver
 	    {
 	        // streams to and from the RecoveryManager
 
-	        BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream())) ;
+	        BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), StandardCharsets.UTF_8)) ;
 
-	        PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream()));
+	        PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), StandardCharsets.UTF_8));
 
 	        toServer.println(scanType);
 

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/state/InputBuffer.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/state/InputBuffer.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.logging.tsLogger;
 
@@ -379,7 +380,7 @@ public class InputBuffer
 
         realign(length);
 
-        return new String(b);
+        return new String(b, StandardCharsets.UTF_8);
     }
 
     /**

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/state/OutputBuffer.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/state/OutputBuffer.java
@@ -35,6 +35,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.logging.tsLogger;
 
@@ -373,7 +374,7 @@ public class OutputBuffer
 
         if (sz > 0)
         {
-            byte[] bytes = dummy.getBytes();
+            byte[] bytes = dummy.getBytes(StandardCharsets.UTF_8);
             _output.write(bytes, 0, bytes.length);
             realign(bytes.length);
         }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/RecoveryMonitor.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/RecoveryMonitor.java
@@ -37,6 +37,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.recovery.RecoveryDriver;
 
@@ -132,9 +133,9 @@ public class RecoveryMonitor
 
 	    // streams to and from the RecoveryManager
 
-	    BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream())) ;
+	    BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), StandardCharsets.UTF_8)) ;
                               
-	    PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream()));
+	    PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), StandardCharsets.UTF_8));
 
 	    if (asyncScan)
 		toServer.println(RecoveryDriver.ASYNC_SCAN);

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/log/LogBrowser.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/log/LogBrowser.java
@@ -22,6 +22,7 @@
 package com.arjuna.ats.arjuna.tools.log;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.exceptions.ObjectStoreException;
@@ -87,7 +88,7 @@ class LogConsole
 
                 System.in.read(command);
 
-                String commandString = new String(command);
+                String commandString = new String(command, StandardCharsets.UTF_8);
 
                 Command com = validCommand(commandString);
 

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/LogStore.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/LogStore.java
@@ -16,6 +16,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.SyncFailedException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -728,7 +729,7 @@ public class LogStore extends FileSystemStore
         if (tName != null)
         {
             int imageSize = (int) state.length();
-            byte[] uidString = objUid.stringForm().getBytes();
+            byte[] uidString = objUid.stringForm().getBytes(StandardCharsets.UTF_8);
             int buffSize = _redzone.length + uidString.length + imageSize + 8;  // don't put in endOfLog since we keep overwriting that.
             RandomAccessFile ofile = null;
             java.nio.channels.FileLock lock = null;
@@ -1081,7 +1082,7 @@ public class LogStore extends FileSystemStore
 
                     for (int i = 0; i < objectStates.size(); i++)
                     {
-                        byte[] uidString = objectStates.get(i).stateUid().stringForm().getBytes();
+                        byte[] uidString = objectStates.get(i).stateUid().stringForm().getBytes(StandardCharsets.UTF_8);
                         int buffSize = _redzone.length + uidString.length + objectStates.get(i).buffer().length + 8;
                         java.nio.ByteBuffer buff = java.nio.ByteBuffer.allocate(buffSize);
 
@@ -1217,7 +1218,7 @@ public class LogStore extends FileSystemStore
 
                             iFile.read(uidString);
 
-                            Uid txId = new Uid(new String(uidString));
+                            Uid txId = new Uid(new String(uidString, StandardCharsets.UTF_8));
                             int imageSize = iFile.readInt();
                             byte[] imageState = new byte[imageSize];
 

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/TransactionStatusConnector.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/TransactionStatusConnector.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.coordinator.ActionStatus;
@@ -194,9 +195,9 @@ public class TransactionStatusConnector
             _connector_socket.setSoTimeout ( _socket_timeout_in_msecs ) ;
    
             // streams to and from the TransactionStatusManager
-            _from_server = new BufferedReader ( new InputStreamReader( _connector_socket.getInputStream() )) ;
+            _from_server = new BufferedReader ( new InputStreamReader( _connector_socket.getInputStream(), StandardCharsets.UTF_8 )) ;
                               
-            _to_server = new PrintWriter ( new OutputStreamWriter( _connector_socket.getOutputStream() ) ) ;
+            _to_server = new PrintWriter ( new OutputStreamWriter( _connector_socket.getOutputStream(), StandardCharsets.UTF_8 ) ) ;
 
             // Check that the process id of the server is the same as
             // this connectors process id.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/WorkerService.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/WorkerService.java
@@ -38,6 +38,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.ats.arjuna.logging.tsLogger;
 import com.arjuna.ats.arjuna.recovery.RecoveryDriver;
@@ -52,8 +53,8 @@ public class WorkerService implements Service
     
     public void doWork (InputStream is, OutputStream os) throws IOException
     {
-	BufferedReader in  = new BufferedReader(new InputStreamReader(is));
-	PrintWriter out = new PrintWriter(new OutputStreamWriter(os));
+	BufferedReader in  = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+	PrintWriter out = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
 
 	try
 	{

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/utils/ExecProcessId.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/utils/ExecProcessId.java
@@ -37,6 +37,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import com.arjuna.ats.arjuna.exceptions.FatalError;
@@ -141,7 +143,14 @@ public class ExecProcessId implements com.arjuna.ats.arjuna.utils.Process
                     if (tempFile != null)
                         tempFile.delete();
 
-                    StringTokenizer theTokenizer = new StringTokenizer(bstream.toString());
+                    StringTokenizer theTokenizer;
+                    try {
+                        theTokenizer = new StringTokenizer(bstream.toString(StandardCharsets.UTF_8.name()));
+                    } catch (UnsupportedEncodingException e) {
+                        tsLogger.i18NLogger.fatal_encoding_not_supported(StandardCharsets.UTF_8.name());
+                        throw new IllegalStateException(
+                            tsLogger.i18NLogger.get_encoding_not_supported(StandardCharsets.UTF_8.name()));
+                    }
                     theTokenizer.nextToken();
 
                     String pid = theTokenizer.nextToken();

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XATxConverter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XATxConverter.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.ats.jta.xa;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import javax.transaction.xa.Xid;
@@ -95,13 +96,12 @@ public class XATxConverter
             throw new IllegalStateException(jtaLogger.i18NLogger.get_nodename_null());
         }
 
-        int nodeNameLengthToUse =  nodeName.getBytes().length;
+        int nodeNameLengthToUse = nodeName.getBytes(StandardCharsets.UTF_8).length;
         xid.gtrid_length = gtridUid.length+nodeNameLengthToUse;
 
         // src, srcPos, dest, destPos, length
         System.arraycopy(gtridUid, 0, xid.data, 0, gtridUid.length);
-        System.arraycopy(nodeName.getBytes(), 0, xid.data, gtridUid.length, nodeNameLengthToUse);
-
+        System.arraycopy(nodeName.getBytes(StandardCharsets.UTF_8), 0, xid.data, gtridUid.length, nodeNameLengthToUse);
         
         
         if (branch.notEquals(Uid.nullUid()))
@@ -165,7 +165,7 @@ public class XATxConverter
 		// way to tell where it starts is to figure out how long the Uid is.
 		int offset = Uid.UID_SIZE;
 
-		return new String(Arrays.copyOfRange(globalTransactionId, offset, globalTransactionId.length));
+		return new String(Arrays.copyOfRange(globalTransactionId, offset, globalTransactionId.length), StandardCharsets.UTF_8);
 	}
 
 	public static void setSubordinateNodeName(XID theXid, String xaNodeName) {
@@ -182,7 +182,7 @@ public class XATxConverter
 		theXid.data[offset++] = (byte) (length >>> 8);
 		theXid.data[offset++] = (byte) (length >>> 0);
 		if (length > 0) {
-			byte[] nameAsBytes = xaNodeName.getBytes();
+			byte[] nameAsBytes = xaNodeName.getBytes(StandardCharsets.UTF_8);
 			System.arraycopy(nameAsBytes, 0, theXid.data, offset, length);
 		}
 		theXid.bqual_length = Uid.UID_SIZE+4+4+length;
@@ -206,7 +206,7 @@ public class XATxConverter
 				+ ((branchQualifier[offset++] & 0xFF) << 8)
 				+ (branchQualifier[offset++] & 0xFF);
 		if (length > 0) {
-			return new String(Arrays.copyOfRange(branchQualifier, offset, offset+length));
+			return new String(Arrays.copyOfRange(branchQualifier, offset, offset+length), StandardCharsets.UTF_8);
 		} else {
 			return null;
 		}

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/JacOrbRCDefaultServant.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/JacOrbRCDefaultServant.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.ats.internal.jts.orbspecific.jacorb.recoverycoordinators;
 
+import java.nio.charset.StandardCharsets;
 import org.omg.CORBA.ORB;
 import org.omg.CORBA.SystemException;
 import org.omg.CosTransactions.NotPrepared;
@@ -77,7 +78,7 @@ public class JacOrbRCDefaultServant extends GenericRecoveryCoordinator
 	     byte[] objectId = poa_current.get_object_id();
 	     //End New
 	     
-	     String objectIdString = new String(objectId);
+	     String objectIdString = new String(objectId, StandardCharsets.UTF_8);
 
 	     // convert that to the structured id
 	     RecoveryCoordinatorId  recovCoId = RecoveryCoordinatorId.reconstruct(objectIdString);

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/RecoverIOR.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/RecoverIOR.java
@@ -25,6 +25,7 @@
 
 package com.arjuna.ats.internal.jts.orbspecific.jacorb.recoverycoordinators;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.jacorb.orb.CDROutputStream;
@@ -36,6 +37,7 @@ import org.omg.IOP.TaggedProfile;
 import org.omg.IOP.TaggedProfileHolder;
 
 import com.arjuna.ats.internal.jts.ORBManager;
+import com.sun.corba.se.spi.ior.IORFactories;
 
 public class RecoverIOR
 {
@@ -67,7 +69,7 @@ public class RecoverIOR
 		IIOPProfile pb = (IIOPProfile) profiles.get(i);
 		IIOPProfile new_pb = (IIOPProfile) pb.copy();
 
-		new_pb.set_object_key(new_object_key.getBytes());
+		new_pb.set_object_key(new_object_key.getBytes(StandardCharsets.UTF_8));
 
 		new_ior.profiles[i] = new TaggedProfile();
 		new_ior.profiles[i].tag = 0; // IIOP
@@ -84,7 +86,7 @@ public class RecoverIOR
 	// It appears that the following method do the same role as above
 	public IOR newIOR(String objectId)
 	{
-	    String the_object_key = new String(get_object_key());
+	    String the_object_key = new String(get_object_key(), StandardCharsets.UTF_8);
 	    int position = the_object_key.indexOf("RecoveryManager");
 	    String new_object_key = the_object_key.substring(0, position).concat(objectId);
 	    IOR new_ior = ParsedIOR.createObjectIOR(getEffectiveProfile());

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/ServerRecoveryInterceptor.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/jacorb/recoverycoordinators/ServerRecoveryInterceptor.java
@@ -37,7 +37,7 @@ import org.omg.IOP.ServiceContext;
 import org.omg.PortableInterceptor.ForwardRequest;
 import org.omg.PortableInterceptor.ServerRequestInfo;
 import org.omg.PortableInterceptor.ServerRequestInterceptor;
-
+import java.nio.charset.StandardCharsets;
 import com.arjuna.ats.jts.logging.jtsLogger;
 
 /**
@@ -76,7 +76,7 @@ public class ServerRecoveryInterceptor
         try
         {
             context = ri.get_request_service_context (RecoveryContextId);
-	    String objectIdString = new String(context.context_data);
+	    String objectIdString = new String(context.context_data, StandardCharsets.UTF_8);
 	    JacOrbRCDefaultServant.RCObjectId = context.context_data;
         }
         catch (Exception ex) {

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/ClientForwardInterceptor.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/ClientForwardInterceptor.java
@@ -33,6 +33,7 @@ package com.arjuna.ats.internal.jts.orbspecific.javaidl.recoverycoordinators;
 
 
 import com.arjuna.ats.jts.logging.jtsLogger;
+import java.nio.charset.StandardCharsets;
 import org.omg.CORBA.Any;
 import org.omg.CORBA.TCKind;
 import org.omg.CosTransactions.RecoveryCoordinator;
@@ -118,7 +119,7 @@ public class ClientForwardInterceptor
 			     * Extract the substring of the ObjectId that contains the Uid and 
 			     * the Process Id and pass it to the data of the service context
 			     */
-			    RCobjectId = extractObjectId(objectIdString).getBytes();
+			    RCobjectId = extractObjectId(objectIdString).getBytes(StandardCharsets.UTF_8);
 			    RCctx = new ServiceContext(RecoveryContextId, RCobjectId);
 			    in_loop = false;
 			    throw new ForwardRequest( reco );

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/JavaIdlRCDefaultServant.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/JavaIdlRCDefaultServant.java
@@ -34,6 +34,7 @@ package com.arjuna.ats.internal.jts.orbspecific.javaidl.recoverycoordinators;
 import com.arjuna.ats.internal.jts.orbspecific.recovery.recoverycoordinators.GenericRecoveryCoordinator;
 import com.arjuna.ats.internal.jts.orbspecific.recovery.recoverycoordinators.RecoveryCoordinatorId;
 import com.arjuna.ats.jts.logging.jtsLogger;
+import java.nio.charset.StandardCharsets;
 import org.omg.CORBA.ORB;
 import org.omg.CORBA.SystemException;
 import org.omg.CosTransactions.NotPrepared;
@@ -76,7 +77,7 @@ public class JavaIdlRCDefaultServant extends GenericRecoveryCoordinator
             byte[] objectId = poa_current.get_object_id();
             //End New
 
-            String objectIdString = new String(objectId);
+            String objectIdString = new String(objectId, StandardCharsets.UTF_8);
             String poaName = poa_current.get_POA().the_name();
 
             if (objectIdString.startsWith(poaName)) {

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/RecoverIOR.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/javaidl/recoverycoordinators/RecoverIOR.java
@@ -30,6 +30,8 @@ import com.sun.corba.se.impl.ior.IORImpl;
 import com.sun.corba.se.impl.orbutil.ORBUtility;
 import com.sun.corba.se.spi.ior.IORFactories;
 import com.sun.corba.se.spi.ior.ObjectId;
+import java.nio.charset.StandardCharsets;
+
 import org.omg.CosTransactions.RecoveryCoordinatorHelper;
 
 /**
@@ -48,7 +50,8 @@ public class RecoverIOR
         org.omg.CORBA.Object corbject = ORBManager.getORB().orb().string_to_object(str);
 
         com.sun.corba.se.spi.ior.IOR ior = IORFactories.getIOR(corbject);
-        ObjectId oid = IORFactories.makeObjectId(new_object_key.getBytes());
+        ObjectId oid = IORFactories.makeObjectId(new_object_key.getBytes(StandardCharsets.UTF_8));
+
         IORImpl new_ior = new IORImpl(sun_orb, RecoveryCoordinatorHelper.id(), ior.getIORTemplates(), oid);
 
         return new_ior.stringify();

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/utils/Utility.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/utils/Utility.java
@@ -32,7 +32,7 @@
 package com.arjuna.ats.jts.utils;
 
 import java.io.PrintWriter;
-
+import java.nio.charset.StandardCharsets;
 import com.arjuna.ats.jts.logging.jtsLogger;
 import org.omg.CORBA.BAD_PARAM;
 import org.omg.CosTransactions.PropagationContext;
@@ -250,13 +250,13 @@ public class Utility
 	    return null;
 
 	otid_t otid = new otid_t();
-	byte[] b = theUid.getBytes();
+	byte[] b = theUid.getBytes(StandardCharsets.UTF_8);
 
 	if (TxControl.getXANodeName() == null) {
 		throw new IllegalStateException(jtsLogger.i18NLogger.get_nodename_null());
 	}
 
-	byte[] nodeName = TxControl.getXANodeName().getBytes();
+	byte[] nodeName = TxControl.getXANodeName().getBytes(StandardCharsets.UTF_8);
 
 	otid.formatID = 0;
 	otid.tid = new byte[b.length+nodeName.length];
@@ -291,7 +291,7 @@ public class Utility
 	    
 	    System.arraycopy(otid.tid, 0, theUid, 0, uidLength);
 	    
-	    Uid u = new Uid(new String(theUid), true);  // errors in string give NIL_UID
+	    Uid u = new Uid(new String(theUid, StandardCharsets.UTF_8), true);  // errors in string give NIL_UID
 	    
 	    /*
 	     * Currently we ignore bqual. THIS WILL BE AN ISSUE FOR INTEROPERABILITY!!

--- a/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/Services.java
+++ b/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/Services.java
@@ -39,6 +39,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Vector;
 
 import org.omg.CORBA.BAD_PARAM;
@@ -271,7 +272,7 @@ public org.omg.CORBA.Object getService (String serviceName,
 		    ifile.read(b);
 		    ifile.close();
 	
-		    String objString = new String(b);
+		    String objString = new String(b, StandardCharsets.UTF_8);
 		    objRef = _orb.orb().string_to_object(objString);
 
 		    objString = null;
@@ -472,7 +473,7 @@ public void registerService (org.omg.CORBA.Object objRef,
 		    ofile = new FileOutputStream(serviceName);
 		
 		String objString = _orb.orb().object_to_string(objRef);
-		byte b[] = objString.getBytes();
+		byte b[] = objString.getBytes(StandardCharsets.UTF_8);
 
 		ofile.write(b);
 		ofile.close();

--- a/XTS/WSAS/classes/com/arjuna/mwlabs/wsas/activity/ActivityHandleImple.java
+++ b/XTS/WSAS/classes/com/arjuna/mwlabs/wsas/activity/ActivityHandleImple.java
@@ -32,6 +32,7 @@
 package com.arjuna.mwlabs.wsas.activity;
 
 import com.arjuna.mwlabs.wsas.activity.ActivityImple;
+import java.nio.charset.StandardCharsets;
 
 import com.arjuna.mw.wsas.activity.ActivityHandle;
 
@@ -126,7 +127,7 @@ public class ActivityHandleImple implements ActivityHandle
 
     public String tid ()
     {
-	return ((_theActivity == null) ? null : new String(_theActivity.getGlobalId().value()));
+	return ((_theActivity == null) ? null : new String(_theActivity.getGlobalId().value(), StandardCharsets.UTF_8));
     }
 
     public final ActivityImple getActivity ()

--- a/XTS/WSAS/classes/com/arjuna/mwlabs/wsas/common/arjunacore/GlobalIdImple.java
+++ b/XTS/WSAS/classes/com/arjuna/mwlabs/wsas/common/arjunacore/GlobalIdImple.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.mwlabs.wsas.common.arjunacore;
 
+import java.nio.charset.StandardCharsets;
 import com.arjuna.ats.arjuna.common.Uid;
 
 import com.arjuna.mw.wsas.common.GlobalId;
@@ -50,14 +51,14 @@ public class GlobalIdImple extends Uid implements GlobalId
     {
 	super();
 
-	_value = stringForm().getBytes();
+	_value = stringForm().getBytes(StandardCharsets.UTF_8);
     }
     
     public GlobalIdImple (String id)
     {
 	super(id);
 
-	_value = stringForm().getBytes();
+	_value = stringForm().getBytes(StandardCharsets.UTF_8);
     }
     
     public byte[] value ()

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/CoordinatorIdImple.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/CoordinatorIdImple.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.mwlabs.wscf.model.sagas.arjunacore;
 
+import java.nio.charset.StandardCharsets;
 import com.arjuna.ats.arjuna.common.Uid;
 
 import com.arjuna.mw.wscf.common.CoordinatorId;
@@ -50,14 +51,14 @@ public class CoordinatorIdImple extends Uid implements CoordinatorId
     {
 	super();
 
-	_value = stringForm().getBytes();
+	_value = stringForm().getBytes(StandardCharsets.UTF_8);
     }
     
     public CoordinatorIdImple (String id)
     {
 	super(id);
 
-	_value = stringForm().getBytes();
+	_value = stringForm().getBytes(StandardCharsets.UTF_8);
     }
 
     public CoordinatorIdImple (Uid id)

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/CoordinatorIdImple.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/CoordinatorIdImple.java
@@ -31,6 +31,8 @@
 
 package com.arjuna.mwlabs.wscf.model.twophase.arjunacore;
 
+import java.nio.charset.StandardCharsets;
+
 import com.arjuna.ats.arjuna.common.Uid;
 
 import com.arjuna.mw.wscf.common.CoordinatorId;
@@ -57,14 +59,14 @@ public class CoordinatorIdImple extends Uid implements CoordinatorId
     {
 	super(id);
 
-	_value = stringForm().getBytes();
+	_value = stringForm().getBytes(StandardCharsets.UTF_8);
     }
 
     public CoordinatorIdImple (Uid id)
     {
 	super(id);
 
-	_value = stringForm().getBytes();
+	_value = stringForm().getBytes(StandardCharsets.UTF_8);
     }
     
     public byte[] value ()

--- a/blacktie/integration-tests/src/test/java/org/jboss/narayana/blacktie/jatmibroker/xatmi/CSControl.java
+++ b/blacktie/integration-tests/src/test/java/org/jboss/narayana/blacktie/jatmibroker/xatmi/CSControl.java
@@ -20,6 +20,7 @@ package org.jboss.narayana.blacktie.jatmibroker.xatmi;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -260,7 +261,7 @@ public abstract class CSControl extends TestCase {
                                 }
                                 pos = 0;
                             } else if (pos == buf.length) {
-                                ostream.write("missing synchronization sequence from service - force notify".getBytes("UTF-8"));
+                                ostream.write("missing synchronization sequence from service - force notify".getBytes(StandardCharsets.UTF_8));
                                 log.warn("missing synchronization sequence from service");
                                 synchronized (this) {
                                     this.notify();

--- a/blacktie/wildfly-blacktie/subsystem/src/main/java/org/codehaus/stomp/StompMarshaller.java
+++ b/blacktie/wildfly-blacktie/subsystem/src/main/java/org/codehaus/stomp/StompMarshaller.java
@@ -24,6 +24,7 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -79,7 +80,7 @@ public class StompMarshaller {
         // Add a newline to seperate the headers from the content.
         buffer.append(Stomp.NEWLINE);
 
-        os.write(buffer.toString().getBytes("UTF-8"));
+        os.write(buffer.toString().getBytes(StandardCharsets.UTF_8));
         os.write(stomp.getContent());
         os.write(END_OF_FRAME);
     }
@@ -187,6 +188,6 @@ public class StompMarshaller {
             baos.write(b);
         }
         byte[] sequence = baos.toByteArray();
-        return new String(sequence, "UTF-8");
+        return new String(sequence, StandardCharsets.UTF_8);
     }
 }

--- a/blacktie/wildfly-blacktie/subsystem/src/main/java/org/codehaus/stomp/jms/ProtocolConverter.java
+++ b/blacktie/wildfly-blacktie/subsystem/src/main/java/org/codehaus/stomp/jms/ProtocolConverter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -156,7 +157,7 @@ public class ProtocolConverter {
             log.debug("Caught an exception: ", e);
             // Let the stomp client know about any protocol errors.
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintWriter stream = new PrintWriter(new OutputStreamWriter(baos, "UTF-8"));
+            PrintWriter stream = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
             e.printStackTrace(stream);
             stream.close();
 
@@ -304,7 +305,7 @@ public class ProtocolConverter {
         StompFrame sf;
         if (msg == null) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PrintWriter stream = new PrintWriter(new OutputStreamWriter(baos, "UTF-8"));
+            PrintWriter stream = new PrintWriter(new OutputStreamWriter(baos, StandardCharsets.UTF_8));
             stream.print("No messages available");
             stream.close();
 

--- a/blacktie/wildfly-blacktie/subsystem/src/main/java/org/codehaus/stomp/jms/StompSession.java
+++ b/blacktie/wildfly-blacktie/subsystem/src/main/java/org/codehaus/stomp/jms/StompSession.java
@@ -19,6 +19,7 @@ package org.codehaus.stomp.jms;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -263,7 +264,7 @@ public class StompSession {
             bm.writeBytes(command.getContent());
             msg = bm;
         } else {
-            String text = new String(command.getContent(), "UTF-8");
+            String text = new String(command.getContent(), StandardCharsets.UTF_8);
             msg = session.createTextMessage(text);
         }
         copyStandardHeadersFromFrameToMessage(command, msg);
@@ -280,7 +281,7 @@ public class StompSession {
 
         if (message instanceof TextMessage) {
             TextMessage msg = (TextMessage) message;
-            command.setContent(msg.getText().getBytes("UTF-8"));
+            command.setContent(msg.getText().getBytes(StandardCharsets.UTF_8));
         } else if (message instanceof BytesMessage) {
 
             BytesMessage msg = (BytesMessage) message;

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/ObjStoreBrowserImpl.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/ObjStoreBrowserImpl.java
@@ -44,6 +44,8 @@ import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -54,13 +56,19 @@ import java.util.Set;
 
 public class ObjStoreBrowserImpl implements ObjStoreBrowserService{
     private ObjStoreBrowser osb;
-    private PrintStream printStream = new PrintStream(System.out, true);
+    private PrintStream printStream;
     private List<String> recordTypes = new ArrayList<String>();
     private String currentType = null;
     private String currentLog = "";
     private boolean attached = false;
 
     public ObjStoreBrowserImpl(ObjStoreBrowser osb) {
+        try {
+            printStream = new PrintStream(System.out, true, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            System.err.println("Encoding " + StandardCharsets.UTF_8.name() + " is not supported");
+            throw new IllegalStateException(StandardCharsets.UTF_8.name() + " is not supported");
+        }
         this.osb = osb;
     }
 


### PR DESCRIPTION
This PR fixes a bug came from static code analysis:
21994 Dm: Dubious method used In org.jboss.narayana.osgi.jta.internal.ObjStoreBrowserImpl.ObjStoreBrowserImpl (com.arjuna.ats.arjuna.tools.osb.mbean.ObjStoreBrowser): Found a call to a method which will perform a byte to String (or String to byte) conversion, and will assume that the default platform encoding is suitable)

The reason why the using default encoding could cause problems is that code behaves differently depending on the platform it runs on. Especially this is harmful if the data flows from one platform to another.

System default encoding could differ based on OS and geographical location.
Java uses parameter `-Dfile.encoding` to change default encoding to be different from system one. Value of this parameter is used whenever default encoding is needed to be used for program calls.

One example which come to my mind specifically with TM is if JVM crash occurs and object store is moved from one machine to another. Base on how node identifier is set it occurs that is decoded differently on each machine and that way transactions won't be recovered as the newly started node will not identify that is responsible for in-doubt ones.

It is considered bad practice to rely on the default platform encoding.

 !BLACKTIE !PERF !XTS !QA_JTS !QA_JTS_JDKORB