### PR TITLE
JBTM-2724 Blacktie should not override maven-assembly-plugin version from parent

### DIFF
--- a/blacktie/blacktie/pom.xml
+++ b/blacktie/blacktie/pom.xml
@@ -101,8 +101,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <!-- this is required for EL5 as the newer versions of the assembly plugin do not allow us to update the zip -->
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>make-assembly</id>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2724
!XTS !PERF !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !MAIN