### PR TITLE
[JBTM-2925] adding db2 driver name to jdbc driver list

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/drivers/modifiers/list.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/drivers/modifiers/list.java
@@ -41,7 +41,8 @@ public class list
 				"MySQL Connector Java",
 				"MySQL-AB JDBC Driver",
 				"MariaDB connector/J",
-				"H2 JDBC Driver"}) {
+				"H2 JDBC Driver",
+				"IBM Data Server Driver for JDBC and SQLJ"}) {
 			ModifierFactory.putModifier(driver, -1, -1,
 					IsSameRMModifier.class.getName());
 		}


### PR DESCRIPTION
The list checks what the jdbc connection DatabaseMetaData.getDriverName() gets.
Adding string returned by jdbc driver from DB2 database.

This is per discussion from with Tom and @domhanak.

!QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !XTS