### PR TITLE
[WFLY-8275][JBEAP-8993] jca inflow integration with wildfly transaction client

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
@@ -592,7 +592,12 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
 
 	public Transaction getTransaction(Xid xid) throws XAException {
 		// first see if the xid is a root coordinator
-		return TransactionImple.getTransaction(new XidImple(xid).getTransactionUid());
+		Transaction transaction = TransactionImple.getTransaction(new XidImple(xid).getTransactionUid());
+		// second see if the xid is a subordinate txn
+		if(transaction == null) {
+		    transaction = SubordinationManager.getTransactionImporter().getImportedTransaction(xid);
+		}
+		return transaction;
 	}
 
     public TransactionImportResult importTransaction(Xid xid, int timeoutIfNew) throws XAException {

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
@@ -1153,7 +1153,7 @@ public class TransactionImple implements javax.transaction.Transaction,
 	 * Creates if does not exist and adds to our internal mapping table.
 	 */
 
-	static final TransactionImple getTransaction ()
+	public static final TransactionImple getTransaction ()
 	{
 		TransactionImple tx = null;
 
@@ -1208,6 +1208,21 @@ public class TransactionImple implements javax.transaction.Transaction,
 
 		return tx;
 	}
+
+       public static final TransactionImple getTransaction(Uid id)
+       {
+            try
+            {
+                if (id != null)
+                    return (TransactionImple) _transactions.get(id);
+                else
+                    return null;
+            }
+            catch (Exception e)
+            {
+                return new TransactionImple(null);
+            }
+        }
 
 	public final void shutdown ()
 	{

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/jca/XATerminatorImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/jca/XATerminatorImple.java
@@ -61,6 +61,7 @@ import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManag
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporter;
 import com.arjuna.ats.internal.jta.transaction.jts.subordinate.jca.TransactionImple;
 import com.arjuna.ats.internal.jta.transaction.jts.subordinate.jca.coordinator.ServerTransaction;
+import com.arjuna.ats.internal.jta.utils.jtaxLogger;
 import com.arjuna.ats.jta.exceptions.UnexpectedConditionException;
 import com.arjuna.ats.jta.xa.XidImple;
 import org.jboss.tm.ExtendedJBossXATerminator;
@@ -452,7 +453,12 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
 
     public Transaction getTransaction(Xid xid) throws XAException {
         // first see if the xid is a root coordinator
-        return com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple.getTransaction(new XidImple(xid).getTransactionUid());
+        Transaction transaction = TransactionImple.getTransaction(new XidImple(xid).getTransactionUid());
+        // second see if the xid is a subordinate txn
+        if(transaction == null) {
+            transaction = SubordinationManager.getTransactionImporter().getImportedTransaction(xid);
+        }
+        return transaction;
     }
 
     public TransactionImportResult importTransaction(Xid xid, int timeoutIfNew) throws XAException {
@@ -465,12 +471,11 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
     }
 
     public Transaction getTransactionById(Object id) {
-        return com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple.getTransaction((Uid) id);
+        return TransactionImple.getTransaction((Uid) id);
     }
 
     public Object getCurrentTransactionId() {
-        com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple transaction =
-            com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple.getTransaction();
+        com.arjuna.ats.internal.jta.transaction.jts.TransactionImple transaction = TransactionImple.getTransaction();
         if (transaction == null)
             return null;
 
@@ -485,19 +490,13 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
         final Set<Xid> xidsToRecover = new HashSet<Xid>();
         if (recoverInFlight) {
             final TransactionImporter transactionImporter = SubordinationManager.getTransactionImporter();
-            if (transactionImporter instanceof com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporterImple) {
-                final Set<Xid> inFlightXids = ((com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporterImple) transactionImporter).getInflightXids(parentNodeName);
-                if (inFlightXids != null) {
-                    xidsToRecover.addAll(inFlightXids);
-                }
+            if (transactionImporter instanceof TransactionImporterImple) {
+                throw new UnsupportedOperationException(jtaxLogger.i18NLogger.get_not_supported());
             }
         }
         final javax.resource.spi.XATerminator xaTerminator = SubordinationManager.getXATerminator();
-        if (xaTerminator instanceof com.arjuna.ats.internal.jta.transaction.arjunacore.jca.XATerminatorImple) {
-            final Xid[] inDoubtTransactions = ((com.arjuna.ats.internal.jta.transaction.arjunacore.jca.XATerminatorImple) xaTerminator).doRecover(null, parentNodeName);
-            if (inDoubtTransactions != null) {
-                xidsToRecover.addAll(Arrays.asList(inDoubtTransactions));
-            }
+        if (xaTerminator instanceof XATerminatorImple) {
+            throw new UnsupportedOperationException(jtaxLogger.i18NLogger.get_not_supported());
         } else {
             final Xid[] inDoubtTransactions = xaTerminator.recover(recoveryFlags);
             if (inDoubtTransactions != null) {

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
@@ -260,6 +260,9 @@ public interface jtaxI18NLogger {
     @LogMessage(level = WARN)
     public void warn_could_not_load_class_will_wait_for_bottom_up(@Cause() ClassNotFoundException cnfe);
 
+	@Message(id = 24059, value = "Inflow recovery is not supported for JTS mode", format = MESSAGE_FORMAT)
+	String get_not_supported();
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in sequence. Don't reuse ids.


### PR DESCRIPTION
This change is part of fix of jca inflow integration with new transaction client. The fix is mainly done in WFLY integration (see https://github.com/jbosstm/jboss-as/pull/69) and change is needed in wfly client as well (see https://github.com/wildfly/wildfly-transaction-client/pull/17#issuecomment-283989487).

The point why the change is needed in Narayana (and what I would kindly ask for review here) is that wfly client checks if underlaying TM (for JBoss it's Narayana) knows about transaction. And the `XATerminator` implementation, as it was written, consider knowledge only of top level transactions but not subordinate. That's why I'm adding check for subordinate ones and those one is then returned to wfly transaction client which then works with it.

!BLACKTIE !PERF

https://issues.jboss.org/browse/JBEAP-8993
https://issues.jboss.org/browse/WFLY-8275

requires: https://github.com/jbosstm/jboss-as/pull/69
requires: https://github.com/jbosstm/jboss-transaction-spi/pull/23