### PR TITLE
setRollbackOnly() should be called on any exception if rollbackOn() is empty. Not only RuntimeException.

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorMandatory.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorMandatory.java
@@ -47,12 +47,12 @@ public class TransactionalInterceptorMandatory extends TransactionalInterceptorB
     }
 
     @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
+    public Object intercept(InvocationContext ic) throws Throwable {
         return super.intercept(ic);
     }
 
     @Override
-    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Throwable {
         if (tx == null) {
             throw new TransactionalException(jtaLogger.i18NLogger.get_tx_required(), new TransactionRequiredException());
         }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNever.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNever.java
@@ -47,7 +47,7 @@ public class TransactionalInterceptorNever extends TransactionalInterceptorBase 
     }
 
     @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
+    public Object intercept(InvocationContext ic) throws Throwable {
         return super.intercept(ic);
     }
 

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNotSupported.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorNotSupported.java
@@ -43,7 +43,7 @@ public class TransactionalInterceptorNotSupported extends TransactionalIntercept
     }
 
     @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
+    public Object intercept(InvocationContext ic) throws Throwable {
         return super.intercept(ic);
     }
 

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequired.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequired.java
@@ -43,12 +43,12 @@ public class TransactionalInterceptorRequired extends TransactionalInterceptorBa
     }
 
     @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
+    public Object intercept(InvocationContext ic) throws Throwable {
         return super.intercept(ic);
     }
 
     @Override
-    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Throwable {
         if (tx == null) {
             return invokeInOurTx(ic, tm);
         } else {

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequiresNew.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequiresNew.java
@@ -43,12 +43,12 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
     }
 
     @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
+    public Object intercept(InvocationContext ic) throws Throwable {
         return super.intercept(ic);
     }
 
     @Override
-    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Throwable {
         if (tx != null) {
             tm.suspend();
             try {

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorSupports.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorSupports.java
@@ -43,12 +43,12 @@ public class TransactionalInterceptorSupports extends TransactionalInterceptorBa
     }
 
     @AroundInvoke
-    public Object intercept(InvocationContext ic) throws Exception {
+    public Object intercept(InvocationContext ic) throws Throwable {
         return super.intercept(ic);
     }
 
     @Override
-    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
+    protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Throwable {
         if (tx == null) {
             return invokeInNoTx(ic);
         } else {


### PR DESCRIPTION
If rollbackOn() is empty or if pure @Transactional, the transaction is marked for rollback if RuntimeException was thrown. Any exception should mark transaction for rollback.