### PR TITLE
JBTM-2853 + JBTM-2858: transaction importer

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/NarayanaSubordinateTransactionImporter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/NarayanaSubordinateTransactionImporter.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.internal.jta.transaction.arjunacore.jca;
+
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.Xid;
+import org.jboss.tm.SubordinateTransactionImporter;
+
+/**
+ * <p>
+ * Subordinate transaction importer which uses {@link SubordinationManager}
+ * to get the transaction being imported.
+ * <p>
+ * This is implementation of generic spi interface which is used when we import subordinate transaction
+ * to transaction manager implementation different to Narayana implementation.
+ * <p>
+ * This happens e.g. in WFLY where wildfly-transaction-client defines it's own transaction
+ * manager and we need to import transaction there.
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+public class NarayanaSubordinateTransactionImporter implements SubordinateTransactionImporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    public Transaction getTransaction(Xid xid) throws XAException {
+        return SubordinationManager.getTransactionImporter().importTransaction(xid);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
     <version.org.jboss.arquillian.container.weld>1.0.0.CR8</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.arquillian.container.tomcat>1.0.0.CR7</version.org.jboss.arquillian.container.tomcat>
     <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
-    <version.org.jboss.jboss-transaction-spi>7.5.1.Final</version.org.jboss.jboss-transaction-spi>
+    <version.org.jboss.jboss-transaction-spi>7.5.2.Final-SNAPSHOT</version.org.jboss.jboss-transaction-spi>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
     <version.org.mockito>1.10.19</version.org.mockito>

--- a/rts/at/bridge/pom.xml
+++ b/rts/at/bridge/pom.xml
@@ -225,9 +225,6 @@
                                 <server.jvm.args>${server.jvm.args}</server.jvm.args>
                                 <node.address>127.0.0.1</node.address>
                             </systemPropertyVariables>
-                            <excludes>
-                              <exclude>AnnotationsTestCase.java</exclude>
-                            </excludes> 
                         </configuration>
                     </plugin>
                 </plugins>

--- a/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridge.java
+++ b/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridge.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 
+import javax.naming.InitialContext;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -35,8 +36,8 @@ import javax.transaction.xa.Xid;
 import com.arjuna.ats.jta.recovery.SerializableXAResourceDeserializer;
 import org.jboss.logging.Logger;
 
-import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManager;
 import com.arjuna.ats.jta.TransactionManager;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
@@ -87,6 +88,7 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
         enlist(this);
     }
 
+
     public void start() {
         if (LOG.isTraceEnabled()) {
             LOG.trace("InboundBridge.start " + this);
@@ -99,7 +101,7 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
         }
 
         try {
-            TransactionManager.transactionManager().resume(transaction);
+            TransactionManager.transactionManager(new InitialContext()).resume(transaction);
         } catch (Exception e) {
             LOG.warn(e.getMessage(), e);
             throw new InboundBridgeException("Failed to start the bridge.", e);
@@ -112,8 +114,8 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
         }
 
         try {
-            TransactionManager.transactionManager().suspend();
-        } catch (SystemException e) {
+            TransactionManager.transactionManager(new InitialContext()).suspend();
+        } catch (Exception e) {
             LOG.warn(e.getMessage(), e);
             throw new InboundBridgeException("Failed to stop the bridge.", e);
         }
@@ -216,7 +218,7 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
         final Transaction transaction;
 
         try {
-            transaction = SubordinationManager.getTransactionImporter().importTransaction(xid);
+            transaction = jtaPropertyManager.getJTAEnvironmentBean().getSubordinateTransactionImporter().getTransaction(xid);
         } catch (XAException e) {
             LOG.warn(e.getMessage(), e);
             throw new InboundBridgeException("Failed to import transaction.", e);
@@ -351,5 +353,4 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
             LOG.trace("InboundBridge.start: xid=" + xid + ", i=" + i);
         }
     }
-
 }

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/common/AdvancedInboundBridgeResource.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/common/AdvancedInboundBridgeResource.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.narayana.rest.bridge.inbound.test.common;
 
+import javax.naming.InitialContext;
 import javax.transaction.Transaction;
 import javax.transaction.Transactional;
 import javax.ws.rs.GET;
@@ -66,7 +67,7 @@ public class AdvancedInboundBridgeResource {
         try {
             loggingXAResource = new LoggingXAResource();
 
-            Transaction t = TransactionManager.transactionManager().getTransaction();
+            Transaction t = TransactionManager.transactionManager(new InitialContext()).getTransaction();
             t.enlistResource(loggingXAResource);
 
         } catch (Exception e) {

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeTestCase.java
@@ -72,11 +72,12 @@ public class InboundBridgeTestCase extends AbstractTestCase {
 
         JSONArray jsonArray = getResourceInvocations(ADVANCED_INBOUND_BRIDGE_RESOURCE_URL);
 
-        Assert.assertEquals(4, jsonArray.length());
-        Assert.assertEquals("LoggingXAResource.start", jsonArray.get(0));
-        Assert.assertEquals("LoggingXAResource.end", jsonArray.get(1));
-        Assert.assertEquals("LoggingXAResource.prepare", jsonArray.get(2));
-        Assert.assertEquals("LoggingXAResource.commit", jsonArray.get(3));
+        Assert.assertEquals(5, jsonArray.length());
+        Assert.assertEquals("LoggingXAResource.setTransactionTimeout", jsonArray.get(0));
+        Assert.assertEquals("LoggingXAResource.start", jsonArray.get(1));
+        Assert.assertEquals("LoggingXAResource.end", jsonArray.get(2));
+        Assert.assertEquals("LoggingXAResource.prepare", jsonArray.get(3));
+        Assert.assertEquals("LoggingXAResource.commit", jsonArray.get(4));
     }
 
     @Test
@@ -87,10 +88,11 @@ public class InboundBridgeTestCase extends AbstractTestCase {
 
         JSONArray jsonArray = getResourceInvocations(ADVANCED_INBOUND_BRIDGE_RESOURCE_URL);
 
-        Assert.assertEquals(3, jsonArray.length());
-        Assert.assertEquals("LoggingXAResource.start", jsonArray.get(0));
-        Assert.assertEquals("LoggingXAResource.end", jsonArray.get(1));
-        Assert.assertEquals("LoggingXAResource.rollback", jsonArray.get(2));
+        Assert.assertEquals(4, jsonArray.length());
+        Assert.assertEquals("LoggingXAResource.setTransactionTimeout", jsonArray.get(0));
+        Assert.assertEquals("LoggingXAResource.start", jsonArray.get(1));
+        Assert.assertEquals("LoggingXAResource.end", jsonArray.get(2));
+        Assert.assertEquals("LoggingXAResource.rollback", jsonArray.get(3));
     }
 
     @Test
@@ -109,11 +111,12 @@ public class InboundBridgeTestCase extends AbstractTestCase {
         Assert.assertEquals("LoggingRestATResource.terminateParticipant(" + TxStatusMediaType.TX_COMMITTED + ")",
                 loggingRestATResourceInvocations.get(1));
 
-        Assert.assertEquals(4, loggingXAResourceInvocations.length());
-        Assert.assertEquals("LoggingXAResource.start", loggingXAResourceInvocations.get(0));
-        Assert.assertEquals("LoggingXAResource.end", loggingXAResourceInvocations.get(1));
-        Assert.assertEquals("LoggingXAResource.prepare", loggingXAResourceInvocations.get(2));
-        Assert.assertEquals("LoggingXAResource.commit", loggingXAResourceInvocations.get(3));
+        Assert.assertEquals(5, loggingXAResourceInvocations.length());
+        Assert.assertEquals("LoggingXAResource.setTransactionTimeout", loggingXAResourceInvocations.get(0));
+        Assert.assertEquals("LoggingXAResource.start", loggingXAResourceInvocations.get(1));
+        Assert.assertEquals("LoggingXAResource.end", loggingXAResourceInvocations.get(2));
+        Assert.assertEquals("LoggingXAResource.prepare", loggingXAResourceInvocations.get(3));
+        Assert.assertEquals("LoggingXAResource.commit", loggingXAResourceInvocations.get(4));
 
     }
 
@@ -131,10 +134,11 @@ public class InboundBridgeTestCase extends AbstractTestCase {
         Assert.assertEquals("LoggingRestATResource.terminateParticipant(" + TxStatusMediaType.TX_ROLLEDBACK + ")",
                 loggingRestATResourceInvocations.get(0));
 
-        Assert.assertEquals(3, loggingXAResourceInvocations.length());
-        Assert.assertEquals("LoggingXAResource.start", loggingXAResourceInvocations.get(0));
-        Assert.assertEquals("LoggingXAResource.end", loggingXAResourceInvocations.get(1));
-        Assert.assertEquals("LoggingXAResource.rollback", loggingXAResourceInvocations.get(2));
+        Assert.assertEquals(4, loggingXAResourceInvocations.length());
+        Assert.assertEquals("LoggingXAResource.setTransactionTimeout", loggingXAResourceInvocations.get(0));
+        Assert.assertEquals("LoggingXAResource.start", loggingXAResourceInvocations.get(1));
+        Assert.assertEquals("LoggingXAResource.end", loggingXAResourceInvocations.get(2));
+        Assert.assertEquals("LoggingXAResource.rollback", loggingXAResourceInvocations.get(3));
     }
 
 }

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeWithMultipleDeploymentsTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeWithMultipleDeploymentsTestCase.java
@@ -97,28 +97,32 @@ public class InboundBridgeWithMultipleDeploymentsTestCase extends AbstractTestCa
         JSONArray firstLoggingXAResourceInvocations = getResourceInvocations(FIRST_RESOURCE_URL);
         JSONArray secondLoggingXAResourceInvocations = getResourceInvocations(SECOND_RESOURCE_URL);
 
-        if (firstLoggingXAResourceInvocations.length() == 5) {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", firstLoggingXAResourceInvocations.get(1));
+        if (firstLoggingXAResourceInvocations.length() == 6) {
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", firstLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(1));
+            Assert.assertEquals("LoggingXAResource.isSameRM", firstLoggingXAResourceInvocations.get(2));
+            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(3));
+            Assert.assertEquals("LoggingXAResource.prepare", firstLoggingXAResourceInvocations.get(4));
+            Assert.assertEquals("LoggingXAResource.commit", firstLoggingXAResourceInvocations.get(5));
+
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", secondLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(1));
+            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(2));
+            Assert.assertEquals("LoggingXAResource.prepare", secondLoggingXAResourceInvocations.get(3));
+            Assert.assertEquals("LoggingXAResource.commit", secondLoggingXAResourceInvocations.get(4));
+        } else {
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", firstLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(1));
             Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(2));
             Assert.assertEquals("LoggingXAResource.prepare", firstLoggingXAResourceInvocations.get(3));
             Assert.assertEquals("LoggingXAResource.commit", firstLoggingXAResourceInvocations.get(4));
 
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.prepare", secondLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.commit", secondLoggingXAResourceInvocations.get(3));
-        } else {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.prepare", firstLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.commit", firstLoggingXAResourceInvocations.get(3));
-
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.prepare", secondLoggingXAResourceInvocations.get(3));
-            Assert.assertEquals("LoggingXAResource.commit", secondLoggingXAResourceInvocations.get(4));
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", secondLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(1));
+            Assert.assertEquals("LoggingXAResource.isSameRM", secondLoggingXAResourceInvocations.get(2));
+            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(3));
+            Assert.assertEquals("LoggingXAResource.prepare", secondLoggingXAResourceInvocations.get(4));
+            Assert.assertEquals("LoggingXAResource.commit", secondLoggingXAResourceInvocations.get(5));
         }
     }
 
@@ -133,24 +137,28 @@ public class InboundBridgeWithMultipleDeploymentsTestCase extends AbstractTestCa
         JSONArray firstLoggingXAResourceInvocations = getResourceInvocations(FIRST_RESOURCE_URL);
         JSONArray secondLoggingXAResourceInvocations = getResourceInvocations(SECOND_RESOURCE_URL);
 
-        if (firstLoggingXAResourceInvocations.length() == 4) {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", firstLoggingXAResourceInvocations.get(1));
+        if (firstLoggingXAResourceInvocations.length() == 5) {
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", firstLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(1));
+            Assert.assertEquals("LoggingXAResource.isSameRM", firstLoggingXAResourceInvocations.get(2));
+            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(3));
+            Assert.assertEquals("LoggingXAResource.rollback", firstLoggingXAResourceInvocations.get(4));
+
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", secondLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(1));
+            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(2));
+            Assert.assertEquals("LoggingXAResource.rollback", secondLoggingXAResourceInvocations.get(3));
+        } else {
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", firstLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(1));
             Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(2));
             Assert.assertEquals("LoggingXAResource.rollback", firstLoggingXAResourceInvocations.get(3));
 
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.rollback", secondLoggingXAResourceInvocations.get(2));
-        } else {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.rollback", firstLoggingXAResourceInvocations.get(2));
-
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.rollback", secondLoggingXAResourceInvocations.get(3));
+            Assert.assertEquals("LoggingXAResource.setTransactionTimeout", secondLoggingXAResourceInvocations.get(0));
+            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(1));
+            Assert.assertEquals("LoggingXAResource.isSameRM", secondLoggingXAResourceInvocations.get(2));
+            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(3));
+            Assert.assertEquals("LoggingXAResource.rollback", secondLoggingXAResourceInvocations.get(4));
         }
     }
 

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -294,7 +294,7 @@ function build_as {
   [ $? = 0 ] || fatal "git rebase failed"
 
   export MAVEN_OPTS="-XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC $MAVEN_OPTS"
-  JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" ./build.sh clean install -DskipTests -Dts.smoke=false -Dlicense.skipDownloadLicenses=true $IPV6_OPTS -Drelease=true -Dversion.org.jboss.narayana=5.5.4.Final-SNAPSHOT
+  JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" ./build.sh clean install -DskipTests -Dts.smoke=false -Dlicense.skipDownloadLicenses=true $IPV6_OPTS -Drelease=true -Dversion.org.jboss.narayana=5.5.4.Final-SNAPSHOT -Dversion.org.wildfly.transaction.client=1.0.0.Beta18
   [ $? = 0 ] || fatal "AS build failed"
   
   #Enable remote debugger

--- a/txbridge/pom.xml
+++ b/txbridge/pom.xml
@@ -306,10 +306,6 @@
 							<includes>
 								<include>**/*Tests.java</include>
 							</includes>
-              <excludes>
-								<exclude>InboundBasicTests.java</exclude>
-								<exclude>InboundCrashRecoveryTests.java</exclude>
-              </excludes>              
 							<!-- System properties passed to test cases -->
 							<systemPropertyVariables>
 								<!-- Used in arquillian.xml - arguments for all JBoss AS instances. -->

--- a/txbridge/src/main/java/org/jboss/jbossts/txbridge/inbound/OptionalJaxWSTxInboundBridgeHandler.java
+++ b/txbridge/src/main/java/org/jboss/jbossts/txbridge/inbound/OptionalJaxWSTxInboundBridgeHandler.java
@@ -27,6 +27,8 @@ import com.arjuna.mw.wst11.TransactionManagerFactory;
 import com.arjuna.wst.SystemException;
 import org.jboss.jbossts.txbridge.utils.txbridgeLogger;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.Transaction;
 import javax.xml.ws.handler.Handler;
 import javax.xml.ws.handler.MessageContext;
@@ -110,8 +112,8 @@ public class OptionalJaxWSTxInboundBridgeHandler implements Handler {
         Transaction transaction = null;
 
         try {
-            transaction = TransactionManager.transactionManager().getTransaction();
-        } catch (javax.transaction.SystemException e) {
+            transaction = TransactionManager.transactionManager(new InitialContext()).getTransaction();
+        } catch (javax.transaction.SystemException | NamingException ignore) {
         }
 
         return transaction != null;

--- a/txbridge/src/main/java/org/jboss/jbossts/txbridge/outbound/AbstractJTAOverWSATHandler.java
+++ b/txbridge/src/main/java/org/jboss/jbossts/txbridge/outbound/AbstractJTAOverWSATHandler.java
@@ -24,6 +24,8 @@ package org.jboss.jbossts.txbridge.outbound;
 
 import java.util.Iterator;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.xml.soap.Name;
@@ -109,9 +111,9 @@ public abstract class AbstractJTAOverWSATHandler<C extends MessageContext> imple
         boolean isJTATransaction = false;
 
         try {
-            final Transaction transaction = TransactionManager.transactionManager().getTransaction();
+            final Transaction transaction = TransactionManager.transactionManager(new InitialContext()).getTransaction();
             isJTATransaction = transaction != null;
-        } catch (SystemException e) {
+        } catch (SystemException | NamingException ignore) {
         }
 
         return isJTATransaction;

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/service/TestServiceImpl.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/service/TestServiceImpl.java
@@ -32,6 +32,8 @@ import javax.jws.HandlerChain;
 import javax.jws.WebMethod;
 import javax.jws.WebService;
 import javax.jws.soap.SOAPBinding;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 
@@ -54,8 +56,8 @@ public class TestServiceImpl {
     }
 
     @WebMethod(exclude = true)
-    public void enlistSynchronization(int count) {
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+    public void enlistSynchronization(int count) throws NamingException {
+        TransactionManager tm = getTransactionManager();
         try {
             for (int i = 0; i < count; i++) {
                 TestSynchronization testSynchronization = new TestSynchronization();
@@ -67,8 +69,8 @@ public class TestServiceImpl {
     }
 
     @WebMethod(exclude = true)
-    public void enlistXAResource(int count) {
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
+    public void enlistXAResource(int count) throws NamingException {
+        TransactionManager tm = getTransactionManager();
         try {
             for (int i = 0; i < count; i++) {
                 TestXAResource testXAResource = new TestXAResource();
@@ -77,5 +79,9 @@ public class TestServiceImpl {
         } catch (Exception e) {
             log.error("could not enlist", e);
         }
+    }
+
+    private TransactionManager getTransactionManager() throws NamingException {
+        return com.arjuna.ats.jta.TransactionManager.transactionManager(new InitialContext());
     }
 }


### PR DESCRIPTION
This adds implematation of `org.jboss.tm.SubordinateTransactionImporter` from SPI. This PR then uses it in RTS and XTS bridge to import transaction from propriate (Subordinate)TM implementation.

https://issues.jboss.org/browse/JBTM-2853
https://issues.jboss.org/browse/JBTM-2858

!PERF !BLACKTIE !QA_JTA !QA_JTS_JDKORB !MAIN

requires: https://github.com/jbosstm/jboss-as/pull/68
requires: https://github.com/jbosstm/jboss-transaction-spi/pull/21