### PR TITLE
Removing unused variable declaration in xa JTA/JTSTest

### DIFF
--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
@@ -46,8 +46,6 @@ import javax.transaction.xa.Xid;
 
 import org.junit.Test;
 
-import com.arjuna.ats.jta.common.jtaPropertyManager;
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -69,7 +67,6 @@ public class JTATest {
         AtomicBoolean endCalled = new AtomicBoolean(false);
 
         assertTrue(theTransaction.enlistResource(new SimpleXAResource() {
-            public int id = 1;
             @Override
             public boolean isSameRM(XAResource xares) throws XAException {
                 try {
@@ -96,7 +93,6 @@ public class JTATest {
             }
         }));
         assertTrue(theTransaction.enlistResource(new SimpleXAResource() {
-            public int id = 1;
             @Override
             public boolean isSameRM(XAResource xares) throws XAException {
                 try {
@@ -123,7 +119,6 @@ public class JTATest {
             }
         }));
         assertTrue(theTransaction.enlistResource(new SimpleXAResource() {
-            public int id = 2;
             @Override
             public boolean isSameRM(XAResource xares) throws XAException {
                 return false;

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/xa/JTSTest.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/xa/JTSTest.java
@@ -42,7 +42,6 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-import com.hp.mwtests.ts.jta.xa.JTATest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,7 +96,6 @@ public class JTSTest {
         AtomicBoolean endCalled = new AtomicBoolean(false);
 
         assertTrue(theTransaction.enlistResource(new SimpleXAResource() {
-            public int id = 1;
             @Override
             public boolean isSameRM(XAResource xares) throws XAException {
                 try {
@@ -124,7 +122,6 @@ public class JTSTest {
             }
         }));
         assertTrue(theTransaction.enlistResource(new SimpleXAResource() {
-            public int id = 1;
             @Override
             public boolean isSameRM(XAResource xares) throws XAException {
                 try {
@@ -151,7 +148,6 @@ public class JTSTest {
             }
         }));
         assertTrue(theTransaction.enlistResource(new SimpleXAResource() {
-            public int id = 2;
             @Override
             public boolean isSameRM(XAResource xares) throws XAException {
                 return false;


### PR DESCRIPTION
Based on check of static code analysis got warning of unused variables at
ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/JTATest.java
ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/xa/JTSTest.java

I'm proposing here update to remove those unused ones.

This is only a minor update and I'm not sure how do you them. If you think it's not good/relevant to propose such adjustments, please, close this PR. thanks.

!QA_JTA !QA_JTS_JDKORB !BLACKTIE !XTS !PERF NO_WIN