### PR TITLE
JBTM-2936 JAX-RS response headers from an LRA @Nested method doesn't include the parent LRA id

### DIFF
--- a/rts/lra/lra-test/src/test/java/io/narayana/lra/participant/SpecIT.java
+++ b/rts/lra/lra-test/src/test/java/io/narayana/lra/participant/SpecIT.java
@@ -261,6 +261,11 @@ public class SpecIT {
                 .header(LRAClient.LRA_HTTP_HEADER, lra)
                 .put(Entity.text(""));
 
+        Object parentId = response.getHeaders().getFirst(LRAClient.LRA_HTTP_HEADER);
+
+        assertNotNull(parentId);
+        assertEquals(lra.toExternalForm(), parentId);
+
         String nestedLraId = checkStatusAndClose(response, Response.Status.OK.getStatusCode(), true);
 
         List<LRAStatus> lras = lraClient.getActiveLRAs();


### PR DESCRIPTION
#https://issues.jboss.org/browse/JBTM-2936

!BLACKTIE !XTS !PERF NO_WIN !JTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !AS_TESTS !QA_JTS_OPENJDKORB !RTS