### PR TITLE
JBTM-2934 LRA nested and parent coordinators should optimise calls when in a single VM

### DIFF
--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -182,6 +182,10 @@ public class Transaction extends AtomicAction {
 
                 if (record == null || !record.restore_state(os, ot) || !list.insert(record))
                     return false;
+
+                if (record instanceof LRARecord)
+                    ((LRARecord) record).setLRAService(lraService);
+
             }
         } catch (IOException e1) {
             return false;
@@ -434,7 +438,7 @@ public class Transaction extends AtomicAction {
         if (findLRAParticipant(participantUrl, false) != null)
             return null;    // already enlisted
 
-        LRARecord p = new LRARecord(coordinatorUrl.toExternalForm(), participantUrl, compensatorData);
+        LRARecord p = new LRARecord(lraService, coordinatorUrl.toExternalForm(), participantUrl, compensatorData);
         String pid = p.get_uid().fileStringForm();
 
         String txId = URLEncoder.encode(coordinatorUrl.toExternalForm(), "UTF-8");


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2934

!BLACKTIE !XTS !PERF NO_WIN !JTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !AS_TESTS !QA_JTS_OPENJDKORB !RTS

When a nested LRA is started and is in the same JVM as the parent then it registers itself as a compensator with the parent using a Java (instead of JAX-RS) call to the coordinator. When the parent LRA is ended and the nested compensator is in the same JVM, then the nested compensator is ended using a direct Java invocation. 

Two points of note:

1, I did this in 2 commits to enhance readability. The first commit shows the necessary changes for the new functionality and is straight forward. The second commit (which is less clear) simply cleans up the code.
2. I believe I have caught all the parent/nested LRA interactions and performed an inVM call accordingly. However it would be great if you could verify that with your openshift demos.

