### PR TITLE
JBTM-2853 + JBTM-2858: based on XTS handler and RTS filter

### DIFF
--- a/rts/at/bridge/pom.xml
+++ b/rts/at/bridge/pom.xml
@@ -225,9 +225,6 @@
                                 <server.jvm.args>${server.jvm.args}</server.jvm.args>
                                 <node.address>127.0.0.1</node.address>
                             </systemPropertyVariables>
-                            <excludes>
-                              <exclude>AnnotationsTestCase.java</exclude>
-                            </excludes> 
                         </configuration>
                     </plugin>
                 </plugins>

--- a/txbridge/pom.xml
+++ b/txbridge/pom.xml
@@ -306,10 +306,6 @@
 							<includes>
 								<include>**/*Tests.java</include>
 							</includes>
-              <excludes>
-								<exclude>InboundBasicTests.java</exclude>
-								<exclude>InboundCrashRecoveryTests.java</exclude>
-              </excludes>              
 							<!-- System properties passed to test cases -->
 							<systemPropertyVariables>
 								<!-- Used in arquillian.xml - arguments for all JBoss AS instances. -->


### PR DESCRIPTION
This is an alternative fix for https://github.com/jbosstm/narayana/pull/1138. In fact there are fixes only at WFLY side and fix in test here in Narayana.

The point is that transaction client is hooked after transaction is imported by txn bridge in Narayana. The RTS/XTS hok then import (pull) the transaction from Narayana to wildfly transaction client global context.

For the fix would wok it needs the fix of WFLY-8275 which is discussed at https://github.com/jbosstm/narayana/pull/1144. I mean this PR is dependent on PR#1144. That's why one of the commits refers to  	WFLY-8275 but it won't be part of this PR at the end.

requires: https://github.com/jbosstm/jboss-as/pull/70

!BLACKTIE !PERF NO_WIN

https://issues.jboss.org/browse/JBTM-2853
https://issues.jboss.org/browse/JBTM-2858
https://issues.jboss.org/browse/WFLY-8275