### PR TITLE
[JBTM-2905] moving JCAServerTransactionHeaderReader to a runtime package

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/osb/mbean/ObjStoreBrowser.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/osb/mbean/ObjStoreBrowser.java
@@ -95,7 +95,7 @@ public class ObjStoreBrowser implements ObjStoreBrowserMBean {
                     "com.arjuna.ats.internal.jta.tools.osb.mbean.jts.JCAServerTransactionWrapper",
                     "com.arjuna.ats.internal.jta.tools.osb.mbean.jts.JTSActionBean",
                     SUBORDINATE_ATI_TYPE,
-                    "com.hp.mwtests.ts.jta.jts.tools.JCAServerTransactionHeaderReader"
+                    "com.arjuna.ats.internal.jta.tools.osb.mbean.jts.JCAServerTransactionHeaderReader"
             ),
             new OSBTypeHandler(
                     true,

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/tools/osb/mbean/jts/JCAServerTransactionHeaderReader.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/tools/osb/mbean/jts/JCAServerTransactionHeaderReader.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package com.hp.mwtests.ts.jta.jts.tools;
+package com.arjuna.ats.internal.jta.tools.osb.mbean.jts;
 
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.tools.osb.mbean.HeaderState;
@@ -31,11 +31,11 @@ import java.io.IOException;
 /**
  * Header reader for {@link com.arjuna.ats.internal.jta.transaction.jts.subordinate.jca.coordinator.ServerTransaction}
  * records.
- * 
+ *
  * @author Mike Musgrove
  */
 /**
- * @deprecated as of 5.0.5.Final In a subsequent release we will change packages names in order to 
+ * @deprecated as of 5.0.5.Final In a subsequent release we will change packages names in order to
  * provide a better separation between public and internal classes.
  */
 @Deprecated // in order to provide a better separation between public and internal classes.

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/tools/NewTypeTest.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/tools/NewTypeTest.java
@@ -32,6 +32,7 @@ import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.tools.osb.mbean.OSBTypeHandler;
 import com.arjuna.ats.arjuna.tools.osb.mbean.ObjStoreBrowser;
 import com.arjuna.ats.arjuna.tools.osb.mbean.UidWrapper;
+import com.arjuna.ats.internal.jta.tools.osb.mbean.jts.JCAServerTransactionHeaderReader;
 /**
  * An example of how to instrument new record types.
  *


### PR DESCRIPTION
Moving the reader to location where is build to jts jar distributed as part of Narayana release.

https://issues.jboss.org/browse/JBTM-2905

!QA_JTS_JDKORB !BLACKTIE !XTS !PERF !RTS