### PR TITLE
[BZ-1363836][JBTM-2703] When a transaction is committed at the same i…

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/SubordinateJTAXAResourceOrphanFilter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/SubordinateJTAXAResourceOrphanFilter.java
@@ -113,7 +113,7 @@ public class SubordinateJTAXAResourceOrphanFilter implements XAResourceOrphanFil
 						if (uid.notEquals(Uid.nullUid())) {
 							SubordinateAtomicAction tx = new SubordinateAtomicAction(uid, true);
 							XidImple transactionXid = (XidImple) tx.getXid();
-							if (transactionXid.isSameTransaction(recoveredResourceXid)) {
+							if (transactionXid != null && transactionXid.isSameTransaction(recoveredResourceXid)) {
 								if (jtaLogger.logger.isDebugEnabled()) {
 									jtaLogger.logger.debug("Found record for " + theXid);
 								}

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/tools/osb/mbean/jta/SubordinateActionBean.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/tools/osb/mbean/jta/SubordinateActionBean.java
@@ -38,6 +38,9 @@ public class SubordinateActionBean extends JTAActionBean implements SubordinateA
         try {
             SubordinateAtomicAction sub = (SubordinateAtomicAction) ra.getAction();
 
+            if (sub.getXid() == null) {
+                return "Error: The objectstore record could not be activated";
+            }
             return sub.getXid().toString();
         } catch (ClassCastException e) {
             if (tsLogger.logger.isDebugEnabled()) {

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
@@ -394,7 +394,7 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
 						if (parentNodeName != null) {
 							SubordinateAtomicAction saa = new SubordinateAtomicAction(uid, true);
 							XidImple loadedXid = (XidImple) saa.getXid();
-							if (loadedXid.getFormatId() == XATxConverter.FORMAT_ID) {
+							if (loadedXid != null && loadedXid.getFormatId() == XATxConverter.FORMAT_ID) {
 								String loadedXidSubordinateNodeName = XATxConverter.getSubordinateNodeName(loadedXid.getXID());
 								if (TxControl.getXANodeName().equals(loadedXidSubordinateNodeName)) {
 									if (parentNodeName.equals(saa.getParentNodeName())) {
@@ -416,7 +416,7 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
 						} else {
 							SubordinateAtomicAction saa = new SubordinateAtomicAction(uid, true);
 							XidImple loadedXid = (XidImple) saa.getXid();
-							if (loadedXid.getFormatId() == XATxConverter.FORMAT_ID) {
+							if (loadedXid != null && loadedXid.getFormatId() == XATxConverter.FORMAT_ID) {
 								String loadedXidSubordinateNodeName = XATxConverter.getSubordinateNodeName(loadedXid.getXID());
 								if (XATxConverter.getSubordinateNodeName(new XidImple(xid).getXID()).equals(loadedXidSubordinateNodeName)) {
 									if (Arrays.equals(loadedXid.getGlobalTransactionId(), xid.getGlobalTransactionId())) {

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/jca/SubordinateTxUnitTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/jca/SubordinateTxUnitTest.java
@@ -31,17 +31,22 @@
 
 package com.hp.mwtests.ts.jta.jca;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
 import com.arjuna.ats.arjuna.ObjectType;
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.subordinate.jca.SubordinateAtomicAction;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.subordinate.jca.TransactionImple;
+import com.arjuna.ats.jta.xa.XidImple;
+import org.junit.Test;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SubordinateTxUnitTest
 {
@@ -72,5 +77,86 @@ public class SubordinateTxUnitTest
         InputObjectState is = new InputObjectState(os);
         
         assertTrue(saa2.restore_state(is, ObjectType.ANDPERSISTENT));
+    }
+
+    @Test
+    public void testSAA() throws Exception {
+        SubordinateAtomicAction saa = new SubordinateAtomicAction();
+
+        saa.add(new XAResourceRecord(null, new XAResource() {
+            @Override
+            public void commit(Xid xid, boolean b) throws XAException {
+
+            }
+
+            @Override
+            public void end(Xid xid, int i) throws XAException {
+
+            }
+
+            @Override
+            public void forget(Xid xid) throws XAException {
+
+            }
+
+            @Override
+            public int getTransactionTimeout() throws XAException {
+                return 0;
+            }
+
+            @Override
+            public boolean isSameRM(XAResource xaResource) throws XAException {
+                return false;
+            }
+
+            @Override
+            public int prepare(Xid xid) throws XAException {
+                return 0;
+            }
+
+            @Override
+            public Xid[] recover(int i) throws XAException {
+                return new Xid[0];
+            }
+
+            @Override
+            public void rollback(Xid xid) throws XAException {
+
+            }
+
+            @Override
+            public boolean setTransactionTimeout(int i) throws XAException {
+                return false;
+            }
+
+            @Override
+            public void start(Xid xid, int i) throws XAException {
+
+            }
+        }, new XidImple(new Xid() {
+
+            @Override
+            public int getFormatId() {
+                return 0;
+            }
+
+            @Override
+            public byte[] getGlobalTransactionId() {
+                return new byte[0];
+            }
+
+            @Override
+            public byte[] getBranchQualifier() {
+                return new byte[0];
+            }
+        }), null));
+
+        saa.doPrepare();
+        SubordinateAtomicAction saa2 = new SubordinateAtomicAction(saa.get_uid(), true);
+        assertTrue(saa2.getXid() != null);
+
+        saa.doCommit();
+        SubordinateAtomicAction saa3 = new SubordinateAtomicAction(saa.get_uid(), true);
+        assertTrue(saa3.getXid() == null); // Since the SAA was committed the transaction log record will have been removed so the xid returned from getXid() should no longer be available and the intention is the SAA creator would disregard this instance
     }
 }


### PR DESCRIPTION
…nstance as a resource adapter/remote EJB calls XAT::recover() then you can get an NPE

upstream: jbosstm/narayana#1034
https://issues.jboss.org/browse/JBTM-2703
7.1.0: https://issues.jboss.org/browse/JBEAP-5540 (merged by jbosstm/narayana#1034)
7.0.z: https://issues.jboss.org/browse/JBEAP-5612 (merged by jbosstm/narayana#1050)
6.4.z: https://bugzilla.redhat.com/show_bug.cgi?id=1363836