### PR TITLE
JBTM-2725 Fix race condition issue in ControlWrapper#rollback

### DIFF
--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/ControlWrapper.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/ControlWrapper.java
@@ -240,8 +240,11 @@ public class ControlWrapper implements Reapable
 	{
 		try
 		{
-			if (_controlImpl != null)
-				_controlImpl.getImplHandle().commit(report_heuristics);
+			if (_controlImpl != null) {
+				synchronized(_controlImpl) {
+					_controlImpl.getImplHandle().commit(report_heuristics);
+				}
+			}
 			else
 			{
 				Terminator t = null;
@@ -279,8 +282,11 @@ public class ControlWrapper implements Reapable
 	{
 		try
 		{
-			if (_controlImpl != null)
-				_controlImpl.getImplHandle().rollback();
+			if (_controlImpl != null) {
+				synchronized (_controlImpl) {
+					_controlImpl.getImplHandle().rollback();
+				}
+			}
 			else
 			{
 				Terminator t = null;


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2575

When the thread rolls back the transaction immediately after the reaper they both end in ControlWrapper#rollback method which is unexpected and leads to error in ArjunaTransactionImple class. It should be synchronized so that only one thread performs the ArjunaTransactionImple#rollback method. Synchronizing ControlWrapper#rollback method doesn't work as there are lot of those objects created for one transaction. I have synchronized the invocation on ControlImple object. As I understand the code this object is shared across the whole transaction. I have run the tests with the update and no error occurs.