### PR TITLE
[JBTM-2793] intermittent test failures on xts happening

### DIFF
--- a/XTS/localjunit/crash-recovery-tests/src/main/java/com/arjuna/qa/extension/BaseServerKillProcessor.java
+++ b/XTS/localjunit/crash-recovery-tests/src/main/java/com/arjuna/qa/extension/BaseServerKillProcessor.java
@@ -122,7 +122,9 @@ public abstract class BaseServerKillProcessor implements ServerKillProcessor {
         String scriptName = config.get("scriptName");
 
         String dir = "target" + File.separator + "surefire-reports" + File.separator + "processes";
-        runShellCommand("mkdir " + dir);
+        if(!new File(dir).exists()) {
+            runShellCommand("mkdir " + dir);
+        }
 
         String logFile = dir + File.separator + scriptName + ":" + testClass + "_" + processLogId++ + ".txt";
         runShellCommand(getProcessesCmd() + " > " + logFile);

--- a/XTS/localjunit/crash-recovery-tests/src/test/java/com/arjuna/qa/junit/BaseCrashTest.java
+++ b/XTS/localjunit/crash-recovery-tests/src/test/java/com/arjuna/qa/junit/BaseCrashTest.java
@@ -61,7 +61,7 @@ public class BaseCrashTest
     public void setUp()
     {
         javaVmArguments = System.getProperty("server.jvm.args")
-                .replaceAll("=listen","=script:target/test-classes/scripts/@BMScript@.btm,boot:target/lib/byteman.jar,listen");
+                .replaceAll("=listen","=script:target/test-classes/scripts/@BMScript@.btm,listen");
 
         javaVmArguments = javaVmArguments.replace("@BMScript@", scriptName);
 

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeRecoveryTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeRecoveryTestCase.java
@@ -56,7 +56,7 @@ public class InboundBridgeRecoveryTestCase extends AbstractTestCase {
     private static final String BYTEMAN_ARGUMENTS = "-Dorg.jboss.byteman.verbose"
             + " -Djboss.modules.system.pkgs=org.jboss.byteman"
             + " -Dorg.jboss.byteman.transform.all"
-            + " -javaagent:../lib/byteman.jar=script:scripts/@BMScript@.btm,boot:../lib/byteman.jar,listener:true";
+            + " -javaagent:../lib/byteman.jar=script:scripts/@BMScript@.btm,listener:true";
 
     @Deployment(name = DEPLOYMENT_NAME, testable = false, managed = false)
     public static WebArchive createTestArchive() {

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeRecoveryWithMultipleDeploymentsTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeRecoveryWithMultipleDeploymentsTestCase.java
@@ -65,7 +65,7 @@ public class InboundBridgeRecoveryWithMultipleDeploymentsTestCase extends Abstra
     private static final String BYTEMAN_ARGUMENTS = "-Dorg.jboss.byteman.verbose"
             + " -Djboss.modules.system.pkgs=org.jboss.byteman"
             + " -Dorg.jboss.byteman.transform.all"
-            + " -javaagent:../lib/byteman.jar=script:scripts/@BMScript@.btm,boot:../lib/byteman.jar,listener:true";
+            + " -javaagent:../lib/byteman.jar=script:scripts/@BMScript@.btm,listener:true";
 
     @Deployment(name = FIRST_DEPLOYMENT_NAME, testable = false, managed = false)
     public static WebArchive createFirstTestArchive() {

--- a/rts/at/integration/src/test/java/org/jboss/narayana/rest/integration/test/integration/RecoveryIntegrationTestCase.java
+++ b/rts/at/integration/src/test/java/org/jboss/narayana/rest/integration/test/integration/RecoveryIntegrationTestCase.java
@@ -37,7 +37,7 @@ public final class RecoveryIntegrationTestCase extends AbstractIntegrationTestCa
     private static final String VM_ARGUMENTS = System.getProperty("server.jvm.args").trim()
             + " -Dcom.arjuna.ats.arjuna.recovery.periodicRecoveryPeriod=" + RECOVERY_PERIOD;
 
-    private static final String BYTEMAN_ARGUMENTS = "-Dorg.jboss.byteman.verbose -Djboss.modules.system.pkgs=org.jboss.byteman -Dorg.jboss.byteman.transform.all -javaagent:lib/byteman.jar=script:scripts/@BMScript@.btm,boot:lib/byteman.jar,listener:true";
+    private static final String BYTEMAN_ARGUMENTS = "-Dorg.jboss.byteman.verbose -Djboss.modules.system.pkgs=org.jboss.byteman -Dorg.jboss.byteman.transform.all -javaagent:lib/byteman.jar=script:scripts/@BMScript@.btm,listener:true";
 
     @Deployment(name = DEPLOYMENT_NAME, managed = false, testable = false)
     public static WebArchive getDeployment() {


### PR DESCRIPTION
After investigation and discussion with Andrew I propose this change.

The `Rule` could be loaded from different class loader which could cause errors of the already loaded rule wouldn't been visible - different class loader means different `Rule` for the Byteman. The `boot:` option is not needed if we rule does not transform some classes from `rt.jar` which seems not being the case here.

This change/fix causes Byteman `-agent:` being loaded only by system classloader.

!QA_JTA !QA_JTS_JDKORB !BLACKTIE !PERF