### PR TITLE
JBTM-2940 Ensure recovery finishes LRAs that finish asynchronously 

### DIFF
--- a/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/LRA.java
+++ b/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/LRA.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * An annotation for controlling the lifecycle of Long Running Actions (LRAs).
  *
  * Newly created LRAs are uniquely identified and the id is referred to as the LRA context. The context is passed around
- * using a JAX-RS request/response header called LRAClient#LRA_HTTP_HEADER ("X-lra"). The implementation (of the LRA
+ * using a JAX-RS request/response header called LRAClient#LRA_HTTP_HEADER ("Long-Running-Action"). The implementation (of the LRA
  * specification) is expected to manage this context and the application developer is expected to declaratively control
  * the creation, propagation and destruction of LRAs using the @LRA annotation. When a JAX-RS bean method is invoked in the
  * context of an LRA any JAX-RS client requests that it performs will carry the same header so that the receiving

--- a/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/TimeLimit.java
+++ b/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/TimeLimit.java
@@ -49,5 +49,5 @@ public @interface TimeLimit {
      */
     long limit() default 0;
 
-    TimeUnit unit() default TimeUnit.MILLISECONDS;
+    TimeUnit unit() default TimeUnit.SECONDS;
 }

--- a/rts/lra/lra-cdi-rest/src/main/java/io/narayana/lra/cdi/LraAnnotationProcessingExtension.java
+++ b/rts/lra/lra-cdi-rest/src/main/java/io/narayana/lra/cdi/LraAnnotationProcessingExtension.java
@@ -40,7 +40,6 @@ import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.WithAnnotations;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
@@ -124,7 +123,7 @@ public class LraAnnotationProcessingExtension implements Extension {
 
         if(methodsWithCompensate.size() > 0) {
             // Each method annotated with LRA-style annotations contain all necessary REST annotations
-            // @Compensate - requires @Path and @POST
+            // @Compensate - requires @Path and @PUT
             final AnnotatedMethod<? super X> methodWithCompensate = methodsWithCompensate.get(0);
             Function<Class<?>, String> getCompensateMissingErrMsg = (wrongAnnotation) ->
                 getMissingAnnotationError(methodWithCompensate, classAnnotatedWithLra, Compensate.class, wrongAnnotation);
@@ -132,14 +131,14 @@ public class LraAnnotationProcessingExtension implements Extension {
             if(!isCompensateContainsPathAnnotation) {
                 throw new DeploymentException(getCompensateMissingErrMsg.apply(Path.class));
             }
-            boolean isCompensateContainsPostAnnotation = methodWithCompensate.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(POST.class));
-            if(!isCompensateContainsPostAnnotation) {
-                throw new DeploymentException(getCompensateMissingErrMsg.apply(POST.class));
+            boolean isCompensateContainsPutAnnotation = methodWithCompensate.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(PUT.class));
+            if(!isCompensateContainsPutAnnotation) {
+                throw new DeploymentException(getCompensateMissingErrMsg.apply(PUT.class));
             }
         }
 
         if(methodsWithComplete.size() > 0) {
-            // @Complete - requires @Path and @POST
+            // @Complete - requires @Path and @PUT
             final AnnotatedMethod<? super X> methodWithComplete = methodsWithComplete.get(0);
             Function<Class<?>, String> getCompleteMissingErrMsg = (wrongAnnotation) ->
                 getMissingAnnotationError(methodWithComplete, classAnnotatedWithLra, Complete.class, wrongAnnotation);
@@ -147,9 +146,9 @@ public class LraAnnotationProcessingExtension implements Extension {
             if(!isCompleteContainsPathAnnotation) {
                 throw new DeploymentException(getCompleteMissingErrMsg.apply(Path.class));
             }
-            boolean isCompleteContainsPostAnnotation = methodWithComplete.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(POST.class));
-            if(!isCompleteContainsPostAnnotation) {
-                throw new DeploymentException(getCompleteMissingErrMsg.apply(POST.class));
+            boolean isCompleteContainsPutAnnotation = methodWithComplete.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(PUT.class));
+            if(!isCompleteContainsPutAnnotation) {
+                throw new DeploymentException(getCompleteMissingErrMsg.apply(PUT.class));
             }
         }
         
@@ -162,8 +161,8 @@ public class LraAnnotationProcessingExtension implements Extension {
             if(!isStatusContainsPathAnnotation) {
                 throw new DeploymentException(getStatusMissingErrMsg.apply(Path.class));
             }
-            boolean isStatusContainsPostAnnotation = methodWithStatus.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(GET.class));
-            if(!isStatusContainsPostAnnotation) {
+            boolean isStatusContainsGetAnnotation = methodWithStatus.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(GET.class));
+            if(!isStatusContainsGetAnnotation) {
                 throw new DeploymentException(getStatusMissingErrMsg.apply(GET.class));
             }
         }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
@@ -85,7 +85,7 @@ public class StartCdiCheckIT {
     
     @Test
     public void methodTypeAnnotationMissing() throws Exception {
-        checkSwarmWithDeploymentException("should use complementary annotation.*(POST|GET)",
+        checkSwarmWithDeploymentException("should use complementary annotation.*(PUT|GET)",
             NoPostOrGetBean.class);
     }
     

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectBean.java
@@ -23,7 +23,7 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -35,14 +35,14 @@ import io.narayana.lra.annotation.Status;
 public class CorrectBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/ForgetWithoutDeleteBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/ForgetWithoutDeleteBean.java
@@ -23,7 +23,7 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -36,14 +36,14 @@ import io.narayana.lra.annotation.Status;
 public class ForgetWithoutDeleteBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LeaveWithoutPutBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LeaveWithoutPutBean.java
@@ -23,7 +23,7 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -36,14 +36,14 @@ import io.narayana.lra.annotation.Status;
 public class LeaveWithoutPutBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/MultiForgetBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/MultiForgetBean.java
@@ -24,7 +24,7 @@ package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -37,14 +37,14 @@ import io.narayana.lra.annotation.Status;
 public class MultiForgetBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClientAPI.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClientAPI.java
@@ -168,9 +168,9 @@ public interface LRAClientAPI {
      *                -  Completing: the Compensator is tidying up after being told to complete.
      *                -  Completed: the coordinator/participant has confirmed.
      *                -  FailedToComplete: the Compensator was unable to tidy-up.
-     *                     Performing a POST on URL/compensate will cause the compensator to compensate
+     *                     Performing a PUT on URL/compensate will cause the compensator to compensate
      *                     the work that was done within the scope of the LRA.
-     *                     Performing a POST on URL/complete will cause the compensator to tidy up and
+     *                     Performing a PUT on URL/complete will cause the compensator to tidy up and
      *                  it can forget this LRA.  (optional)
      *
      * @param compensatorData
@@ -187,9 +187,9 @@ public interface LRAClientAPI {
      * @param lraId The unique identifier of the LRA (required)
      * @param timelimit The time limit (in seconds) that the Compensator can guarantee that it
      *                can compensate the work performed by the service
-     * @param compensateUrl Performing a POST onthis URL will cause the participant to compensate the work that
+     * @param compensateUrl Performing a PUT onthis URL will cause the participant to compensate the work that
      *                      was done within the scope of the LRA.
-     * @param completeUrl Performing a POST on this URL  will cause the participant to tidy up and it can forget this transaction.
+     * @param completeUrl Performing a PUT on this URL  will cause the participant to tidy up and it can forget this transaction.
      * @param leaveUrl Performing a PUT on this URL with cause the compensator to leave the LRA
      * @param statusUrl Performing a GET on this URL will return the status of the compensator {@see joinLRA}
      *

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -249,19 +249,19 @@ public class Coordinator {
         return Response.ok(lra.getLRAStatus().name()).build();
     }
 
-    @POST
+    @PUT
     @Path("{NestedLraId}/complete")
     public Response completeNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         return endLRA(toURL(nestedLraId), false, true);
     }
 
-    @POST
+    @PUT
     @Path("{NestedLraId}/compensate")
     public Response compensateNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         return endLRA(toURL(nestedLraId), true, true);
     }
 
-    @POST
+    @PUT
     @Path("{NestedLraId}/forget")
     public Response forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         lraService.remove(null, toURL(nestedLraId));
@@ -449,9 +449,9 @@ public class Coordinator {
                     + "-  Completed: the coordinator/participant has confirmed.\n"
                     + "-  FailedToComplete: the Compensator was unable to tidy-up.\n"
                     + "\n"
-                    + "Performing a POST on <URL>/compensate will cause the compensator to compensate\n"
+                    + "Performing a PUT on <URL>/compensate will cause the compensator to compensate\n"
                     + "  the work that was done within the scope of the LRA.\n"
-                    + "Performing a POST on <URL>/complete will cause the compensator to tidy up and\n"
+                    + "Performing a PUT on <URL>/complete will cause the compensator to tidy up and\n"
                     + "   it can forget this LRA.\n")
                     String compensatorUrl) throws NotFoundException {
         // test to see if the join request contains any compensator specific data

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
@@ -22,6 +22,7 @@
 package io.narayana.lra.coordinator.api;
 
 import io.narayana.lra.client.GenericLRAException;
+import io.narayana.lra.coordinator.domain.model.LRAStatus;
 import io.narayana.lra.coordinator.domain.service.LRAService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 @ApplicationScoped
 @Path(LRAClient.RECOVERY_COORDINATOR_PATH_NAME)
@@ -127,5 +129,18 @@ public class RecoveryCoordinator {
         }
 
         throw new NotFoundException(rcvCoordId);
+    }
+
+    @GET
+    @Path("recovery")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List recovering Long Running Actions",
+            notes = "Returns LRAs that are recovering (ie some compensators still need to be ran)",
+            response = LRAStatus.class, responseContainer = "List")
+    @ApiResponses( {
+            @ApiResponse( code = 200, message = "The request was successful" )
+    } )
+    public List<LRAStatus> getRecoveringLRAs() {
+        return lraService.getAllRecovering(true);
     }
 }

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -182,6 +182,10 @@ public class Transaction extends AtomicAction {
 
                 if (record == null || !record.restore_state(os, ot) || !list.insert(record))
                     return false;
+
+                if (record instanceof LRARecord)
+                    ((LRARecord) record).setLRAService(lraService);
+
             }
         } catch (IOException e1) {
             return false;
@@ -434,7 +438,7 @@ public class Transaction extends AtomicAction {
         if (findLRAParticipant(participantUrl, false) != null)
             return null;    // already enlisted
 
-        LRARecord p = new LRARecord(coordinatorUrl.toExternalForm(), participantUrl, compensatorData);
+        LRARecord p = new LRARecord(lraService, coordinatorUrl.toExternalForm(), participantUrl, compensatorData);
         String pid = p.get_uid().fileStringForm();
 
         String txId = URLEncoder.encode(coordinatorUrl.toExternalForm(), "UTF-8");

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -74,7 +74,6 @@ public class Transaction extends AtomicAction {
     private LocalDateTime cancelOn; // TODO make sure this acted upon during restore_state()
     private ScheduledFuture<?> scheduledAbort;
     private boolean inFlight;
-
     private LRAService lraService;
 
     public Transaction(LRAService lraService, String baseUrl, URL parentId, String clientId) throws MalformedURLException {
@@ -251,6 +250,10 @@ public class Transaction extends AtomicAction {
         return clientId;
     }
 
+    protected LRAService getLraService() {
+        return lraService;
+    }
+
     /**
      * return the current status of the LRA
      *
@@ -258,6 +261,10 @@ public class Transaction extends AtomicAction {
      */
     public CompensatorStatus getLRAStatus() {
         return status;
+    }
+
+    protected void setLRAStatus(int actionStatus) {
+        status = toLRAStatus(actionStatus);
     }
 
     public boolean isComplete() {

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -86,8 +86,15 @@ public class LRAService {
         return lras.values().stream().map(LRAStatus::new).collect(toList());
     }
 
-    public List<LRAStatus> getAllRecovering() {
+    public List<LRAStatus> getAllRecovering(boolean scan) {
+        if (scan)
+            RecoveryManager.manager().scan();
+
         return recoveringLRAs.values().stream().map(LRAStatus::new).collect(toList());
+    }
+
+    public List<LRAStatus> getAllRecovering() {
+        return getAllRecovering(false);
     }
 
     public void addTransaction(Transaction lra) {

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
@@ -118,42 +118,6 @@ public class LRARecoveryModule implements RecoveryModule {
             }
     }
 
-    private boolean isTransactionInMidFlight( int status )
-    {
-        boolean inFlight;
-
-        switch ( status )
-        {
-            // these states can only come from a process that is still alive
-            case ActionStatus.RUNNING    :
-            case ActionStatus.ABORT_ONLY :
-            case ActionStatus.PREPARING  :
-            case ActionStatus.COMMITTING :
-            case ActionStatus.ABORTING   :
-            case ActionStatus.PREPARED   :
-                inFlight = true ;
-                break ;
-
-            // the transaction is apparently still there, but has completed its
-            // phase2. should be safe to redo it.
-            case ActionStatus.COMMITTED  :
-            case ActionStatus.H_COMMIT   :
-            case ActionStatus.H_MIXED    :
-            case ActionStatus.H_HAZARD   :
-            case ActionStatus.ABORTED    :
-            case ActionStatus.H_ROLLBACK :
-                inFlight = false ;
-                break ;
-
-            // this shouldn't happen
-            case ActionStatus.INVALID :
-            default:
-                inFlight = false ;
-        }
-
-        return inFlight ;
-    }
-
     private Vector<Uid> processTransactions( InputObjectState uids ) {
         Vector<Uid> uidVector = new Vector<>() ;
 

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
@@ -23,10 +23,16 @@
 package io.narayana.lra.coordinator.internal;
 
 import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.coordinator.AbstractRecord;
 import com.arjuna.ats.arjuna.coordinator.ActionStatus;
+import com.arjuna.ats.arjuna.coordinator.RecordList;
+import com.arjuna.ats.arjuna.coordinator.RecordListIterator;
 import com.arjuna.ats.arjuna.logging.tsLogger;
+import io.narayana.lra.coordinator.domain.model.LRARecord;
 import io.narayana.lra.coordinator.domain.model.Transaction;
 import io.narayana.lra.coordinator.domain.service.LRAService;
+
+import java.util.ArrayList;
 
 class RecoveringLRA extends Transaction {
     /**
@@ -61,6 +67,9 @@ class RecoveringLRA extends Transaction {
                     (_theStatus == ActionStatus.H_MIXED) ||
                     (_theStatus == ActionStatus.H_HAZARD) )
             {
+                // move any heuristics back onto the prepared list for another attempt:
+                moveTo(heuristicList, preparedList);
+
                 super.phase2Commit( _reportHeuristics ) ;
             }
             else if ( (_theStatus == ActionStatus.ABORTED) ||
@@ -68,6 +77,9 @@ class RecoveringLRA extends Transaction {
                     (_theStatus == ActionStatus.ABORTING) ||
                     (_theStatus == ActionStatus.ABORT_ONLY) )
             {
+                // move any heuristics back onto the pending list for another attempt:
+                moveTo(heuristicList, pendingList);
+
                 super.phase2Abort( _reportHeuristics ) ;
             }
             else {
@@ -85,6 +97,22 @@ class RecoveringLRA extends Transaction {
             }
 
             // Failure to activate (NB other types such as AtomicActionExpiryScanner move the log)
+        }
+    }
+
+    private void moveTo(RecordList fromList, RecordList toList) {
+        RecordListIterator i = new RecordListIterator(fromList);
+        AbstractRecord record;
+
+        while ((record = i.iterate()) != null) {
+            if (record instanceof LRARecord) {
+                toList.putRear(record);
+            }
+        }
+
+        // clear the source list
+        while (fromList.getRear() != null) {
+            // do nothing;
         }
     }
 

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
@@ -28,6 +28,7 @@ import com.arjuna.ats.arjuna.coordinator.ActionStatus;
 import com.arjuna.ats.arjuna.coordinator.RecordList;
 import com.arjuna.ats.arjuna.coordinator.RecordListIterator;
 import com.arjuna.ats.arjuna.logging.tsLogger;
+import io.narayana.lra.annotation.CompensatorStatus;
 import io.narayana.lra.coordinator.domain.model.LRARecord;
 import io.narayana.lra.coordinator.domain.model.Transaction;
 import io.narayana.lra.coordinator.domain.service.LRAService;
@@ -87,6 +88,19 @@ class RecoveringLRA extends Transaction {
                     tsLogger.logger.info("RecoveringLRA.replayPhase2: Unexpected status: "
                             + ActionStatus.stringForm(_theStatus));
                 }
+            }
+
+            if (heuristicList.size() == 0 && failedList.size() == 0) {
+                setLRAStatus(_theStatus);
+            }
+
+            switch (getLRAStatus()) {
+                case Completed:
+                case Compensated:
+                    getLraService().finished(this, false);
+                    break;
+                default:
+                    /* FALLTHRU */
             }
         }
         else {

--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -398,24 +398,13 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
     }
 
     private String getCompensatorId(URL lraId, URI baseUri) {
-        Map<String, String> terminateURIs = getTerminationUris(resourceInfo.getResourceClass());
+        Map<String, String> terminateURIs = LRAClient.getTerminationUris(resourceInfo.getResourceClass(), baseUri);
 
-        if (!terminateURIs.containsKey(COMPENSATE) || !terminateURIs.containsKey(COMPLETE))
+        if (!terminateURIs.containsKey("Link"))
             throw new GenericLRAException(lraId, Response.Status.BAD_REQUEST.getStatusCode(),
                     "Missing complete or compensate annotations", null);
 
-        // register with the coordinator
-
-        StringBuilder linkHeaderValue = new StringBuilder();
-        Annotation resourcePathAnnotation = resourceInfo.getResourceClass().getAnnotation(Path.class);
-        String resourcePath = resourcePathAnnotation == null ? "/" : ((Path) resourcePathAnnotation).value();
-
-        String uriPrefix = String.format("%s:%s%s",
-                baseUri.getScheme(), baseUri.getSchemeSpecificPart(), resourcePath.substring(1));
-
-        terminateURIs.forEach((k, v) -> getParticipantLink(linkHeaderValue, uriPrefix, k, v));
-
-        return linkHeaderValue.toString();
+        return terminateURIs.get("Link");
     }
 
     /**

--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -436,7 +436,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                 checkMethod(paths, FORGET, (Path) pathAnnotation, method.getAnnotation(Forget.class));
             }
 
-            // NB the lra-cdi-rest maven artifact also validates that the annotated methods are using @POST annotation
+            // NB the lra-cdi-rest maven artifact also validates that the annotated methods are using @PUT annotation
         });
 
         return paths;

--- a/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/api/ActivityController.java
+++ b/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/api/ActivityController.java
@@ -43,7 +43,6 @@ import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -147,7 +146,7 @@ public class ActivityController {
         return Response.ok("non transactional").build();
     }
 
-    @POST
+    @PUT
     @Path("/complete")
     @Produces(MediaType.APPLICATION_JSON)
     @Complete
@@ -165,7 +164,7 @@ public class ActivityController {
         return Response.ok(activity.statusUrl).build();
     }
 
-    @POST
+    @PUT
     @Path("/compensate")
     @Produces(MediaType.APPLICATION_JSON)
     @Compensate
@@ -183,7 +182,7 @@ public class ActivityController {
         return Response.ok(activity.statusUrl).build();
     }
 
-    @POST
+    @PUT
     @Path("/forget")
     @Produces(MediaType.APPLICATION_JSON)
     @Forget
@@ -413,7 +412,7 @@ public class ActivityController {
     }
 
     /**
-     * Performing a POST on <compensator URL>/compensate will cause the participant to compensate
+     * Performing a PUT on <compensator URL>/compensate will cause the participant to compensate
      * the work that was done within the scope of the transaction.
      *
      * The compensator will either return a 200 OK code and a <status URL> which indicates the outcome and which can be probed (via GET)
@@ -422,7 +421,7 @@ public class ActivityController {
      * <URL>/cannot-compensate
      * <URL>/cannot-complete
      */
-    @POST
+    @PUT
     @Path("/{TxId}/compensate")
     @Produces(MediaType.APPLICATION_JSON)
     public Response compensate(@PathParam("TxId")String txId) throws NotFoundException {
@@ -435,14 +434,14 @@ public class ActivityController {
     }
 
     /**
-     * Performing a POST on <compensator URL>/complete will cause the participant to tidy up and it can forget this transaction.
+     * Performing a PUT on <compensator URL>/complete will cause the participant to tidy up and it can forget this transaction.
      *
      * The compensator will either return a 200 OK code and a <status URL> which indicates the outcome and which can be probed (via GET)
      * and will simply return the same (implicit) information:
      * <URL>/cannot-compensate
      * <URL>/cannot-complete
      */
-    @POST
+    @PUT
     @Path("/{TxId}/complete")
     @Produces(MediaType.APPLICATION_JSON)
     public Response complete(@PathParam("TxId")String txId) throws NotFoundException {
@@ -454,7 +453,7 @@ public class ActivityController {
         return Response.ok(activity.statusUrl).build();
     }
 
-    @POST
+    @PUT
     @Path("/{TxId}/forget")
     public void forget(@PathParam("TxId")String txId) throws NotFoundException {
         Activity activity = activityService.getActivity(txId);

--- a/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/model/Activity.java
+++ b/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/model/Activity.java
@@ -24,17 +24,63 @@ package io.narayana.lra.participant.model;
 import io.narayana.lra.annotation.CompensatorStatus;
 
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Activity implements Serializable {
-
     public String id;
     public String rcvUrl;
     public String statusUrl;
     public CompensatorStatus status;
     public boolean registered;
     public String registrationStatus;
+    private String userData;
+    private String endData;
+    private final AtomicInteger acceptedCount = new AtomicInteger(0);
 
     public Activity(String txId) {
         this.id = txId;
+    }
+
+    public void setUserData(String userData) {
+        this.userData = userData;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+
+    public void setEndData(String endData) {
+        this.endData = endData;
+    }
+
+    public String getEndData() {
+        return endData;
+    }
+
+    @Override
+    public String toString() {
+        return "Activity{" +
+                "id='" + id + '\'' +
+                ", rcvUrl='" + rcvUrl + '\'' +
+                ", statusUrl='" + statusUrl + '\'' +
+                ", status=" + status +
+                ", registered=" + registered +
+                ", registrationStatus='" + registrationStatus + '\'' +
+                ", userData='" + userData + '\'' +
+                ", endData='" + endData + '\'' +
+                '}';
+    }
+
+    public int getAcceptedCount() {
+        return acceptedCount.get();
+    }
+
+    public void setAcceptedCount(int acceptedCount) {
+        this.acceptedCount.set(acceptedCount);
+    }
+
+
+    public int getAndDecrementAcceptCount() {
+        return acceptedCount.getAndDecrement();
     }
 }

--- a/rts/sra/src/main/java/io/narayana/sra/annotation/SRA.java
+++ b/rts/sra/src/main/java/io/narayana/sra/annotation/SRA.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * An annotation for controlling the lifecycle of Short Running Actions (SRAs).
  *
  * Newly created SRAs are uniquely identified and the id is referred to as the SRA context. The context
- * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("X-io.narayana.sra").
+ * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("Short-Running-Action").
  * The implementation (of the SRA specification) is expected to manage this context and the application
  * developer is expected to declaratively control the creation, propagation and destruction of SRAs
  * using the @SRA annotation. When a JAX-RS bean method is invoked in the context of an SRA any JAX-RS

--- a/rts/sra/src/main/java/io/narayana/sra/annotation/TimeLimit.java
+++ b/rts/sra/src/main/java/io/narayana/sra/annotation/TimeLimit.java
@@ -44,5 +44,5 @@ import java.util.concurrent.TimeUnit;
 public @interface TimeLimit {
     long limit() default 0;
 
-    TimeUnit unit() default TimeUnit.MILLISECONDS;
+    TimeUnit unit() default TimeUnit.SECONDS;
 }

--- a/rts/sra/src/main/java/io/narayana/sra/client/SRAClient.java
+++ b/rts/sra/src/main/java/io/narayana/sra/client/SRAClient.java
@@ -67,8 +67,8 @@ import java.util.concurrent.TimeUnit;
  */
 @RequestScoped
 public class SRAClient implements SRAClientAPI, Closeable {
-    public static final String SRA_HTTP_HEADER = "X-io.narayana.sra";
-    public static final String RTS_HTTP_RECOVERY_HEADER = "X-io.narayana.sra-recovery";
+    public static final String SRA_HTTP_HEADER = "Short-Running-Action";
+    public static final String RTS_HTTP_RECOVERY_HEADER = "Short-Running-Action-Recovery";
 
     public static final String COORDINATOR_PATH_NAME = "tx/transaction-manager";
     public static final String RECOVERY_COORDINATOR_PATH_NAME = "tx/transaction-manager";


### PR DESCRIPTION
!BLACKTIE !XTS !PERF NO_WIN !JTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !AS_TESTS !QA_JTS_OPENJDKORB !RTS

These changes implement the spec updates made in https://github.com/jbosstm/microprofile-sandbox/pull/5

https://issues.jboss.org/browse/JBTM-2934 LRA nested and parent coordinators should optimise calls when in a single VM
https://issues.jboss.org/browse/JBTM-2935 Make LRA @Complete optional
https://issues.jboss.org/browse/JBTM-2937 Do not recommend "X-" prefixed headers
https://issues.jboss.org/browse/JBTM-2938 LRA participant complete/compensate methods should use HTTP PUT
https://issues.jboss.org/browse/JBTM-2940 Ensure recovery handles participants that reply with 202 Accepted
