### PR TITLE
[JBTM-2870] deferred suppressed throwables

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -1021,6 +1021,26 @@ public class TransactionImple implements javax.transaction.Transaction,
 	    
 	    return res;
 	}
+
+	/**
+	 * Returning list of throwables which are bound to transaction failure.
+	 * This method is intended to be used when handling some error states.
+	 * The result exception could be enriched with these returned ones.
+	 */
+	public List<Throwable> getDeferredThrowables()
+	{
+	    return _theTransaction.getDeferredThrowables();
+	}
+
+	/**
+	 * Method {@link #getDeferredThrowables()} will return list
+	 * of deferred throwables.
+	 *
+	 * @return true
+	 */
+	public boolean supportsDeferredThrowables() {
+	    return true;
+	}
 	
 	public String toString()
 	{

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/SubordinateTransaction.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/SubordinateTransaction.java
@@ -20,6 +20,8 @@
  */
 package com.arjuna.ats.internal.jta.transaction.arjunacore.jca;
 
+import java.util.List;
+
 import javax.transaction.HeuristicCommitException;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
@@ -113,4 +115,14 @@ public interface SubordinateTransaction extends ImportedTransaction
     public Xid baseXid();
 
     public Uid get_uid();
+
+    /**
+     * {@inheritDoc}
+     */
+    public List<Throwable> getDeferredThrowables();
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean supportsDeferredThrowables();
 }

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/TransactionImple.java
@@ -31,6 +31,8 @@
 
 package com.arjuna.ats.internal.jta.transaction.jts.subordinate.jca;
 
+import java.util.List;
+
 import javax.transaction.xa.Xid;
 
 import com.arjuna.ats.arjuna.common.Uid;
@@ -117,5 +119,22 @@ public class TransactionImple extends
     public boolean activated() {
         return true; // TODO: more sensible implementation.
     }
-	
+
+    /**
+     * JTS implementation does not work with deferred throwables
+     * as ORB protocol does not support adding a deferred throwable
+     * under the base throwable.
+     */
+    public List<Throwable> getDeferredThrowables() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Method {@link #getDeferredThrowables()} will throw {@link UnsupportedOperationException}.
+     *
+     * @return false
+     */
+    public boolean supportsDeferredThrowables() {
+        return false;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
     <version.org.jboss.arquillian.container.weld>1.0.0.CR8</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.arquillian.container.tomcat>1.0.0.CR7</version.org.jboss.arquillian.container.tomcat>
     <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
-    <version.org.jboss.jboss-transaction-spi>7.5.2.Final</version.org.jboss.jboss-transaction-spi>
+    <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
     <version.org.mockito>1.10.19</version.org.mockito>


### PR DESCRIPTION
Implementation of SPI added to `ImportedTransaction` to get seferred transaction and WFTC/ejb could put them under suppressed part.

https://issues.jboss.org/browse/JBTM-2870
https://bugzilla.redhat.com/show_bug.cgi?id=1435549
https://issues.jboss.org/browse/WFTC-9
https://issues.jboss.org/browse/JBEAP-9993
https://issues.jboss.org/browse/JBEAP-9996

!MAIN !QA_JTA !BLACKTIE !XTS !PERF NO_WIN