### PR TITLE
Make sure empty credentials are not used to create new connection

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/DirectRecoverableConnection.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/DirectRecoverableConnection.java
@@ -360,7 +360,7 @@ public class DirectRecoverableConnection implements RecoverableXAConnection, Con
 		    _theDataSource = _dynamicConnection.getDataSource(_dbName);
 		}
 
-		if ((_user == null) && (_passwd == null))
+		if ((_user == null || _user.isEmpty()) && (_passwd == null || _passwd.isEmpty()))
 		{
 		    if (jdbcLogger.logger.isTraceEnabled()) {
                 jdbcLogger.logger.trace("DirectRecoverableConnection - getting connection with no user");

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/IndirectRecoverableConnection.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/IndirectRecoverableConnection.java
@@ -379,7 +379,7 @@ public class IndirectRecoverableConnection implements RecoverableXAConnection, C
 	    if (_theDataSource == null)
 		createDataSource();
 
-	    if ((_user == null) && (_passwd == null))
+	    if ((_user == null || _user.isEmpty()) && (_passwd == null || _passwd.isEmpty()))
 		_theConnection = _theDataSource.getXAConnection();
 	    else
 		_theConnection = _theDataSource.getXAConnection(_user, _passwd);

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ProvidedXADataSourceConnection.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ProvidedXADataSourceConnection.java
@@ -270,7 +270,7 @@ public class ProvidedXADataSourceConnection implements ConnectionControl, Transa
 
 	    try
 	    {
-		if ((_user == null) && (_passwd == null))
+		if ((_user == null || _user.isEmpty()) && (_passwd == null || _passwd.isEmpty()))
 		{
 		    if (jdbcLogger.logger.isTraceEnabled()) {
                 jdbcLogger.logger.trace("DirectRecoverableConnection - getting connection with no user");

--- a/ArjunaJTA/jdbc/tests/classes/com/arjuna/ats/internal/jdbc/DirectRecoverableConnectionUnitTest.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/arjuna/ats/internal/jdbc/DirectRecoverableConnectionUnitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arjuna.ats.internal.jdbc;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public class DirectRecoverableConnectionUnitTest {
+
+    @Test
+    public void shouldGetConnectionWithNullCredentials() throws SQLException {
+        DirectRecoverableConnection connection = new DirectRecoverableConnection("testDb", null, null, TestDynamicClass.class.getName(), null);
+        XAConnection xaConnection = connection.getConnection();
+        assertEquals(TestDynamicClass.lastInstance.getXaConnection(), xaConnection);
+        verify(TestDynamicClass.lastInstance.getDataSource("testDb")).getXAConnection();
+    }
+
+    @Test
+    public void shouldGetConnectionWithEmptyCredentials() throws SQLException {
+        DirectRecoverableConnection connection = new DirectRecoverableConnection("testDb", "", "", TestDynamicClass.class.getName(), null);
+        XAConnection xaConnection = connection.getConnection();
+        assertEquals(TestDynamicClass.lastInstance.getXaConnection(), xaConnection);
+        verify(TestDynamicClass.lastInstance.getDataSource("testDb")).getXAConnection();
+    }
+
+    @Test
+    public void shouldGetConnectionWithCredentials() throws SQLException {
+        DirectRecoverableConnection connection = new DirectRecoverableConnection("testDb", "testName", "testPass", TestDynamicClass.class.getName(), null);
+        XAConnection xaConnection = connection.getConnection();
+        assertEquals(TestDynamicClass.lastInstance.getXaConnection(), xaConnection);
+        verify(TestDynamicClass.lastInstance.getDataSource("testDb")).getXAConnection(eq("testName"), eq("testPass"));
+    }
+
+    public static class TestDynamicClass implements DynamicClass {
+
+        static TestDynamicClass lastInstance;
+
+        @Mock
+        private XADataSource xaDataSource;
+
+        @Mock
+        private XAConnection xaConnection;
+
+        public TestDynamicClass() {
+            MockitoAnnotations.initMocks(this);
+            lastInstance = this;
+        }
+
+        @Override
+        public XADataSource getDataSource(String dbName) throws SQLException {
+            when(xaDataSource.getXAConnection()).thenReturn(xaConnection);
+            when(xaDataSource.getXAConnection("testName", "testPass")).thenReturn(xaConnection);
+            return xaDataSource;
+        }
+
+        public XAConnection getXaConnection() {
+            return xaConnection;
+        }
+    }
+
+}

--- a/ArjunaJTA/jdbc/tests/classes/com/arjuna/ats/internal/jdbc/ProvidedXADataSourceConnectionUnitTest.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/arjuna/ats/internal/jdbc/ProvidedXADataSourceConnectionUnitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arjuna.ats.internal.jdbc;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public class ProvidedXADataSourceConnectionUnitTest {
+
+    @Mock
+    private ConnectionImple connectionImple;
+
+    @Mock
+    private XADataSource xaDataSource;
+
+    @Mock
+    private XAConnection xaConnection;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldGetConnectionWithNullCredentials() throws SQLException {
+        when(xaDataSource.getXAConnection()).thenReturn(xaConnection);
+        ProvidedXADataSourceConnection connection = new ProvidedXADataSourceConnection("testDb", null, null, xaDataSource, connectionImple);
+        assertEquals(xaConnection, connection.getConnection());
+        verify(xaDataSource).getXAConnection();
+    }
+
+    @Test
+    public void shouldGetConnectionWithEmptyCredentials() throws SQLException {
+        when(xaDataSource.getXAConnection()).thenReturn(xaConnection);
+        ProvidedXADataSourceConnection connection = new ProvidedXADataSourceConnection("testDb", "", "", xaDataSource, connectionImple);
+        assertEquals(xaConnection, connection.getConnection());
+        verify(xaDataSource).getXAConnection();
+    }
+
+    @Test
+    public void shouldGetConnectionWithCredentials() throws SQLException {
+        when(xaDataSource.getXAConnection(eq("testName"), eq("testPass"))).thenReturn(xaConnection);
+        ProvidedXADataSourceConnection connection = new ProvidedXADataSourceConnection("testDb", "testName", "testPass", xaDataSource, connectionImple);
+        assertEquals(xaConnection, connection.getConnection());
+        verify(xaDataSource).getXAConnection(eq("testName"), eq("testPass"));
+    }
+
+}


### PR DESCRIPTION
!BLACKTIE !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !PERF
https://issues.jboss.org/browse/JBTM-2902