### PR TITLE
[JBTM-2852][JBTM-2853] integration with wildfly transaction client

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
@@ -26,8 +26,6 @@ package com.arjuna.ats.jta.cdi.transactional;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
 import com.arjuna.ats.jta.logging.jtaLogger;
 
-import org.jboss.tm.usertx.client.ServerVMClientUserTransaction;
-
 import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.inject.Intercepted;
 import javax.enterprise.inject.spi.Bean;
@@ -39,6 +37,8 @@ import javax.transaction.Status;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.Transactional;
+
+import org.jboss.tm.usertx.UserTransactionOperationsProvider;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -178,14 +178,16 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
     protected boolean setUserTransactionAvailable(boolean available) {
 
-        boolean previousUserTransactionAvailability = ServerVMClientUserTransaction.isAvailable();
-        ServerVMClientUserTransaction.setAvailability(available);
+        UserTransactionOperationsProvider userTransactionProvider =
+            jtaPropertyManager.getJTAEnvironmentBean().getUserTransactionOperationsProvider();
+        boolean previousUserTransactionAvailability = userTransactionProvider.getAvailability();
+        userTransactionProvider.setAvailability(available);
         return previousUserTransactionAvailability;
     }
 
     protected void resetUserTransactionAvailability(boolean previousUserTransactionAvailability) {
-
-        ServerVMClientUserTransaction.setAvailability(previousUserTransactionAvailability);
+        jtaPropertyManager.getJTAEnvironmentBean().getUserTransactionOperationsProvider()
+            .setAvailability(previousUserTransactionAvailability);
     }
 
     protected TransactionManager getTransactionManager() {

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactionScoped/TransactionScopedTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactionScoped/TransactionScopedTest.java
@@ -32,8 +32,10 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.arjuna.ats.jta.common.jtaPropertyManager;
 import javax.enterprise.context.ContextNotActiveException;
 import javax.inject.Inject;
+import javax.naming.InitialContext;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
@@ -44,7 +46,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.*;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -54,8 +55,6 @@ import static org.junit.Assert.assertTrue;
 public class TransactionScopedTest {
     @Inject
     UserTransaction userTransaction;
-
-    TransactionManager transactionManager;
 
     @Inject
     TestCDITransactionScopeBean testTxAssociationChangeBean;
@@ -90,8 +89,7 @@ public class TransactionScopedTest {
 
     //Based on test case from JTA 1.2 spec
     private void testTxAssociationChange() throws Exception {
-
-        transactionManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionManager transactionManager = com.arjuna.ats.jta.TransactionManager.transactionManager(new InitialContext());
 
         addTimestamp("begin1");
         userTransaction.begin(); //tx1 begun

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TransactionalImplTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TransactionalImplTest.java
@@ -377,6 +377,15 @@ public class TransactionalImplTest {
         testTransactionalBean.invokeWithNeverUseUserTransaction();
     }
 
+    /**
+     * <p>
+     * Expecting {@link IllegalStateException} as the bean's method calls
+     * {@link UserTransaction#getStatus()}. That's not permitted by JTA spec 1.2
+     * <p>
+     * <code> If an attempt is made to call any method of the UserTransaction interface from within the scope of a bean
+     * or method annotated with @Transactional and a Transactional.TxType other than NOT_SUPPORTED or NEVER,
+     * an IllegalStateException must be thrown</code>
+     */
     @Test(expected = IllegalStateException.class)
     public void testUseUserTransactionInRequiresNew() throws Exception {
 

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/Utills.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/Utills.java
@@ -1,7 +1,11 @@
 package com.hp.mwtests.ts.jta.cdi.transactional;
 
+import org.jboss.logging.Logger;
 import org.junit.Assert;
 
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
@@ -9,6 +13,7 @@ import javax.transaction.TransactionManager;
  * @author paul.robinson@redhat.com 08/05/2013
  */
 public class Utills {
+    private static final Logger LOGGER = Logger.getLogger(Utills.class);
 
 
     public static void assertTransactionActive(boolean expectActive) throws Exception {
@@ -37,7 +42,14 @@ public class Utills {
     }
 
     public static TransactionManager getTransactionManager() {
-        return com.arjuna.ats.jta.TransactionManager.transactionManager();
+        try {
+            return com.arjuna.ats.jta.TransactionManager.transactionManager(new InitialContext());
+        } catch (NamingException ne) {
+            String errorMsg = String.format("failure to lookup transaction manager at '%s'",
+                jtaPropertyManager.getJTAEnvironmentBean().getTransactionManagerJNDIContext());
+            LOGGER.error(errorMsg, ne);
+            throw new RuntimeException(errorMsg, ne);
+        }
     }
 
     public static Transaction getCurrentTransaction() throws Exception {

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/NarayanaSubordinateTransactionImporter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/NarayanaSubordinateTransactionImporter.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.internal.jta.transaction.arjunacore.jca;
+
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.Xid;
+import org.jboss.tm.SubordinateTransactionImporter;
+
+/**
+ * <p>
+ * Subordinate transaction importer which uses {@link SubordinationManager}
+ * to get the transaction being imported.
+ * <p>
+ * This is implementation of generic spi interface which is used when we import subordinate transaction
+ * to transaction manager implementation different to Narayana implementation.
+ * <p>
+ * This happens e.g. in WFLY where wildfly-transaction-client defines it's own transaction
+ * manager and we need to import transaction there.
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+public class NarayanaSubordinateTransactionImporter implements SubordinateTransactionImporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    public Transaction getTransaction(Xid xid) throws XAException {
+        return SubordinationManager.getTransactionImporter().importTransaction(xid);
+    }
+
+}

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/common/JTAEnvironmentBean.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/common/JTAEnvironmentBean.java
@@ -29,7 +29,12 @@ import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
+import org.jboss.tm.SubordinateTransactionImporter;
+import org.jboss.tm.usertx.UserTransactionOperationsProvider;
+import org.jboss.tm.usertx.client.ServerVMClientUserTransactionOperationsProvider;
+
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecordWrappingPlugin;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.NarayanaSubordinateTransactionImporter;
 import com.arjuna.ats.jta.recovery.XAResourceOrphanFilter;
 import com.arjuna.ats.jta.recovery.XAResourceRecovery;
 import com.arjuna.ats.jta.resources.XAResourceMap;
@@ -109,6 +114,14 @@ public class JTAEnvironmentBean implements JTAEnvironmentBeanMBean
 	private Map<String, Boolean> performImmediateCleanupOfCommitMarkableResourceBranchesMap = new HashMap<String, Boolean>();
 
 	private Map<String, Integer> commitMarkableResourceRecordDeleteBatchSizeMap = new HashMap<String, Integer>();
+
+	private static final String defaultSubordinateTransactionImporterClassName = NarayanaSubordinateTransactionImporter.class.getName();
+	private volatile String subordinateTransactionImporterClassName = defaultSubordinateTransactionImporterClassName;
+	private volatile SubordinateTransactionImporter subordinateTransactionImporter;
+
+	private static final String defaultTransactionOperationsProviderClassName = ServerVMClientUserTransactionOperationsProvider.class.getName();
+	private volatile String userTransactionOperationsProviderClassName = defaultTransactionOperationsProviderClassName;
+	private volatile UserTransactionOperationsProvider userTransactionOperationsProvider = null;
 
 	/**
      * Returns true if subtransactions are allowed.
@@ -1225,4 +1238,101 @@ public class JTAEnvironmentBean implements JTAEnvironmentBeanMBean
 			boolean notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches) {
 		this.notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches = notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches;
 	}
+
+	/**
+	 * <p>
+     * Setting name of class which is taken to be used as transaction importer
+     * when a {@link javax.transaction.xa.Xid} needs to be imported as a transaction to currently running TM.<br>
+     * The classname which is set here has to implement {@link org.jboss.tm.SubordinateTransactionImporter} interface.
+     * <p>
+     * When null is set then default provider implementation is used which is
+     * {@code #defaultSubordinateTransactionImporterClassName}.
+     */
+    public void setSubordinateTransactionImporterClassName(String importerClassName) {
+        synchronized(this) {
+            if (!subordinateTransactionImporterClassName.equals(importerClassName)) {
+                subordinateTransactionImporter = null;
+            }
+
+            if(importerClassName == null) {
+                subordinateTransactionImporterClassName = defaultSubordinateTransactionImporterClassName;
+            } else {
+                subordinateTransactionImporterClassName = importerClassName;
+            }
+        }
+    }
+
+    public String getSubordinateTransactionImporterClassName(){
+        return this.subordinateTransactionImporterClassName;
+    }
+
+    /**
+     * Importing subordinate transaction.
+     */
+    public SubordinateTransactionImporter getSubordinateTransactionImporter() {
+        if(subordinateTransactionImporter == null && subordinateTransactionImporterClassName != null) {
+            synchronized(this) {
+                if(subordinateTransactionImporter == null && subordinateTransactionImporterClassName != null) {
+                    subordinateTransactionImporter = ClassloadingUtility.loadAndInstantiateClass(SubordinateTransactionImporter.class,
+                        subordinateTransactionImporterClassName, null);
+                }
+            }
+        }
+
+        return subordinateTransactionImporter;
+    }
+
+    /**
+     * <p>
+     * Setting of class name that defines {@link UserTransactionOperationsProvider}.
+     * The provider is later used to get more info about {@link UserTransaction}.
+     * <p>
+     * When null is set then default provider implementation is used which is
+     * {@code #defaultTransactionOperationsProviderClassName}.
+     *
+     * @param providerClassName  class name implementing {@link UserTransactionOperationsProvider}
+     */
+    public void setUserTransactionOperationsProviderClassName(String providerClassName) {
+        synchronized (this) {
+            if (!userTransactionOperationsProviderClassName.equals(providerClassName)) {
+                userTransactionOperationsProvider = null;
+            }
+
+            if(providerClassName == null) {
+                userTransactionOperationsProviderClassName = defaultTransactionOperationsProviderClassName;
+            } else {
+                userTransactionOperationsProviderClassName = providerClassName;
+            }
+        }
+    }
+
+    /**
+     * Get class name that is used as {@link UserTransactionOperationsProvider}
+     *
+     * @return class name implementing {@link UserTransactionOperationsProvider}
+     */
+    public String getUserTransactionOperationsProviderClassName() {
+        return this.userTransactionOperationsProviderClassName;
+    }
+
+    /**
+     * Returning singleton instance of {@link UserTransactionOperationsProvider} instantiated based
+     * based on name specified by {@link #setUserTransactionOperationsProviderClassName(String)}.<br>
+     * When class name is redefined during runtime there should be instantiated new provider.
+     *
+     * @return instance of class implementing {@link UserTransactionOperationsProvider}
+     */
+    public UserTransactionOperationsProvider getUserTransactionOperationsProvider() {
+
+        if(userTransactionOperationsProvider == null && userTransactionOperationsProviderClassName != null) {
+            synchronized(this) {
+                if(userTransactionOperationsProvider == null && userTransactionOperationsProviderClassName != null) {
+                    userTransactionOperationsProvider = ClassloadingUtility.loadAndInstantiateClass(UserTransactionOperationsProvider.class,
+                        userTransactionOperationsProviderClassName, null);
+                }
+            }
+        }
+
+        return userTransactionOperationsProvider;
+    }
 }

--- a/common/tests/com/arjuna/common/tests/simple/EnvironmentBeanTest.java
+++ b/common/tests/com/arjuna/common/tests/simple/EnvironmentBeanTest.java
@@ -204,6 +204,8 @@ public class EnvironmentBeanTest
         setter.invoke(bean, new Object[] { proxy }); // setFoo()
         assertSame(getter.invoke(bean, new Object[] {}), proxy); // getFoo
 
+        // invoking setter via reflection with parameter being null
+        // assertions expect that there is simple getter and getter for class name both returning null
         setter.invoke(bean, new Object[] { null }); // setFoo()
         assertNull(getter.invoke(bean, new Object[] {})); // getFoo
         assertNull(classNameGetter.invoke(bean, new Object[] {})); // getFooClassName

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
     <version.org.jboss.arquillian.container.weld>1.0.0.CR8</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.arquillian.container.tomcat>1.0.0.CR7</version.org.jboss.arquillian.container.tomcat>
     <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
-    <version.org.jboss.jboss-transaction-spi>7.5.0.Final</version.org.jboss.jboss-transaction-spi>
+    <version.org.jboss.jboss-transaction-spi>7.5.1.Final-SNAPSHOT</version.org.jboss.jboss-transaction-spi>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
     <version.org.mockito>1.10.19</version.org.mockito>

--- a/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridgeParticipant.java
+++ b/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridgeParticipant.java
@@ -57,7 +57,7 @@ public class InboundBridgeParticipant implements Participant, Serializable {
             LOG.trace("InboundBridgeParticipant.prepare: xid=" + xid);
         }
 
-        startBridge();
+        startBridge(true);
 
         final Vote outcome = prepareSubordinate();
 
@@ -80,7 +80,7 @@ public class InboundBridgeParticipant implements Participant, Serializable {
             LOG.trace("InboundBridgeParticipant.commit: xid=" + xid);
         }
 
-        startBridge();
+        startBridge(false);
 
         try {
             commitSubordinate();
@@ -95,7 +95,7 @@ public class InboundBridgeParticipant implements Participant, Serializable {
             LOG.trace("InboundBridgeParticipant.commitOnePhase: xid=" + xid);
         }
 
-        startBridge();
+        startBridge(false);
 
         final Vote outcome = prepareSubordinate();
 
@@ -119,7 +119,7 @@ public class InboundBridgeParticipant implements Participant, Serializable {
             LOG.trace("InboundBridgeParticipant.rollback: xid=" + xid);
         }
 
-        startBridge();
+        startBridge(false);
 
         try {
             rollbackSubordinate();
@@ -128,11 +128,11 @@ public class InboundBridgeParticipant implements Participant, Serializable {
         }
     }
 
-    private void startBridge() {
+    private void startBridge(boolean resume) {
         final InboundBridge inboundBridge = getInboundBridge();
 
         if (inboundBridge != null) {
-            inboundBridge.start();
+            inboundBridge.start(resume);
         } else {
             throw new ParticipantException("Inbound bridge is not available.");
         }

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/common/AdvancedInboundBridgeResource.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/common/AdvancedInboundBridgeResource.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.narayana.rest.bridge.inbound.test.common;
 
+import javax.naming.InitialContext;
 import javax.transaction.Transaction;
 import javax.transaction.Transactional;
 import javax.ws.rs.GET;
@@ -66,7 +67,7 @@ public class AdvancedInboundBridgeResource {
         try {
             loggingXAResource = new LoggingXAResource();
 
-            Transaction t = TransactionManager.transactionManager().getTransaction();
+            Transaction t = TransactionManager.transactionManager(new InitialContext()).getTransaction();
             t.enlistResource(loggingXAResource);
 
         } catch (Exception e) {

--- a/txbridge/src/main/java/org/jboss/jbossts/txbridge/inbound/OptionalJaxWSTxInboundBridgeHandler.java
+++ b/txbridge/src/main/java/org/jboss/jbossts/txbridge/inbound/OptionalJaxWSTxInboundBridgeHandler.java
@@ -27,6 +27,8 @@ import com.arjuna.mw.wst11.TransactionManagerFactory;
 import com.arjuna.wst.SystemException;
 import org.jboss.jbossts.txbridge.utils.txbridgeLogger;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.Transaction;
 import javax.xml.ws.handler.Handler;
 import javax.xml.ws.handler.MessageContext;
@@ -110,8 +112,8 @@ public class OptionalJaxWSTxInboundBridgeHandler implements Handler {
         Transaction transaction = null;
 
         try {
-            transaction = TransactionManager.transactionManager().getTransaction();
-        } catch (javax.transaction.SystemException e) {
+            transaction = TransactionManager.transactionManager(new InitialContext()).getTransaction();
+        } catch (javax.transaction.SystemException | NamingException ignore) {
         }
 
         return transaction != null;

--- a/txbridge/src/main/java/org/jboss/jbossts/txbridge/outbound/AbstractJTAOverWSATHandler.java
+++ b/txbridge/src/main/java/org/jboss/jbossts/txbridge/outbound/AbstractJTAOverWSATHandler.java
@@ -24,6 +24,8 @@ package org.jboss.jbossts.txbridge.outbound;
 
 import java.util.Iterator;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.xml.soap.Name;
@@ -109,9 +111,9 @@ public abstract class AbstractJTAOverWSATHandler<C extends MessageContext> imple
         boolean isJTATransaction = false;
 
         try {
-            final Transaction transaction = TransactionManager.transactionManager().getTransaction();
+            final Transaction transaction = TransactionManager.transactionManager(new InitialContext()).getTransaction();
             isJTATransaction = transaction != null;
-        } catch (SystemException e) {
+        } catch (SystemException | NamingException ignore) {
         }
 
         return isJTATransaction;

--- a/txbridge/src/main/java/org/jboss/jbossts/txbridge/outbound/OutboundBridgeManager.java
+++ b/txbridge/src/main/java/org/jboss/jbossts/txbridge/outbound/OutboundBridgeManager.java
@@ -24,10 +24,12 @@
 package org.jboss.jbossts.txbridge.outbound;
 
 import com.arjuna.ats.jta.TransactionManager;
-import com.arjuna.ats.jta.transaction.Transaction;
 import com.arjuna.ats.arjuna.common.Uid;
 
 import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.RollbackException;
 import javax.transaction.Synchronization;
 import javax.transaction.xa.XAResource;
@@ -52,7 +54,8 @@ public class OutboundBridgeManager
     public static String BRIDGEWRAPPER_PREFIX = "txbridge_";
 
     // maps JTA Tx Id to OutboundBridge instance.
-    private static final ConcurrentMap<Uid, org.jboss.jbossts.txbridge.outbound.OutboundBridge> outboundBridgeMappings = new ConcurrentHashMap<Uid, org.jboss.jbossts.txbridge.outbound.OutboundBridge>();
+    private static final ConcurrentMap<Transaction, Uid> transctionToUidMappings = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Uid, org.jboss.jbossts.txbridge.outbound.OutboundBridge> outboundBridgeMappings = new ConcurrentHashMap<>();
 
     /**
      * Return an OutboundBridge instance that maps the current Thread's JTA transaction context
@@ -66,18 +69,21 @@ public class OutboundBridgeManager
 
         try
         {
-            Transaction transaction = (Transaction)TransactionManager.transactionManager().getTransaction();
+            Transaction transaction = (Transaction)TransactionManager.transactionManager(new InitialContext()).getTransaction();
 
-            Uid externalTxId = transaction.get_uid();
+            // generating new Uid to get it connected to incoming transaction
+            // the incoming transaction could come from different TM than Narayana is (e.g. Wildfly Transaction client)
+            transctionToUidMappings.putIfAbsent(transaction, new Uid());
+            Uid outboundMappingUid = transctionToUidMappings.get(transaction);
 
-            if(!outboundBridgeMappings.containsKey(externalTxId)) {
-                createMapping(transaction, externalTxId);
+            if(!outboundBridgeMappings.containsKey(outboundMappingUid)) {
+                createMapping(transaction, outboundMappingUid);
             }
 
-            return outboundBridgeMappings.get(externalTxId);
+            return outboundBridgeMappings.get(outboundMappingUid);
 
         }
-        catch(SystemException e)
+        catch(SystemException | NamingException e)
         {
             txbridgeLogger.logger.error(e);
         }
@@ -88,28 +94,30 @@ public class OutboundBridgeManager
     /**
      * Remove the mapping for the given externalTxId. This should be called for gc when the tx is finished.
      *
-     * @param externalTxId The JTA transaction identifier.
+     * @param outboundMappingUid identifier bound to the JTA transaction
      */
-    public static synchronized void removeMapping(Uid externalTxId)
+    public static synchronized void removeMapping(Uid outboundMappingUid)
     {
-        txbridgeLogger.logger.trace("OutboundBridgeManager.removeMapping(externalTxId="+externalTxId+")");
+        txbridgeLogger.logger.trace("OutboundBridgeManager.removeMapping(outboundMappingUid="+outboundMappingUid+")");
 
-        if(externalTxId != null) {
-            outboundBridgeMappings.remove(externalTxId);
+        if(outboundMappingUid != null) {
+            outboundBridgeMappings.remove(outboundMappingUid);
+            transctionToUidMappings.values().remove(outboundMappingUid);
         }
     }
 
     /**
      * Create a WS-AT transaction mapping and support objects for a given JTA transaction context.
      *
-     * @param externalTxId The JTA transaction identifier.
+     * @param externalTransaction  transaction where bridge resource will be registered to
+     * @param outboundMappingUid identifier bound to JTA transaction
      * @throws SystemException
      */
-    private static synchronized void createMapping(Transaction transaction, Uid externalTxId) throws SystemException
+    private static synchronized void createMapping(Transaction externalTransaction, Uid outboundMappingUid) throws SystemException
     {
-        txbridgeLogger.logger.trace("OutboundBridgeManager.createmapping(externalTxId="+externalTxId+")");
+        txbridgeLogger.logger.trace("OutboundBridgeManager.createmapping(outboundMappingUid="+outboundMappingUid+")");
 
-        if(outboundBridgeMappings.containsKey(externalTxId)) {
+        if(outboundBridgeMappings.containsKey(outboundMappingUid)) {
             return;
         }
 
@@ -117,13 +125,13 @@ public class OutboundBridgeManager
         BridgeWrapper bridgeWrapper = BridgeWrapper.create(BRIDGEWRAPPER_PREFIX, 0, false);
 
         org.jboss.jbossts.txbridge.outbound.OutboundBridge outboundBridge = new org.jboss.jbossts.txbridge.outbound.OutboundBridge(bridgeWrapper);
-        XAResource xaResource = new org.jboss.jbossts.txbridge.outbound.BridgeXAResource(externalTxId, bridgeWrapper);
+        XAResource xaResource = new org.jboss.jbossts.txbridge.outbound.BridgeXAResource(outboundMappingUid, bridgeWrapper);
         Synchronization synchronization = new org.jboss.jbossts.txbridge.outbound.BridgeSynchronization(bridgeWrapper);
 
         try
         {
-            transaction.enlistResource(xaResource);
-            transaction.registerSynchronization(synchronization);
+            externalTransaction.enlistResource(xaResource);
+            externalTransaction.registerSynchronization(synchronization);
         }
         catch(RollbackException e)
         {
@@ -131,6 +139,6 @@ public class OutboundBridgeManager
             throw new SystemException(e.toString());
         }
 
-        outboundBridgeMappings.put(externalTxId, outboundBridge);
+        outboundBridgeMappings.put(outboundMappingUid, outboundBridge);
     }
 }

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/service/TestServiceImpl.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/service/TestServiceImpl.java
@@ -32,6 +32,8 @@ import javax.jws.HandlerChain;
 import javax.jws.WebMethod;
 import javax.jws.WebService;
 import javax.jws.soap.SOAPBinding;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 
@@ -55,7 +57,7 @@ public class TestServiceImpl {
 
     @WebMethod(exclude = true)
     public void enlistSynchronization(int count) {
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionManager tm = getTransactionManager();
         try {
             for (int i = 0; i < count; i++) {
                 TestSynchronization testSynchronization = new TestSynchronization();
@@ -68,7 +70,7 @@ public class TestServiceImpl {
 
     @WebMethod(exclude = true)
     public void enlistXAResource(int count) {
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionManager tm = getTransactionManager();
         try {
             for (int i = 0; i < count; i++) {
                 TestXAResource testXAResource = new TestXAResource();
@@ -76,6 +78,15 @@ public class TestServiceImpl {
             }
         } catch (Exception e) {
             log.error("could not enlist", e);
+        }
+    }
+
+    private TransactionManager getTransactionManager() {
+        try {
+            return com.arjuna.ats.jta.TransactionManager.transactionManager(new InitialContext());
+        } catch (NamingException ne) {
+            throw new IllegalStateException("Not possible to find transaction manager, "
+                + "failed to initialize intial context. Cause: " + ne.getMessage(), ne);
         }
     }
 }


### PR DESCRIPTION
Changes to integrate with widlfy transaction client. The glue is done through interfaces from SPI and used here by implementation being set in JTAEnvironmentalBean and in SPI (still not sure if all the settings should not be only maintained in jta and not in SPI. maybe it would be more consistent).

https://issues.jboss.org/browse/JBTM-2852
https://issues.jboss.org/browse/JBTM-2853
https://issues.jboss.org/browse/WFTC-13
https://issues.jboss.org/browse/WFTC-15

!BLACKTIE !QA_JTA !QA_JTS_JDKORB !PERF

requires: https://github.com/jbosstm/jboss-transaction-spi/pull/19
requires: https://github.com/jbosstm/jboss-as/pull/65