### PR TITLE
[JBTM-2799][JBTM-2806] javadoc for jms and tomcat modules

### DIFF
--- a/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/ConnectionClosingSynchronization.java
+++ b/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/ConnectionClosingSynchronization.java
@@ -28,12 +28,17 @@ import javax.jms.JMSException;
 import javax.transaction.Synchronization;
 
 /**
+ * Synchronization to close JMS connection at the end of the transaction.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class ConnectionClosingSynchronization implements Synchronization {
 
     private final Connection connection;
 
+    /**
+     * @param connection connection to be closed.
+     */
     public ConnectionClosingSynchronization(Connection connection) {
         this.connection = connection;
     }
@@ -43,6 +48,11 @@ public class ConnectionClosingSynchronization implements Synchronization {
         // Nothing to do
     }
 
+    /**
+     * Close the connection no matter what the status of the transaction is.
+     *
+     * @param status the status of the completed transaction
+     */
     @Override
     public void afterCompletion(int status) {
         if (jtaLogger.logger.isTraceEnabled()) {

--- a/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/ConnectionFactoryProxy.java
+++ b/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/ConnectionFactoryProxy.java
@@ -39,11 +39,21 @@ public class ConnectionFactoryProxy implements ConnectionFactory {
 
     private final TransactionHelper transactionHelper;
 
+    /**
+     * @param xaConnectionFactory factory to get XA connection instances, not null.
+     * @param transactionHelper utility to make transaction resources registration easier.
+     */
     public ConnectionFactoryProxy(XAConnectionFactory xaConnectionFactory, TransactionHelper transactionHelper) {
         this.xaConnectionFactory = xaConnectionFactory;
         this.transactionHelper = transactionHelper;
     }
 
+    /**
+     * Get XA connection from the provided factory and wrap it with {@link ConnectionProxy}.
+     *
+     * @return XA connection wrapped with {@link ConnectionProxy}.
+     * @throws JMSException if failure occurred creating XA connection.
+     */
     @Override
     public Connection createConnection() throws JMSException {
         Connection connection = new ConnectionProxy(xaConnectionFactory.createXAConnection(), transactionHelper);
@@ -55,6 +65,14 @@ public class ConnectionFactoryProxy implements ConnectionFactory {
         return connection;
     }
 
+    /**
+     * Get XA connection from the provided factory with credentials and wrap it with {@link ConnectionProxy}.
+     * 
+     * @param userName
+     * @param password
+     * @return XA connection wrapped with {@link ConnectionProxy}.
+     * @throws JMSException if failure occurred creating XA connection.
+     */
     @Override
     public Connection createConnection(String userName, String password) throws JMSException {
         Connection connection = new ConnectionProxy(xaConnectionFactory.createXAConnection(userName, password),

--- a/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/ConnectionProxy.java
+++ b/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/ConnectionProxy.java
@@ -47,11 +47,22 @@ public class ConnectionProxy implements Connection {
 
     private final TransactionHelper transactionHelper;
 
+    /**
+     * @param xaConnection XA connection which needs to be proxied.
+     * @param transactionHelper utility to make transaction resources registration easier.
+     */
     public ConnectionProxy(XAConnection xaConnection, TransactionHelper transactionHelper) {
         this.xaConnection = xaConnection;
         this.transactionHelper = transactionHelper;
     }
 
+    /**
+     * Simply create a session with an XA connection if there is no active transaction. Or create a proxied session and register
+     * it with an active transaction.
+     *
+     * @see SessionProxy
+     * @see Connection#createSession(boolean, int)
+     */
     @Override
     public Session createSession(boolean transacted, int acknowledgeMode) throws JMSException {
         if (transactionHelper.isTransactionAvailable()) {
@@ -61,6 +72,13 @@ public class ConnectionProxy implements Connection {
         return xaConnection.createSession(transacted, acknowledgeMode);
     }
 
+    /**
+     * Simply close the proxied connection if there is no active transaction. Or register a
+     * {@link ConnectionClosingSynchronization} if active transaction exists.
+     * 
+     * @throws JMSException if transaction service has failed (in unexpected way) to obtain transaction status,
+     *   or if synchronization registration, or connection closing has failed.
+     */
     @Override
     public void close() throws JMSException {
         if (transactionHelper.isTransactionAvailable()) {
@@ -75,53 +93,104 @@ public class ConnectionProxy implements Connection {
         }
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#getClientID()
+     */
     @Override
     public String getClientID() throws JMSException {
         return xaConnection.getClientID();
     }
 
+    /**
+     * @see Connection#setClientID(String)
+     */
     @Override
     public void setClientID(String clientID) throws JMSException {
         xaConnection.setClientID(clientID);
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#getMetaData()
+     */
     @Override
     public ConnectionMetaData getMetaData() throws JMSException {
         return xaConnection.getMetaData();
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#getExceptionListener()
+     */
     @Override
     public ExceptionListener getExceptionListener() throws JMSException {
         return xaConnection.getExceptionListener();
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#setExceptionListener(ExceptionListener)
+     */
     @Override
     public void setExceptionListener(ExceptionListener listener) throws JMSException {
         xaConnection.setExceptionListener(listener);
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#start()
+     */
     @Override
     public void start() throws JMSException {
         xaConnection.start();
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#stop()
+     */
     @Override
     public void stop() throws JMSException {
         xaConnection.stop();
     }
 
+    /**
+     * Delegate to {@link #xaConnection}
+     *
+     * @see Connection#createConnectionConsumer(Destination, String, ServerSessionPool, int)
+     */
     @Override
     public ConnectionConsumer createConnectionConsumer(Destination destination, String messageSelector,
             ServerSessionPool sessionPool, int maxMessages) throws JMSException {
         return xaConnection.createConnectionConsumer(destination, messageSelector, sessionPool, maxMessages);
     }
 
+    /**
+     * Delegate to {@link #xaConnection}.
+     *
+     * @see Connection#createDurableConnectionConsumer(Topic, String, String, ServerSessionPool, int)
+     */
     @Override
     public ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector,
             ServerSessionPool sessionPool, int maxMessages) throws JMSException {
         return xaConnection.createDurableConnectionConsumer(topic, subscriptionName, messageSelector, sessionPool, maxMessages);
     }
 
+    /**
+     * Create a proxied XA session and enlist its XA resource to the transaction.
+     * <p>
+     * If session's XA resource cannot be enlisted to the transaction, session is closed.
+     *
+     * @return XA session wrapped with {@link SessionProxy}.
+     * @throws JMSException if failure occurred creating XA session or registering its XA resource.
+     */
     private Session createAndRegisterSession() throws JMSException {
         XASession xaSession = xaConnection.createXASession();
         Session session = new SessionProxy(xaSession, transactionHelper);

--- a/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/SessionClosingSynchronization.java
+++ b/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/SessionClosingSynchronization.java
@@ -28,12 +28,17 @@ import javax.jms.Session;
 import javax.transaction.Synchronization;
 
 /**
+ * Synchronization to close JMS session at the end of the transaction.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class SessionClosingSynchronization implements Synchronization {
 
     private final Session session;
 
+    /**
+     * @param session session to be closed.
+     */
     public SessionClosingSynchronization(Session session) {
         this.session = session;
     }
@@ -43,6 +48,11 @@ public class SessionClosingSynchronization implements Synchronization {
         // Nothing to do
     }
 
+    /**
+     * Close the session no matter what the status of the transaction is.
+     *
+     * @param status the status of the completed transaction
+     */
     @Override
     public void afterCompletion(int status) {
         if (jtaLogger.logger.isTraceEnabled()) {

--- a/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/SessionProxy.java
+++ b/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/SessionProxy.java
@@ -46,6 +46,8 @@ import javax.transaction.Synchronization;
 import java.io.Serializable;
 
 /**
+ * Proxy session to wrap around provided {@link XASession}.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class SessionProxy implements Session {
@@ -54,11 +56,21 @@ public class SessionProxy implements Session {
 
     private final TransactionHelper transactionHelper;
 
+    /**
+     * @param xaSession XA session that needs to be proxied.
+     * @param transactionHelper utility to make transaction resources registration easier.
+     */
     public SessionProxy(XASession xaSession, TransactionHelper transactionHelper) {
         this.xaSession = xaSession;
         this.transactionHelper = transactionHelper;
     }
 
+    /**
+     * Simply close proxied session if there is no active transaction. Or if transaction exists, delist session's XA resource
+     * and register a {@link SessionClosingSynchronization} to close the proxied session.
+     * 
+     * @throws JMSException
+     */
     @Override
     public void close() throws JMSException {
         if (transactionHelper.isTransactionAvailable()) {

--- a/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/TransactionHelper.java
+++ b/ArjunaJTA/jms/src/main/java/org/jboss/narayana/jta/jms/TransactionHelper.java
@@ -26,16 +26,51 @@ import javax.transaction.Synchronization;
 import javax.transaction.xa.XAResource;
 
 /**
+ * Utility class to make transaction status checking and resources registration easier.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public interface TransactionHelper {
 
+    /**
+     * Check if transaction is active. If error occurs wrap an original exception with {@link JMSException}.
+     *
+     * @return whether transaction is active or not.
+     * @throws JMSException if transaction service has failed in unexpected way to obtain transaction status
+     */
     boolean isTransactionAvailable() throws JMSException;
 
+    /**
+     * Register synchronization with a current transaction. If error occurs wrap an original exception with
+     * {@link JMSException}.
+     * 
+     * @param synchronization synchronization to be registered.
+     * @throws JMSException if error occurred registering synchronization
+     *   that occurs when transaction service fails in an unexpected way
+     *   or when the transaction is marked for rollback only
+     *   or when transaction is in a state where {@link Synchronization} callbacks cannot be registered
+     */
     void registerSynchronization(Synchronization synchronization) throws JMSException;
 
+    /**
+     * Enlist XA resource to a current transaction. If error occurs wrap an original exception with {@link JMSException}.
+     * 
+     * @param xaResource resource to be enlisted.
+     * @throws JMSException if error occurred enlisting resource
+     *   that occurs when transaction service fails in an unexpected way
+     *   or when the transaction is marked for rollback only
+     *   or when transaction is in a state where resources cannot be enlisted.
+     */
     void registerXAResource(XAResource xaResource) throws JMSException;
 
+    /**
+     * Delist XA resource from a current transaction. If error occurs wrap an original exception with {@link JMSException}.
+     * 
+     * @param xaResource resource to be delisted.
+     * @throws JMSException if error occurred delisting resource.
+     *   that occurs when transaction service fails in an unexpected way
+     *   or when transaction is in a state where resources cannot be delisted.
+     */
     void deregisterXAResource(XAResource xaResource) throws JMSException;
 
 }

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -135,6 +135,14 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Tomcat module javadocs -->
+    <dependency>
+      <groupId>org.jboss.narayana.tomcat</groupId>
+      <artifactId>tomcat-jta</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Ensure these are in the distribution -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
@@ -283,6 +291,10 @@
                     <group>
                       <title>RTS</title>
                       <packages>org.jboss.jbossts.star*</packages>
+                    </group>
+                    <group>
+                      <title>Tomcat JTA</title>
+                      <packages>org.jboss.narayana.tomcat.jta</packages>
                     </group>
                   </groups>
                 </configuration>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -143,6 +143,20 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- JMS module javadocs -->
+    <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>jms</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.jms</groupId>
+      <artifactId>jboss-jms-api_1.1_spec</artifactId>
+      <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec}</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Ensure these are in the distribution -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
@@ -274,7 +288,7 @@
                   <groups>
                     <group>
                       <title>Core</title>
-                      <packages>com.arjuna.ats.arjuna*:com.arjuna.ats.jdbc*:com.arjuna.ats.txoj*:com.arjuna.common*</packages>
+                      <packages>com.arjuna.ats.arjuna*:com.arjuna.ats.jdbc*:com.arjuna.ats.txoj*:com.arjuna.common*:org.jboss.narayana.jta.jms</packages>
                     </group>
                     <group>
                       <title>JTA</title>

--- a/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/NarayanaJtaServletContextListener.java
+++ b/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/NarayanaJtaServletContextListener.java
@@ -47,6 +47,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Class responsible for configuring and initializing Narayana JTA services for the servlet container.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class NarayanaJtaServletContextListener implements ServletContextListener {
@@ -64,6 +66,25 @@ public class NarayanaJtaServletContextListener implements ServletContextListener
     private static final List<String> DEFAULT_EXPIRY_SCANNERS = Arrays
             .asList(ExpiredTransactionStatusManagerScanner.class.getName());
 
+    /**
+     * Initialize and start Narayana JTA services.
+     * <p>
+     * During the setup node identifier, recovery modules, orphan filters, and expiry scanners are setup. Configuration file
+     * will be used to get initial values. If one doesn't exist, following defaults will be used.
+     * The settings from configuration file is transfered to {@link com.arjuna.ats.jta.common.JTAEnvironmentBean} where runtime
+     * configuration resides.
+     * <p>
+     * <ul>
+     * <li>Node identifier: "1"
+     * <li>Recovery modules: {@link AtomicActionRecoveryModule}, {@link XARecoveryModule}
+     * <li>Orphan filters: {@link JTATransactionLogXAResourceOrphanFilter}, {@link JTANodeNameXAResourceOrphanFilter}
+     * <li>Expiry scanners: {@link ExpiredTransactionStatusManagerScanner}
+     * </ul>
+     * <p>
+     * After setup recovery manager, transaction status manager, and transaction reaper are started.
+     * 
+     * @param servletContextEvent containing the ServletContext that is being initialized
+     */
     @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {
         LOGGER.fine("Initializing Narayana");
@@ -76,6 +97,12 @@ public class NarayanaJtaServletContextListener implements ServletContextListener
         TransactionReaper.instantiate();
     }
 
+    /**
+     * First, stop recovery manager, transaction status manager, and transaction reaper. Then, remove transactional driver from
+     * jdbc driver manager's list.
+     * 
+     * @param servletContextEvent containing the ServletContext that is being destroyed
+     */
     @Override
     public void contextDestroyed(ServletContextEvent servletContextEvent) {
         LOGGER.fine("Disabling Narayana");
@@ -91,6 +118,9 @@ public class NarayanaJtaServletContextListener implements ServletContextListener
         });
     }
 
+    /**
+     * If node identifier wasn't set by property manager, then set default {@link #DEFAULT_NODE_IDENTIFIER}.
+     */
     private void initNodeIdentifier() {
         if (arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifier() == null) {
             LOGGER.warning("Node identifier was not set. Setting it to the default value: " + DEFAULT_NODE_IDENTIFIER);
@@ -105,6 +135,9 @@ public class NarayanaJtaServletContextListener implements ServletContextListener
                 .setXaRecoveryNodes(Collections.singletonList(arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifier()));
     }
 
+    /**
+     * If recovery modules were not set by property manager, then set defaults {@link #DEFAULT_RECOVERY_MODULES}.
+     */
     private void initRecoveryModules() {
         if (!recoveryPropertyManager.getRecoveryEnvironmentBean().getRecoveryModuleClassNames().isEmpty()) {
             return;
@@ -114,6 +147,9 @@ public class NarayanaJtaServletContextListener implements ServletContextListener
         recoveryPropertyManager.getRecoveryEnvironmentBean().setRecoveryModuleClassNames(DEFAULT_RECOVERY_MODULES);
     }
 
+    /**
+     * If orphan filters were not set by property manager, then set defaults {@link #DEFAULT_ORPHAN_FILTERS}.
+     */
     private void initOrphanFilters() {
         if (!jtaPropertyManager.getJTAEnvironmentBean().getXaResourceOrphanFilterClassNames().isEmpty()) {
             return;
@@ -123,6 +159,9 @@ public class NarayanaJtaServletContextListener implements ServletContextListener
         jtaPropertyManager.getJTAEnvironmentBean().setXaResourceOrphanFilterClassNames(DEFAULT_ORPHAN_FILTERS);
     }
 
+    /**
+     * If expiry scanners were not set by property manager, then set defaults {@link #DEFAULT_EXPIRY_SCANNERS}.
+     */
     private void initExpiryScanners() {
         if (!recoveryPropertyManager.getRecoveryEnvironmentBean().getExpiryScannerClassNames().isEmpty()) {
             return;

--- a/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionManagerFactory.java
+++ b/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionManagerFactory.java
@@ -30,12 +30,24 @@ import javax.naming.spi.ObjectFactory;
 import java.util.Hashtable;
 
 /**
+ * Object factory to create instances of {@link javax.transaction.TransactionManager}.
+ * 
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class TransactionManagerFactory implements ObjectFactory {
 
+    /**
+     * User internal factory method to instantiate new or reuse existing instance of
+     * {@link javax.transaction.TransactionManager}.
+     * 
+     * @param obj
+     * @param name
+     * @param nameCtx
+     * @param environment
+     * @return instance of {@link javax.transaction.TransactionManager} or {@code null} if instantiation has failed.
+     */
     @Override
-    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) throws Exception {
+    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) {
         return jtaPropertyManager.getJTAEnvironmentBean().getTransactionManager();
     }
 

--- a/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionSynchronizationRegistryFactory.java
+++ b/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/TransactionSynchronizationRegistryFactory.java
@@ -30,12 +30,25 @@ import javax.naming.spi.ObjectFactory;
 import java.util.Hashtable;
 
 /**
+ * Object factory to create instances of {@link javax.transaction.TransactionSynchronizationRegistry}.
+ * 
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class TransactionSynchronizationRegistryFactory implements ObjectFactory {
 
+    /**
+     * User internal factory method to instantiate new or reuse existing instance of
+     * {@link javax.transaction.TransactionSynchronizationRegistry}.
+     * 
+     * @param obj
+     * @param name
+     * @param nameCtx
+     * @param environment
+     * @return instance of {@link javax.transaction.TransactionSynchronizationRegistry} or {@code null} if instantiation has
+     *         failed.
+     */
     @Override
-    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) throws Exception {
+    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) {
         return jtaPropertyManager.getJTAEnvironmentBean().getTransactionSynchronizationRegistry();
     }
 

--- a/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/UserTransactionFactory.java
+++ b/tomcat/tomcat-jta/src/main/java/org/jboss/narayana/tomcat/jta/UserTransactionFactory.java
@@ -30,12 +30,23 @@ import javax.naming.spi.ObjectFactory;
 import java.util.Hashtable;
 
 /**
+ * Object factory to create instances of {@link javax.transaction.UserTransaction}.
+ *
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class UserTransactionFactory implements ObjectFactory {
 
+    /**
+     * User internal factory method to instantiate new or reuse existing instance of {@link javax.transaction.UserTransaction}.
+     *
+     * @param obj
+     * @param name
+     * @param nameCtx
+     * @param environment
+     * @return instance of {@link javax.transaction.UserTransaction} or {@code null} if instantiation has failed.
+     */
     @Override
-    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) throws Exception {
+    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) {
         return jtaPropertyManager.getJTAEnvironmentBean().getUserTransaction();
     }
 


### PR DESCRIPTION
Splitting the pull request of adding recovery for compensation to two parts (this and https://github.com/jbosstm/narayana/pull/1166). This one rip of the part where javadoc for jms and tomcat modules were added. The original PR#1109 then consist only from changes for compensation.

https://issues.jboss.org/browse/JBTM-2799
https://issues.jboss.org/browse/JBTM-2806

!PERF !QA_JTA !QA_JTS_JDKORB !BLACKTIE !XTS NO_WIN !RTS

Split of the PR: https://github.com/jbosstm/narayana/pull/1109
The other part of split PR: https://github.com/jbosstm/narayana/pull/1166