### PR TITLE
JBTM-2813 By default do not create JMX instrumentation for CosTransac…

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/osb/mbean/ObjStoreBrowser.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/osb/mbean/ObjStoreBrowser.java
@@ -84,6 +84,7 @@ public class ObjStoreBrowser implements ObjStoreBrowserMBean {
     private static OSBTypeHandler[] defaultJTSOsbTypes = {
             new OSBTypeHandler(
                     true,
+                    false, // by default do not probe for this type
                     "com.arjuna.ats.internal.jta.tools.osb.mbean.jts.JTSXAResourceRecordWrapper",
                     "com.arjuna.ats.internal.jta.tools.osb.mbean.jts.JTSXAResourceRecordWrapper",
                     "CosTransactions/XAResourceRecord",


### PR DESCRIPTION
…tion/XAResourceRecord record types
https://issues.jboss.org/browse/JBTM-2813
https://issues.jboss.org/browse/JBEAP-7735

!BLACKTIE !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !PERF

@ochaloup I changed the tooling such that CosTransaction/XAResourceRecord records types are not instrumented by default. That fixes the first assert failure in your test suite
```java
JcaInflowTransactionTestCase#rmerrWithRecovery
Assert.assertEquals("Recovery should not touch the txn as it was created by ...);
```

but now the assert a little later in the method is failing (which should be unrelated to the tooling instrumentation changes):
```java
instrumentedTestXAResource.assertMethodCalled("commit");
```