### PR TITLE
[JBTM-2758][JBTM-2759] Locking on interned string

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/utils/FileProcessId.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/utils/FileProcessId.java
@@ -60,7 +60,7 @@ public int getpid ()
     {
 	if (FileProcessId.processId == 0)
 	{
-	    synchronized (FileProcessId.hexStart)
+	    synchronized (FileProcessId.lock)
 	    {
 		/*
 		 * All of this is just to ensure uniqueness!
@@ -123,5 +123,7 @@ public int getpid ()
 private static int processId = 0;
     
 private static final String hexStart = "0x";
+
+private static final Object lock = new Object();
     
 }


### PR DESCRIPTION
Based on static code analysis provided by Coverity tool proposing two fixes for locks on strings which is not recommended approach. String literals are centrally interned and could also be locked on by a library, which could lead to potentially have deadlocks or lock collisions with other code.

!QA_JTA !BLACKTIE !XTS !PERF