### PR TITLE
[JBTM-2927/WFLY-2485] transitive handling @Transactional on @Stereotype

### DIFF
--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/StereotypeBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/StereotypeBean.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import javax.annotation.Resource;
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+@TransactionalRequiredStereotype
+public class StereotypeBean {
+
+    @Resource(mappedName = "java:jboss/TransactionManager")
+    private TransactionManager txnMgr;
+
+    /**
+     * Method using {@link Transactional} declaration inherited from
+     * {@link Stereotype} defined at the class level.
+     */
+    public void stereotypeRequiredAtBean() throws SystemException {
+        // expected @TransactionalRequiredStereotype with REQUIRED
+        if(Status.STATUS_ACTIVE != txnMgr.getStatus())
+            throw new AssertionError("@TransactionalRequiredStereotype defines having an active txn");
+    }
+
+    /**
+     * Method rewriting the {@link Transactional} annotation in {@link Stereotype}
+     * from the class level and changing it by direct usage of the annotation.
+     */
+    @Transactional(value = TxType.NEVER)
+    public void transactionalAtMethod() throws SystemException {
+        // expected @Transactional with NEVER
+        if(Status.STATUS_NO_TRANSACTION != txnMgr.getStatus())
+            throw new AssertionError("@Transactional/NEVER defines no active transaction expected");
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/StereotypeTransitiveBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/StereotypeTransitiveBean.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import javax.annotation.Resource;
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+
+@TransitiveToRequiredNoTransactional
+public class StereotypeTransitiveBean {
+
+    @Resource(mappedName = "java:jboss/TransactionManager")
+    private TransactionManager txnMgr;
+
+    /**
+     * Having declared the {@link Transactional} annotation in {@link Stereotype}
+     * last in the transitive row.
+     */
+    public void process() throws SystemException, TestException {
+        // expected: @TransitiveToRequiredNoTransactional with REQUIRED
+        if(Status.STATUS_ACTIVE == txnMgr.getStatus())
+            throw new TestException();
+
+        // not expected/fail:
+        throw new AssertionError("@TransitiveToRequiredNoTransactional defines having an active txn");
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/StereotypeWithTransactionalBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/StereotypeWithTransactionalBean.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import javax.annotation.Resource;
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+
+@TransitiveToRequiredTransactionalNever
+public class StereotypeWithTransactionalBean {
+
+    @Resource(mappedName = "java:jboss/TransactionManager")
+    private TransactionManager txnMgr;
+
+    /**
+     * Having declared the {@link Transactional} annotation in {@link Stereotype}
+     * last in the transitive row and in the middle one too. 
+     */
+    public void process() throws SystemException, TestException {
+        // expected: @TransitiveToRequiredTransactionalNever with NEVER
+        if(Status.STATUS_NO_TRANSACTION != txnMgr.getStatus())
+            throw new TestException();
+
+        // not expected/fail:
+        throw new AssertionError("There was active transaction even NEVER is expected to be taken"
+            + " as Transactional attribute");
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TestException.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TestException.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+public class TestException extends Exception {
+    private static final long serialVersionUID = -8970104476204947123L;
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransactionalNeverStereotype.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransactionalNeverStereotype.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+@Stereotype
+@Inherited
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Transactional(value = TxType.NEVER)
+public @interface TransactionalNeverStereotype {
+
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransactionalRequiredStereotype.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransactionalRequiredStereotype.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+@Stereotype
+@Inherited
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@Transactional(value = TxType.REQUIRED)
+public @interface TransactionalRequiredStereotype {
+
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveStereotypeTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveStereotypeTest.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import javax.enterprise.inject.Stereotype;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class TransitiveStereotypeTest {
+
+    @Inject
+    StereotypeBean stereotypeMethodBean;
+
+    @Inject
+    StereotypeTransitiveBean stereotypeTransitiveBean;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, "stereotype-test.war")
+            .addClasses(StereotypeBean.class, StereotypeTransitiveBean.class, TestException.class,
+                TransactionalNeverStereotype.class, TransactionalRequiredStereotype.class, TransitiveStereotypeTest.class,
+                TransitiveToNeverNoTransactional.class, TransitiveToRequiredNoTransactional.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void neverStereotypeAtBean() throws Exception {
+        stereotypeMethodBean.stereotypeRequiredAtBean();
+    }
+    
+    @Test
+    public void transactionalAtMethod() throws Exception {
+        stereotypeMethodBean.transactionalAtMethod();
+    }
+
+    @Test(expected = TestException.class)
+    public void transitiveAtBean() throws Exception {
+        stereotypeTransitiveBean.process();
+    }
+    
+    /**
+     * <p>
+     * This test is commented by intention as Weld does not define precise behavior
+     * in state where {@link Stereotype} annoations are chained and the {@link Transactional}
+     * annotation is defined transitively in several of them.
+     * <p>
+     * Currently in such case exception is thrown<br>
+     * <code>WELD-000048: Conflicting interceptor bindings found on class</code>
+     */
+    // @Test(expected = TestException.class)
+    public void transitiveAtBean2() throws Exception {
+        // StereotypeWithTransactionalBean.process();
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveToNeverNoTransactional.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveToNeverNoTransactional.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+
+@Stereotype
+@Inherited
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@TransactionalNeverStereotype
+public @interface TransitiveToNeverNoTransactional {
+
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveToRequiredNoTransactional.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveToRequiredNoTransactional.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+
+@Stereotype
+@Inherited
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@TransactionalRequiredStereotype
+public @interface TransitiveToRequiredNoTransactional {
+
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveToRequiredTransactionalNever.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/TransitiveToRequiredTransactionalNever.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Stereotype;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+@Stereotype
+@Inherited
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@TransactionalRequiredStereotype
+@Transactional(value = TxType.NEVER)
+public @interface TransitiveToRequiredTransactionalNever {
+
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/AddStereotypeAnnotationExtension.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/AddStereotypeAnnotationExtension.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+import com.hp.mwtests.ts.jta.cdi.transactional.stereotype.TransactionalRequiredStereotype;
+
+
+/**
+ * Extension adding the {@link TransactionalRequiredStereotype}
+ * at any processed bean.
+ */
+public class AddStereotypeAnnotationExtension implements Extension {
+
+    void processAnnotatedType(@Observes ProcessAnnotatedType<NoAnnotationBean> bean) {
+        AnnotatedTypeWrapper<NoAnnotationBean> wrapper = new AnnotatedTypeWrapper<NoAnnotationBean>(bean);
+        wrapper.addAnnotation(TransactionalRequiredStereotype.class);
+    	bean.setAnnotatedType(wrapper);
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/AddTransactionalAnnotationExtension.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/AddTransactionalAnnotationExtension.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.transaction.Transactional;
+
+
+/**
+ * Extension adding the {@link Transactional} at any processed bean.
+ */
+public class AddTransactionalAnnotationExtension implements Extension {
+
+    void processAnnotatedType(@Observes ProcessAnnotatedType<NoAnnotationBean> bean) {
+        AnnotatedTypeWrapper<NoAnnotationBean> wrapper = new AnnotatedTypeWrapper<NoAnnotationBean>(bean);
+        wrapper.addAnnotation(new TransactionalLiteral());
+        bean.setAnnotatedType(wrapper);
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/AnnotatedTypeWrapper.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/AnnotatedTypeWrapper.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+public class AnnotatedTypeWrapper<T> implements AnnotatedType<T> {
+
+    private final AnnotatedType<T> wrapped;
+    private final Set<Annotation> annotations;
+
+    public AnnotatedTypeWrapper(AnnotatedType<T> wrapped, Set<Annotation> annotations) {
+        this.wrapped = wrapped;
+        this.annotations = new HashSet<>(annotations);
+    }
+
+    public AnnotatedTypeWrapper(ProcessAnnotatedType<T> processAnnType) {
+        this(processAnnType.getAnnotatedType(), processAnnType.getAnnotatedType().getAnnotations());
+    }
+
+    public void addAnnotation(Annotation annotation) {
+        annotations.add(annotation);
+    }
+
+    public void addAnnotation(Class<? extends Annotation> classAnnotation) {
+        Annotation annotation = new Annotation() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return classAnnotation;
+            }
+        };
+        addAnnotation(annotation);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+        for (Annotation annotation : annotations) {
+            if (annotationType.isInstance(annotation)) {
+                return (A) annotation;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Set<Annotation> getAnnotations() {
+        return annotations;
+    }
+
+    @Override
+    public Type getBaseType() {
+        return wrapped.getBaseType();
+    }
+
+    @Override
+    public Set<Type> getTypeClosure() {
+        return wrapped.getTypeClosure();
+    }
+
+    @Override
+    public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+        for (Annotation annotation : annotations) {
+            if (annotationType.isInstance(annotation)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Set<AnnotatedConstructor<T>> getConstructors() {
+        return wrapped.getConstructors();
+    }
+
+    @Override
+    public Set<AnnotatedField<? super T>> getFields() {
+        return wrapped.getFields();
+    }
+
+    @Override
+    public Class<T> getJavaClass() {
+        return wrapped.getJavaClass();
+    }
+
+    @Override
+    public Set<AnnotatedMethod<? super T>> getMethods() {
+        return wrapped.getMethods();
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/DummyBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/DummyBean.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.transaction.Transactional;
+
+/**
+ * <p>
+ * This bean with {@link Transactional} annotation is needed to be part
+ * of the test deployment, otherwise the CDI Narayana transactional
+ * interceptors won't be activated (set in WFLY integration code at
+ * <code>org.jboss.as.txn.deployment.TransactionDependenciesProcessor.deploy(DeploymentPhaseContext)</code>).
+ * <p>
+ * The {@link NoAnnotationBean} is deliberately defined without the annotation
+ * and the annotation is add later by extension which is not seen by the processor in WFLY.
+ */
+@Transactional
+public class DummyBean {
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/NoAnnotationBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/NoAnnotationBean.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.annotation.Resource;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+
+public class NoAnnotationBean {
+    @Resource(mappedName = "java:jboss/TransactionManager")
+    private TransactionManager txnMgr;
+
+    /**
+     * Expecting the cdi adds a stereotype or transactional annotation
+     * to define bean works in a transaction.
+     */
+    public void process() throws SystemException {
+        if(Status.STATUS_ACTIVE == txnMgr.getStatus())
+            // exception is necessary to be thrown here as it tests how transactional interceptor behaves
+            // in case of the transaction is thrown
+        	throw new RuntimeException("exception for testing purposes - correct active status");
+
+        // not expected/fail:
+        throw new AssertionError("The stereotype bean define by extension annotation for"
+        		+ "having active transaction on method call, but there is not.");
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/StereotypeChangedByExtensionTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/StereotypeChangedByExtensionTest.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.hp.mwtests.ts.jta.cdi.transactional.stereotype.TransactionalRequiredStereotype;
+
+@RunWith(Arquillian.class)
+public class StereotypeChangedByExtensionTest {
+    @Inject
+    NoAnnotationBean bean;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, "stereotype-test.war")
+        	.addPackage(StereotypeChangedByExtensionTest.class.getPackage())
+        	.addClasses(TransactionalRequiredStereotype.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsServiceProvider(javax.enterprise.inject.spi.Extension.class, AddStereotypeAnnotationExtension.class);
+    }
+
+
+    @Test(expected = RuntimeException.class)
+    public void stereotypeAddedByExtensionAtBean() throws Exception {
+        bean.process();
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalChangedByExtensionTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalChangedByExtensionTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class TransactionalChangedByExtensionTest {
+    @Inject
+    NoAnnotationBean bean;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, "transactional-test.war")
+            .addPackage(TransactionalChangedByExtensionTest.class.getPackage())
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsServiceProvider(javax.enterprise.inject.spi.Extension.class, AddTransactionalAnnotationExtension.class);
+    }
+
+
+    @Test(expected = RuntimeException.class)
+    public void transactionalAddedByExtensionAtBean() throws Exception {
+        bean.process();
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalLiteral.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalLiteral.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.transaction.Transactional;
+
+class TransactionalLiteral extends AnnotationLiteral<Transactional> implements Transactional {
+
+    @Override
+    public TxType value() {
+        return TxType.REQUIRED;
+    }
+
+    @Override
+    public Class[] rollbackOn() {
+        return new Class[] {};
+    }
+
+    @Override
+    public Class[] dontRollbackOn() {
+        return new Class[] {};
+    }
+
+}


### PR DESCRIPTION
I finally got to a working implementation of the @Transactional @Stereotype issue. I followed the @mkouba steps:

- modify TransactionExtension - add ProcessManagedBean observer and store <Bean, AnnotatedType> map
- modify TransactionalInterceptorBase to use the AnnotatedType stored in TransactionExtension <Bean, AnnotatedType> map (the key - intercepted bean - is available)
- use BeanAttributes.getStereotypes() together with BeanManager.getStereotypeDefinition() to cover the transitive stereotype declarations
- add reflection fallback for intercepted non-contextual instances (e.g. EE components)

Now I would like ask @mkouba and @manovotn to check it. I expect the behavior needs some tuning.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS