### PR TITLE
Lra cdi extension checking annotations incorrectly counts LRA method annotations

### DIFF
--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
@@ -28,17 +28,6 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
-import io.narayana.lra.cdi.bean.AllAnnotationsNoPathBean;
-import io.narayana.lra.cdi.bean.ForgetWithoutDeleteBean;
-import io.narayana.lra.annotation.Forget;
-import io.narayana.lra.cdi.LraAnnotationProcessingExtension;
-import io.narayana.lra.cdi.bean.OnlyOneLraAnnotationBean;
-import io.narayana.lra.cdi.bean.OnlyTwoLraAnnotationsBean;
-import io.narayana.lra.cdi.bean.CorrectBean;
-import io.narayana.lra.cdi.bean.LeaveWithoutPutBean;
-import io.narayana.lra.cdi.bean.LraJoinFalseBean;
-import io.narayana.lra.cdi.bean.MultiForgetBean;
-import io.narayana.lra.cdi.bean.NoPostOrGetBean;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -53,6 +42,20 @@ import org.wildfly.swarm.cdi.CDIFraction;
 import org.wildfly.swarm.jaxrs.JAXRSFraction;
 
 import com.google.common.collect.Lists;
+
+import io.narayana.lra.annotation.Forget;
+import io.narayana.lra.cdi.bean.AllAnnotationsNoPathBean;
+import io.narayana.lra.cdi.bean.CompleteOptionalBean;
+import io.narayana.lra.cdi.bean.CorrectBean;
+import io.narayana.lra.cdi.bean.CorrectMethodLRABean;
+import io.narayana.lra.cdi.bean.ForgetWithoutDeleteBean;
+import io.narayana.lra.cdi.bean.LeaveWithoutPutBean;
+import io.narayana.lra.cdi.bean.LraJoinFalseBean;
+import io.narayana.lra.cdi.bean.LraJoinFalseMethodLRABean;
+import io.narayana.lra.cdi.bean.MultiForgetBean;
+import io.narayana.lra.cdi.bean.NoPostOrGetBean;
+import io.narayana.lra.cdi.bean.OnlyOneLraAnnotationBean;
+import io.narayana.lra.cdi.bean.OnlyTwoLraAnnotationsBean;
 
 /**
  * Test case which checks functionality of CDI extension by deploying wrongly
@@ -116,12 +119,42 @@ public class StartCdiCheckIT {
             swarm.stop();
         }
     }
+    
+    @Test
+    public void lraJoinFalseCorrectLRAOnMethod() throws Exception {
+        Swarm swarm = startSwarm(tmpFolder.newFile());
+        try {
+            swarm.deploy(getBaseDeployment().addClasses(LraJoinFalseMethodLRABean.class));
+        } finally {
+            swarm.stop();
+        }
+    }
 
     @Test
     public void allCorrect() throws Exception {
         Swarm swarm = startSwarm(tmpFolder.newFile());
         try {
             swarm.deploy(getBaseDeployment().addClasses(CorrectBean.class));
+        } finally {
+            swarm.stop();
+        }
+    }
+    
+    @Test
+    public void allCorrectLRAOnMethod() throws Exception {
+        Swarm swarm = startSwarm(tmpFolder.newFile());
+        try {
+            swarm.deploy(getBaseDeployment().addClasses(CorrectMethodLRABean.class));
+        } finally {
+            swarm.stop();
+        }
+    }
+    
+    @Test
+    public void completeAnnotationIsOptional() throws Exception {
+        Swarm swarm = startSwarm(tmpFolder.newFile());
+        try {
+            swarm.deploy(getBaseDeployment().addClasses(CompleteOptionalBean.class));
         } finally {
             swarm.stop();
         }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/AllAnnotationsNoPathBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/AllAnnotationsNoPathBean.java
@@ -28,8 +28,8 @@ import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Status;
 
 /**
- *
- * @author Ondra Chaloupka <ochaloup@redhat.com>
+ * Bean containing three LRA annotations but they do not contain PATH
+ * where JAXRS endpoind is bound at.
  */
 @LRA
 public class AllAnnotationsNoPathBean {

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CompleteOptionalBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CompleteOptionalBean.java
@@ -22,30 +22,25 @@
 
 package io.narayana.lra.cdi.bean;
 
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
-import io.narayana.lra.annotation.Complete;
-import io.narayana.lra.annotation.Forget;
 import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Status;
 
 /**
- * Having {@link Forget} LRA annotation with missing
- * {@link Path} and method type {@link DELETE}.
+ * {@link LRA} bean which contains annotations - {@link Compensate} and {@link Status}
+ * is enough to run the LRA 
  */
-@LRA
-public class ForgetWithoutDeleteBean {
-    @Complete
-    @Path("complete")
-    @POST
-    public void complete() {
+public class CompleteOptionalBean {
+
+    @LRA
+    public void process() {
         // no implementation needed
     }
-    
+
     @Compensate
     @Path("compensate")
     @POST
@@ -57,11 +52,6 @@ public class ForgetWithoutDeleteBean {
     @Path("status")
     @GET
     public void status() {
-        // no implementation needed
-    }
-
-    @Forget
-    public void forget() {
         // no implementation needed
     }
 }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectBean.java
@@ -31,6 +31,10 @@ import io.narayana.lra.annotation.Complete;
 import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Status;
 
+/**
+ * LRA bean which contain all three LRA annotations with {@link Path}
+ * and correct HTTP method to run at. 
+ */
 @LRA
 public class CorrectBean {
     @Complete

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectMethodLRABean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectMethodLRABean.java
@@ -22,23 +22,25 @@
 
 package io.narayana.lra.cdi.bean;
 
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
 import io.narayana.lra.annotation.Complete;
-import io.narayana.lra.annotation.Forget;
 import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Status;
 
 /**
- * Having {@link Forget} LRA annotation with missing
- * {@link Path} and method type {@link DELETE}.
+ * All three LRA annotations where {@link LRA} is annotated
+ * on a method. 
  */
-@LRA
-public class ForgetWithoutDeleteBean {
+public class CorrectMethodLRABean {
+    @LRA
+    public void process() {
+        // no implementation needed
+    }
+
     @Complete
     @Path("complete")
     @POST
@@ -57,11 +59,6 @@ public class ForgetWithoutDeleteBean {
     @Path("status")
     @GET
     public void status() {
-        // no implementation needed
-    }
-
-    @Forget
-    public void forget() {
         // no implementation needed
     }
 }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LeaveWithoutPutBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LeaveWithoutPutBean.java
@@ -24,6 +24,7 @@ package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -32,6 +33,10 @@ import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Leave;
 import io.narayana.lra.annotation.Status;
 
+/**
+ * Three base LRA annotations are correct but the {@link Leave}
+ * annotation misses the HTTP method to use which should be {@link PUT}.  
+ */
 @LRA
 public class LeaveWithoutPutBean {
     @Complete

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LraJoinFalseBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LraJoinFalseBean.java
@@ -24,6 +24,10 @@ package io.narayana.lra.cdi.bean;
 
 import io.narayana.lra.annotation.LRA;
 
+/**
+ * Having LRA with parameter join which defines the
+ * bean is ok not containing any LRA annotation.
+ */
 @LRA(join = false)
 public class LraJoinFalseBean {
 }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LraJoinFalseMethodLRABean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LraJoinFalseMethodLRABean.java
@@ -22,46 +22,17 @@
 
 package io.narayana.lra.cdi.bean;
 
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-
-import io.narayana.lra.annotation.Compensate;
-import io.narayana.lra.annotation.Complete;
-import io.narayana.lra.annotation.Forget;
 import io.narayana.lra.annotation.LRA;
-import io.narayana.lra.annotation.Status;
 
 /**
- * Having {@link Forget} LRA annotation with missing
- * {@link Path} and method type {@link DELETE}.
+ * Having LRA with parameter join which defines the
+ * bean is ok not containing any LRA annotation.
+ * <p>
+ * The {@link LRA} annotation is put at method.
  */
-@LRA
-public class ForgetWithoutDeleteBean {
-    @Complete
-    @Path("complete")
-    @POST
-    public void complete() {
-        // no implementation needed
-    }
-    
-    @Compensate
-    @Path("compensate")
-    @POST
-    public void compensate() {
-        // no implementation needed
-    }
-    
-    @Status
-    @Path("status")
-    @GET
-    public void status() {
-        // no implementation needed
-    }
-
-    @Forget
-    public void forget() {
+public class LraJoinFalseMethodLRABean {
+    @LRA(join = false)
+    public void process() {
         // no implementation needed
     }
 }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/MultiForgetBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/MultiForgetBean.java
@@ -33,6 +33,9 @@ import io.narayana.lra.annotation.Forget;
 import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Status;
 
+/**
+ * Bean containing more {@link Forget} annotations.
+ */
 @LRA
 public class MultiForgetBean {
     @Complete

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/NoPostOrGetBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/NoPostOrGetBean.java
@@ -29,6 +29,10 @@ import io.narayana.lra.annotation.Complete;
 import io.narayana.lra.annotation.LRA;
 import io.narayana.lra.annotation.Status;
 
+/**
+ * The LRA annotations do not contain HTTP methods
+ * which are compulsory when LRA annotations are used.
+ */
 @LRA
 public class NoPostOrGetBean {
     

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/OnlyOneLraAnnotationBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/OnlyOneLraAnnotationBean.java
@@ -29,9 +29,7 @@ import io.narayana.lra.annotation.LRA;
 
 /**
  * {@link LRA} bean which contains only one annotation - {@link Compensate}
- * but the LRA prescribe for the bean to contain three: {@link Compensate}, {@link Complete} and {@link Status}.
- *
- * @author Ondra Chaloupka <ochaloup@redhat.com>
+ * but the LRA prescribe for the bean to contain two: {@link Compensate} and {@link Status}.
  */
 @LRA
 public class OnlyOneLraAnnotationBean {

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/OnlyTwoLraAnnotationsBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/OnlyTwoLraAnnotationsBean.java
@@ -29,9 +29,7 @@ import io.narayana.lra.annotation.Status;
 
 /**
  * {@link LRA} bean which contains only two annotations - {@link Complete} and {@link Status} 
- * but the LRA prescribe for the bean to contain three: {@link Compensate}, {@link Complete} and {@link Status}.
- *
- * @author Ondra Chaloupka <ochaloup@redhat.com>
+ * but the LRA prescribe for the bean to contain two compulsory: {@link Compensate} and {@link Status}.
  */
 @LRA
 public class OnlyTwoLraAnnotationsBean {


### PR DESCRIPTION
I find a small issue in the LRA CDI extension checking the structure of the LRA annotations on the class. Changed to accept `join` when used on LRA method level annotation.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS