### PR TITLE
JBTM 2623 Check Glassfish-to-Narayana interoperability

### DIFF
--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/interposition/resources/arjuna/ServerTopLevelAction.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/interposition/resources/arjuna/ServerTopLevelAction.java
@@ -89,7 +89,9 @@ import com.arjuna.ats.jts.logging.jtsLogger;
 public class ServerTopLevelAction extends ServerResource implements org.omg.CosTransactions.ResourceOperations
 {
 
-public ServerTopLevelAction (ServerControl control)
+    protected boolean _registered;
+
+    public ServerTopLevelAction (ServerControl control)
     {
 	super(control);
 
@@ -130,6 +132,7 @@ public ServerTopLevelAction (ServerControl control)
 	}
 	else
 	    _valid = false;
+        _registered = false;
     }
 
 public Resource getReference ()
@@ -591,6 +594,9 @@ protected boolean registerResource (Coordinator theCoordinator)
 
 	if (theCoordinator != null)
 	{
+	    if (_registered)
+		return true;
+
 	    try
 	    {
 		/*
@@ -599,6 +605,8 @@ protected boolean registerResource (Coordinator theCoordinator)
 		 */
 
 		RecoveryCoordinator recoveryCoord = theCoordinator.register_resource(_resourceRef);
+
+            _registered = true;
 
 		if (!_theControl.isWrapper())
 		{

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/interposition/resources/strict/ServerStrictTopLevelAction.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/interposition/resources/strict/ServerStrictTopLevelAction.java
@@ -53,8 +53,7 @@ public ServerStrictTopLevelAction (ServerControl control, boolean doRegister)
         jtsLogger.logger.trace("ServerStrictTopLevelAction::ServerStrictTopLevelAction (ServerControl, " + doRegister + " )");
     }
 
-	_registered = false;
-	_theResource = null;
+        _theResource = null;
 	
 	if (_theControl != null)
 	{
@@ -110,6 +109,4 @@ public String type ()
 	return "/Resources/Arjuna/ServerTopLevelAction/ServerStrictTopLevelAction";
     }
 
-private boolean _registered;
-    
 }

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/OTSManager.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/OTSManager.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.ats.jts;
 
+import com.arjuna.ats.jts.common.jtsPropertyManager;
 import org.omg.CORBA.BAD_PARAM;
 import org.omg.CORBA.SystemException;
 import org.omg.CosTransactions.Control;
@@ -315,7 +316,7 @@ public class OTSManager
 	com.arjuna.ats.internal.jts.ORBManager.setPOA(thePoa);
     }
     
-    public static final int serviceId = 0xDEADBEEF;
+    public static final int serviceId = jtsPropertyManager.getJTSEnvironmentBean().getTransactionServiceId();
 
     private static int _localSlotId = -1;
     private static int _receivedSlotId = -1;

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/common/JTSEnvironmentBean.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/common/JTSEnvironmentBean.java
@@ -54,6 +54,7 @@ public class JTSEnvironmentBean implements JTSEnvironmentBeanMBean
 
     @FullPropertyName(name = "com.arjuna.ats.jts.recovery.commitTransactionRetryLimit")
     private volatile int commitedTransactionRetryLimit = 3;
+    private volatile int transactionServiceId = 0xDEADBEEF;
 
 
     /**
@@ -414,5 +415,13 @@ public class JTSEnvironmentBean implements JTSEnvironmentBeanMBean
     public void setCommitedTransactionRetryLimit(int commitedTransactionRetryLimit)
     {
         this.commitedTransactionRetryLimit = commitedTransactionRetryLimit;
+    }
+
+    public int getTransactionServiceId() {
+        return transactionServiceId;
+    }
+
+    public void setTransactionServiceId(int transactionServiceId) {
+        this.transactionServiceId = transactionServiceId;
     }
 }


### PR DESCRIPTION
This PR replaces #1156 (it wasn't possible to change the base branch of the PR). It expands on the response I made to your comment: "Does any of this behaviour need to be cleaned up in StrictServerTLA?"

https://issues.jboss.org/browse/JBTM-2653
https://issues.jboss.org/browse/JBTM-2623

!PERF !QA_JTA !XTS !RTS NO_WIN !BLACKTIE AS_TESTS

These fixes enable transaction propagation between GlassFish and WildFly. It does not address recovery. See the parent JIRA (https://issues.jboss.org/browse/JBTM-2872) for details of what else need doing (including recovery and a quickstart).

Note also that the same set of fixes has been shown to work with WebSphere