### PR TITLE
[JBTM-2897] on Transaction.registerSynchronization throw System not NullPointer

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -364,14 +364,14 @@ public class TransactionImple implements javax.transaction.Transaction,
 			throws javax.transaction.RollbackException,
 			java.lang.IllegalStateException, javax.transaction.SystemException
 	{
-		if (jtaLogger.logger.isTraceEnabled()) {
-            jtaLogger.logger.trace("TransactionImple.registerSynchronization - Class: " + sync.getClass() + " HashCode: " + sync.hashCode() + " toString: " + sync);
-        }
-
 		if (sync == null)
 		{
 			throw new javax.transaction.SystemException(
 					"TransactionImple.registerSynchronization - " + jtaLogger.i18NLogger.get_transaction_arjunacore_nullparam() );
+		}
+
+		if (jtaLogger.logger.isTraceEnabled()) {
+			jtaLogger.logger.trace("TransactionImple.registerSynchronization - Class: " + sync.getClass() + " HashCode: " + sync.hashCode() + " toString: " + sync);
 		}
 
 		registerSynchronizationImple(new SynchronizationImple(sync, false));

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
@@ -449,14 +449,14 @@ public class TransactionImple implements javax.transaction.Transaction,
 			throws javax.transaction.RollbackException,
 			java.lang.IllegalStateException, javax.transaction.SystemException
 	{
-        if (jtaxLogger.logger.isTraceEnabled()) {
-            jtaxLogger.logger.trace("TransactionImple.registerSynchronization - Class: " + sync.getClass() + " HashCode: " + sync.hashCode() + " toString: " + sync);
-        }
-
 		if (sync == null)
 			throw new javax.transaction.SystemException(
                     "TransactionImple.registerSynchronization - "
                             + jtaxLogger.i18NLogger.get_jtax_transaction_jts_nullparam());
+
+		if (jtaxLogger.logger.isTraceEnabled()) {
+			jtaxLogger.logger.trace("TransactionImple.registerSynchronization - Class: " + sync.getClass() + " HashCode: " + sync.hashCode() + " toString: " + sync);
+		}
 
         registerSynchronizationImple(new ManagedSynchronizationImple(sync));
 	}


### PR DESCRIPTION
Having trace logging enabled causes `NullPointerException` being thrown instead of `SystemException` when `Synchronization` is null passed to `Transaction.enlistSynchronization`

https://issues.jboss.org/browse/JBTM-2897

!BLACKTIE !XTS !PERF NO_WIN !RTS