### PR TITLE
JBTM-2766 Updated to ensure when JPA is used with pooling that we onl…

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ConnectionSynchronization.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ConnectionSynchronization.java
@@ -45,9 +45,10 @@ import javax.transaction.Synchronization;
 public class ConnectionSynchronization implements Synchronization
 {
 
-    public ConnectionSynchronization (ConnectionImple conn)
+	public ConnectionSynchronization (ConnectionImple conn, boolean needsClose)
     {
 	_theConnection = conn;
+	this.needsClose = needsClose;
     }
 
     public void afterCompletion(int status)
@@ -55,7 +56,7 @@ public class ConnectionSynchronization implements Synchronization
 		try
 		{
 			if (_theConnection != null) {
-				_theConnection.closeImpl();
+				_theConnection.closeImpl(needsClose);
 			}
 		}
 		catch (Exception ex)
@@ -69,5 +70,6 @@ public class ConnectionSynchronization implements Synchronization
     }
 
     private ConnectionImple _theConnection = null;
+	private final boolean needsClose;
 }
 

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/DirectRecoverableConnection.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/DirectRecoverableConnection.java
@@ -246,7 +246,8 @@ public class DirectRecoverableConnection implements RecoverableXAConnection, Con
             if (_theConnection != null)
             {
                 _theConnection.close();
-                _theConnection = null;
+				_theConnection = null;
+				reset();
             }
         }
     }

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/IndirectRecoverableConnection.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/IndirectRecoverableConnection.java
@@ -252,8 +252,8 @@ public class IndirectRecoverableConnection implements RecoverableXAConnection, C
             if (_theConnection != null)
             {
                 _theConnection.close();
-                _theConnection = null;
-                _theXAResource = null;
+				_theConnection = null;
+				reset();
             }
         }
     }

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ProvidedXADataSourceConnection.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ProvidedXADataSourceConnection.java
@@ -173,8 +173,7 @@ public class ProvidedXADataSourceConnection implements ConnectionControl, Transa
             {
                 _theConnection.close();
                 _theConnection = null;
-				_theXAResource = null;
-				_theTransaction = null;
+				reset();
             }
         }
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2766

This was additional checks that were discovered during the creation of a JPA quickstart: 
https://github.com/jbosstm/quickstart/pull/196

!BLACKTIE !XTS !RTS !AS_TESTS NO_WIN !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB