### PR TITLE
[JBTM-2892] Not IndexOutOfBound exception when enlist on subordinate txn

### DIFF
--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
@@ -120,7 +120,7 @@ public class XAResourceRecord extends com.arjuna.ArjunaOTS.OTSAbstractRecordPOA
 
 		if (params != null)
 		{
-			if (params.length >= XACONNECTION)
+			if (params.length > XACONNECTION)
 			{
 				if (params[XACONNECTION] instanceof RecoverableXAConnection)
 					_recoveryObject = (RecoverableXAConnection) params[XACONNECTION];

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
@@ -546,7 +546,7 @@ public class TransactionImple implements javax.transaction.Transaction,
 
 		if (params != null)
 		{
-			if (params.length >= XAMODIFIER + 1)
+			if (params.length > XAMODIFIER)
 			{
 				if (params[XAMODIFIER] instanceof XAModifier)
 				{
@@ -861,6 +861,8 @@ public class TransactionImple implements javax.transaction.Transaction,
 			 * the resouce. So, for safety mark the transaction as rollback
 			 * only.
 			 */
+
+			jtaxLogger.i18NLogger.warn_could_not_enlist_xar(xaRes, params, e);
 
 			markRollbackOnly();
 

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
@@ -270,6 +270,10 @@ public interface jtaxI18NLogger {
 	@LogMessage(level = WARN)
 	void warn_could_not_end_xar(XAResource xar, @Cause() XAException e1);
 
+	@Message(id = 24061, value = "Could not enlist XA resource {0} with params {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_could_not_enlist_xar(XAResource xar, Object[] params, @Cause() Exception e1);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in sequence. Don't reuse ids.


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2892

When method TransactionImple.enlistResource is called with empty params array `IndexOutOfBound` is emitted.

The check for array length does not correspond by one with index hit.

!BLACKTIE !XTS !PERF NO_WIN !RTS