### PR TITLE
[JBTM-2836] Adding support for suppressed exceptions in prepare for heuristic

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -2724,11 +2724,12 @@ public class BasicAction extends StateManager
                         }
                     }
 
+                    addDeferredThrowables(record, deferredThrowables);
+
                     /*
                               * Prepare on this record failed - we are in trouble.
                               * Add the record back onto the pendingList and return.
                               */
-                    addDeferredThrowables(record, deferredThrowables);
 
                     record = insertRecord(pendingList, record);
 
@@ -2751,6 +2752,8 @@ public class BasicAction extends StateManager
 
                     if (reportHeuristics)
                         updateHeuristic(p, false);
+
+                    addDeferredThrowables(record, deferredThrowables);
 
                     /*
                     * Don't add to the prepared list. We process heuristics

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/basic/ExceptionDeferrerTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/basic/ExceptionDeferrerTest.java
@@ -86,6 +86,29 @@ public class ExceptionDeferrerTest {
         }
     }
 
+    @Test
+    public void testCheckDeferredPrepareHeuristic() throws Exception {
+        ThreadActionData.purgeActions();
+
+        TransactionImple tx = new TransactionImple(0);
+
+        tx.enlistResource(new FailureXAResource());
+
+        try {
+            tx.enlistResource(new FailureXAResource(FailLocation.prepare, FailType.XA_HEURHAZ));
+        } catch (final RollbackException ex) {
+            fail();
+        }
+
+        try {
+            tx.commit();
+
+            fail();
+        } catch (final HeuristicMixedException ex) {
+            assertEquals(XAException.XA_HEURHAZ, ((XAException) ex.getSuppressed()[0]).errorCode);
+        }
+    }
+
    @Test
    public void testCheckDeferredRollbackException () throws Exception
    {

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/common/FailureXAResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/common/FailureXAResource.java
@@ -27,7 +27,7 @@ import javax.transaction.xa.Xid;
 public class FailureXAResource implements XAResource
 {
     public enum FailLocation { none, prepare, commit, rollback, end, prepare_and_rollback };
-    public enum FailType { normal, timeout, heurcom, nota, inval, proto, rmfail, rollback, XA_RBCOMMFAIL, message };
+    public enum FailType { normal, timeout, heurcom, nota, inval, proto, rmfail, rollback, XA_RBCOMMFAIL, XA_HEURHAZ, message };
     
     public FailureXAResource ()
     {
@@ -105,11 +105,14 @@ public class FailureXAResource implements XAResource
 
     public int prepare(Xid xid) throws XAException
     {
-        if ((_locale == FailLocation.prepare) || (_locale == FailLocation.prepare_and_rollback)) {
-            if (_type == FailType.heurcom.message) {
+        if ((_locale == FailLocation.prepare) || (_locale == FailLocation.prepare_and_rollback))
+        {
+            if (_type == FailType.message) {
                 XAException xae = new XAException(XAException.XA_RBROLLBACK);
                 xae.initCause(new Throwable("test message"));
                 throw xae;
+            } else if(_type == FailType.XA_HEURHAZ) {// XA spec invalid error code
+                throw new XAException(XAException.XA_HEURHAZ);
             } else {
                 throw new XAException(XAException.XAER_INVAL);
             }


### PR DESCRIPTION
!BLACKTIE !PERF !QA_JTA !QA_JTS_JDKORB

This is a follow-up enhancement to enhance exception with suppressed ones in case that `prepare` of `XAResource` ends in heuristic state.

https://issues.jboss.org/browse/JBTM-2822
https://issues.jboss.org/browse/JBTM-2836