### PR TITLE
dynamic1PC

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -2605,7 +2605,7 @@ public class BasicAction extends StateManager
              * intentions list.
              */
             
-            if (keepGoing && TxControl.dynamic1PC)
+            if (!subordinate && keepGoing && TxControl.dynamic1PC)
             {
                 /*
                  * If N-1 returned read-only and 1 record left then exit prepare now and force
@@ -3732,6 +3732,8 @@ public class BasicAction extends StateManager
 
     //    private Mutex _lock = new Mutex(); // TODO
     private List<Throwable> deferredThrowables = new ArrayList<>();
+
+    protected boolean subordinate;
     
 }
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
@@ -241,6 +241,12 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
 
             switch (tx.doPrepare())
             {
+            case TwoPhaseOutcome.PREPARE_ONE_PHASE_COMMITTED:
+                // Should never happen Would be great if there was heuristic commit :(
+                SubordinationManager.getTransactionImporter()
+                        .removeImportedTransaction(xid);
+                jtaLogger.i18NLogger.fatalSubordinate1PCDuringPrepare(xid);
+                throw new XAException(XAException.XAER_RMERR);
             case TwoPhaseOutcome.PREPARE_READONLY:
                 SubordinationManager.getTransactionImporter()
                         .removeImportedTransaction(xid);

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/SubordinateAtomicAction.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/SubordinateAtomicAction.java
@@ -50,11 +50,13 @@ public class SubordinateAtomicAction extends
 	public SubordinateAtomicAction ()
 	{
 		this(AtomicAction.NO_TIMEOUT);
+		subordinate = true;
 	}
 
 	public SubordinateAtomicAction (int timeout)
 	{
 		super();
+		subordinate = true;
 
 		start();
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -21,6 +21,7 @@
 package com.arjuna.ats.jta.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.FATAL;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT;
@@ -31,6 +32,8 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 import com.arjuna.ats.arjuna.common.Uid;
+
+import javax.transaction.xa.Xid;
 
 /**
  * i18n log messages for the jta module.
@@ -469,6 +472,10 @@ public interface jtaI18NLogger {
     @Message(id = 16115, value = "Could not access object store to check for log so will leave record alone", format = MESSAGE_FORMAT)
     @LogMessage(level = WARN)
     public void warn_could_not_access_object_store(@Cause() Exception e);
+
+	@Message(id = 16116, value = "Subordinate transaction was committed during prepare, this will look like a rollback {0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = FATAL)
+	public void fatalSubordinate1PCDuringPrepare(Xid xid);
 
     /*
         Allocate new messages directly above this notice.

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/coordinator/ServerTransaction.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/coordinator/ServerTransaction.java
@@ -60,6 +60,8 @@ public class ServerTransaction extends com.arjuna.ats.internal.jts.orbspecific.i
 	public ServerTransaction (Uid actUid, Xid xid)
 	{
 		super(actUid, null);
+
+		subordinate = true;
 		
 		// convert to internal format (makes saving/restoring easier)
 		
@@ -69,6 +71,8 @@ public class ServerTransaction extends com.arjuna.ats.internal.jts.orbspecific.i
 	public ServerTransaction (Uid actId)
 	{
 		super(actId);
+
+		subordinate = true;
 		
 		if (!activate())  // if this fails we'll retry recovery periodically.\
 		{

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/interposition/coordinator/ServerTransaction.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/orbspecific/interposition/coordinator/ServerTransaction.java
@@ -90,6 +90,8 @@ public class ServerTransaction extends ArjunaTransactionImple
 	{
 		super(actUid, myParent, parentImpl);
 
+		subordinate = true;
+
 		if (jtsLogger.logger.isTraceEnabled()) {
             jtsLogger.logger.trace("ServerTransaction::ServerTransaction ( "
                     + actUid

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/subordinate/SubordinateBACoordinator.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/subordinate/SubordinateBACoordinator.java
@@ -112,6 +112,7 @@ public class SubordinateBACoordinator extends BACoordinator
 	public SubordinateBACoordinator()
 	{
 		super();
+        subordinate = true;
         activated = true;
 	}
 
@@ -122,6 +123,7 @@ public class SubordinateBACoordinator extends BACoordinator
 	public SubordinateBACoordinator(Uid recovery)
 	{
 		super(recovery);
+        subordinate = true;
         activated = false;
 	}
 

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/subordinate/SubordinateATCoordinator.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/subordinate/SubordinateATCoordinator.java
@@ -70,6 +70,7 @@ public class SubordinateATCoordinator extends ATCoordinator
 	public SubordinateATCoordinator()
 	{
 		super();
+		subordinate = true;
         activated = true;
         isReadonly = false;
 	}
@@ -80,6 +81,7 @@ public class SubordinateATCoordinator extends ATCoordinator
 	public SubordinateATCoordinator(String subordinateType)
 	{
 		super();
+        subordinate = true;
         activated = true;
         isReadonly = false;
         this.subordinateType = subordinateType;
@@ -92,6 +94,7 @@ public class SubordinateATCoordinator extends ATCoordinator
 	public SubordinateATCoordinator(Uid recovery)
 	{
 		super(recovery);
+        subordinate = true;
         activated = false;
         isReadonly = false;
         subordinateType = null;


### PR DESCRIPTION
Was introduced here:
https://issues.jboss.org/browse/JBTM-1511
d213dae

The error I am protecting against is:
subordinate transaction called with doPrepare
subordinate transaction has 2 x resources
1st resource returns XARD_ONLY
must avoid the doPrepare call proceeding on and commiting the other resource
