### PR TITLE
[JBTM-2870] adding getDeferredThrowables to SubordinateTransaction API

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -1021,6 +1021,26 @@ public class TransactionImple implements javax.transaction.Transaction,
 	    
 	    return res;
 	}
+
+	/**
+	 * Returning list of throwables which are bound to transaction failure.
+	 * This method is intended to be used when handling some error states.
+	 * The result exception could be enriched with these returned ones.
+	 */
+	public List<Throwable> getDeferredThrowables()
+	{
+	    return _theTransaction.getDeferredThrowables();
+	}
+
+	/**
+	 * Method {@link #getDeferredThrowables()} will return list
+	 * of deferred throwables.
+	 *
+	 * @return true
+	 */
+	public boolean supportsDeferredThrowables() {
+	    return true;
+	}
 	
 	public String toString()
 	{

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/SubordinateTransaction.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/SubordinateTransaction.java
@@ -20,6 +20,8 @@
  */
 package com.arjuna.ats.internal.jta.transaction.arjunacore.jca;
 
+import java.util.List;
+
 import javax.transaction.HeuristicCommitException;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
@@ -113,4 +115,41 @@ public interface SubordinateTransaction extends ImportedTransaction
     public Xid baseXid();
 
     public Uid get_uid();
+
+    /**
+     * <p>
+     * Listing deferred throwables gathered during the transaction processing.
+     * This list contains exceptions thrown by transaction resources when an error
+     * occurs.
+     * <p>
+     * Depending on the transaction stage the particular method returns only an error code e.g. {@link #doPrepare()}
+     * then the controller of the subordinate transaction throws its own exception and it could
+     * pack these throwables in some details.
+     * Other methods as {@link #doCommit()} throws an exception but those exception does not contain
+     * underlying exceptions like those coming from resource failures.
+     * <p>
+     * Normally exceptions taken by this call are put under suppressed part of the thrown exception.
+     *
+     * <p>
+     * JTS implementation of the {@link SubordinateTransaction} interface does not support the deferred throwable
+     * based on the limitation of ORB protocol. This method called on JTS implementation causes {@link UnsupportedOperationException}
+     * being thrown.
+     *
+     * @return list of throwables causing the failure state of the transaction
+     * @throws UnsupportedOperationException for JTS implementation
+     */
+    public List<Throwable> getDeferredThrowables();
+
+    /**
+     * <p>
+     * Informs if deferred throwables are supported by implementation. See {@link #getDeferredThrowables()}.
+     * <ul>
+     *   <li>JTS does not support deffered throwable, you can expect false.</li>
+     *   <li>JTA suppors deffered throwable, you can expect true.</li>
+     * </ul>
+     *
+     * @return true, if getting deffered throwables is supported by subordinate transaction implementation,
+     *   false otherwise
+     */
+    public boolean supportsDeferredThrowables();
 }

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/TransactionImple.java
@@ -31,6 +31,8 @@
 
 package com.arjuna.ats.internal.jta.transaction.jts.subordinate.jca;
 
+import java.util.List;
+
 import javax.transaction.xa.Xid;
 
 import com.arjuna.ats.arjuna.common.Uid;
@@ -138,5 +140,22 @@ public class TransactionImple extends
     public boolean activated() {
         return true; // TODO: more sensible implementation.
     }
-	
+
+    /**
+     * JTS implementation does not work with deferred throwables
+     * as ORB protocol does not support adding a deferred throwable
+     * under the base throwable.
+     */
+    public List<Throwable> getDeferredThrowables() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Method {@link #getDeferredThrowables()} will throw {@link UnsupportedOperationException}.
+     *
+     * @return false
+     */
+    public boolean supportsDeferredThrowables() {
+        return false;
+    }
 }


### PR DESCRIPTION
Implementation of SPI added to ImportedTransaction to get seferred transaction and WFTC/ejb could put them under suppressed part.

https://issues.jboss.org/browse/JBTM-2870
https://bugzilla.redhat.com/show_bug.cgi?id=1435549

!BLACKTIE !PERF