### PR TITLE
Jbtm 2940 Spec Updates

### DIFF
--- a/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/LRA.java
+++ b/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/LRA.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * An annotation for controlling the lifecycle of Long Running Actions (LRAs).
  *
  * Newly created LRAs are uniquely identified and the id is referred to as the LRA context. The context is passed around
- * using a JAX-RS request/response header called LRAClient#LRA_HTTP_HEADER ("X-lra"). The implementation (of the LRA
+ * using a JAX-RS request/response header called LRAClient#LRA_HTTP_HEADER ("Long-Running-Action"). The implementation (of the LRA
  * specification) is expected to manage this context and the application developer is expected to declaratively control
  * the creation, propagation and destruction of LRAs using the @LRA annotation. When a JAX-RS bean method is invoked in the
  * context of an LRA any JAX-RS client requests that it performs will carry the same header so that the receiving

--- a/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/TimeLimit.java
+++ b/rts/lra/lra-annotations/src/main/java/io/narayana/lra/annotation/TimeLimit.java
@@ -49,5 +49,5 @@ public @interface TimeLimit {
      */
     long limit() default 0;
 
-    TimeUnit unit() default TimeUnit.MILLISECONDS;
+    TimeUnit unit() default TimeUnit.SECONDS;
 }

--- a/rts/lra/lra-cdi-rest/src/main/java/io/narayana/lra/cdi/LraAnnotationProcessingExtension.java
+++ b/rts/lra/lra-cdi-rest/src/main/java/io/narayana/lra/cdi/LraAnnotationProcessingExtension.java
@@ -41,7 +41,6 @@ import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.WithAnnotations;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
@@ -134,7 +133,7 @@ public class LraAnnotationProcessingExtension implements Extension {
 
         if(methodsWithCompensate.size() > 0) {
             // Each method annotated with LRA-style annotations contain all necessary REST annotations
-            // @Compensate - requires @Path and @POST
+            // @Compensate - requires @Path and @PUT
             final AnnotatedMethod<? super X> methodWithCompensate = methodsWithCompensate.get(0);
             Function<Class<?>, String> getCompensateMissingErrMsg = (wrongAnnotation) ->
                 getMissingAnnotationError(methodWithCompensate, classAnnotatedWithLra, Compensate.class, wrongAnnotation);
@@ -142,9 +141,9 @@ public class LraAnnotationProcessingExtension implements Extension {
             if(!isCompensateContainsPathAnnotation) {
                 throw new DeploymentException(getCompensateMissingErrMsg.apply(Path.class));
             }
-            boolean isCompensateContainsPostAnnotation = methodWithCompensate.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(POST.class));
-            if(!isCompensateContainsPostAnnotation) {
-                throw new DeploymentException(getCompensateMissingErrMsg.apply(POST.class));
+            boolean isCompensateContainsPutAnnotation = methodWithCompensate.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(PUT.class));
+            if(!isCompensateContainsPutAnnotation) {
+                throw new DeploymentException(getCompensateMissingErrMsg.apply(PUT.class));
             }
         }
         
@@ -164,7 +163,7 @@ public class LraAnnotationProcessingExtension implements Extension {
         }
 
         if(methodsWithComplete.size() > 0) {
-            // @Complete - requires @Path and @POST
+            // @Complete - requires @Path and @PUT
             final AnnotatedMethod<? super X> methodWithComplete = methodsWithComplete.get(0);
             Function<Class<?>, String> getCompleteMissingErrMsg = (wrongAnnotation) ->
                 getMissingAnnotationError(methodWithComplete, classAnnotatedWithLra, Complete.class, wrongAnnotation);
@@ -172,9 +171,24 @@ public class LraAnnotationProcessingExtension implements Extension {
             if(!isCompleteContainsPathAnnotation) {
                 throw new DeploymentException(getCompleteMissingErrMsg.apply(Path.class));
             }
-            boolean isCompleteContainsPostAnnotation = methodWithComplete.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(POST.class));
-            if(!isCompleteContainsPostAnnotation) {
-                throw new DeploymentException(getCompleteMissingErrMsg.apply(POST.class));
+            boolean isCompleteContainsPutAnnotation = methodWithComplete.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(PUT.class));
+            if(!isCompleteContainsPutAnnotation) {
+                throw new DeploymentException(getCompleteMissingErrMsg.apply(PUT.class));
+            }
+        }
+        
+        if(methodsWithStatus.size() > 0) {
+            // @Status - requires @Path and @GET
+            final AnnotatedMethod<? super X> methodWithStatus = methodsWithStatus.get(0);
+            Function<Class<?>, String> getStatusMissingErrMsg = (wrongAnnotation) ->
+                getMissingAnnotationError(methodWithStatus, classAnnotatedWithLra, Status.class, wrongAnnotation);
+            boolean isStatusContainsPathAnnotation = methodWithStatus.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(Path.class));
+            if(!isStatusContainsPathAnnotation) {
+                throw new DeploymentException(getStatusMissingErrMsg.apply(Path.class));
+            }
+            boolean isStatusContainsGetAnnotation = methodWithStatus.getAnnotations().stream().anyMatch(a -> a.annotationType().equals(GET.class));
+            if(!isStatusContainsGetAnnotation) {
+                throw new DeploymentException(getStatusMissingErrMsg.apply(GET.class));
             }
         }
 

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
@@ -88,7 +88,7 @@ public class StartCdiCheckIT {
     
     @Test
     public void methodTypeAnnotationMissing() throws Exception {
-        checkSwarmWithDeploymentException("should use complementary annotation.*(POST|GET)",
+        checkSwarmWithDeploymentException("should use complementary annotation.*(PUT|GET)",
             NoPostOrGetBean.class);
     }
     

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CompleteOptionalBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CompleteOptionalBean.java
@@ -23,7 +23,7 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -43,7 +43,7 @@ public class CompleteOptionalBean {
 
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectBean.java
@@ -23,7 +23,7 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -39,14 +39,14 @@ import io.narayana.lra.annotation.Status;
 public class CorrectBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectMethodLRABean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/CorrectMethodLRABean.java
@@ -23,7 +23,7 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -43,14 +43,14 @@ public class CorrectMethodLRABean {
 
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/ForgetWithoutDeleteBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/ForgetWithoutDeleteBean.java
@@ -24,7 +24,7 @@ package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -41,14 +41,14 @@ import io.narayana.lra.annotation.Status;
 public class ForgetWithoutDeleteBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LeaveWithoutPutBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/LeaveWithoutPutBean.java
@@ -23,7 +23,6 @@
 package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
@@ -41,14 +40,14 @@ import io.narayana.lra.annotation.Status;
 public class LeaveWithoutPutBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/MultiForgetBean.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/bean/MultiForgetBean.java
@@ -24,7 +24,7 @@ package io.narayana.lra.cdi.bean;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 
 import io.narayana.lra.annotation.Compensate;
@@ -40,14 +40,14 @@ import io.narayana.lra.annotation.Status;
 public class MultiForgetBean {
     @Complete
     @Path("complete")
-    @POST
+    @PUT
     public void complete() {
         // no implementation needed
     }
     
     @Compensate
     @Path("compensate")
-    @POST
+    @PUT
     public void compensate() {
         // no implementation needed
     }

--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClient.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClient.java
@@ -75,8 +75,8 @@ import java.util.concurrent.TimeUnit;
  */
 @RequestScoped
 public class LRAClient implements LRAClientAPI, Closeable {
-    public static final String LRA_HTTP_HEADER = "X-lra";
-    public static final String LRA_HTTP_RECOVERY_HEADER = "X-lra-recovery";
+    public static final String LRA_HTTP_HEADER = "Long-Running-Action";
+    public static final String LRA_HTTP_RECOVERY_HEADER = "Long-Running-Action-Recovery";
 
     public static final String COORDINATOR_PATH_NAME = "lra-coordinator";
     public static final String RECOVERY_COORDINATOR_PATH_NAME = "lra-recovery-coordinator";
@@ -236,7 +236,7 @@ public class LRAClient implements LRAClientAPI, Closeable {
 
     @Override
     public URL startLRA(String clientID, Long timeout) throws GenericLRAException {
-        return startLRA(null, clientID, timeout, TimeUnit.MILLISECONDS);
+        return startLRA(null, clientID, timeout, TimeUnit.SECONDS);
     }
 
     @Override
@@ -268,8 +268,8 @@ public class LRAClient implements LRAClientAPI, Closeable {
                     .post(Entity.text(""));
 
             // validate the HTTP status code says an LRAStatus resource was created
-            assertEquals(response, response.getStatus(), Response.Status.CREATED.getStatusCode(),
-                    "LRA start returned an unexpected status code: %d versus %d");
+            checkStatus(null, response, "LRA start returned an unexpected status code: %d",
+                    Response.Status.CREATED);
 
             // validate that there is an LRAStatus response header holding the LRAStatus id
             Object lraObject = response.getHeaders().getFirst(LRA_HTTP_HEADER);
@@ -501,10 +501,12 @@ public class LRAClient implements LRAClientAPI, Closeable {
         Map<String, String> paths = new HashMap<>();
 
         Annotation resourcePathAnnotation = compensatorClass.getAnnotation(Path.class);
-        String resourcePath = resourcePathAnnotation == null ? "/" : ((Path) resourcePathAnnotation).value();
+        String resourcePath = resourcePathAnnotation == null
+                ? ""
+                : ((Path) resourcePathAnnotation).value().replaceAll("^/+", "");
 
         final String uriPrefix = String.format("%s:%s%s",
-                baseUri.getScheme(), baseUri.getSchemeSpecificPart(), resourcePath.substring(1))
+                baseUri.getScheme(), baseUri.getSchemeSpecificPart(), resourcePath)
                 .replaceAll("/$", "");
 
         Arrays.stream(compensatorClass.getMethods()).forEach(method -> {
@@ -546,8 +548,19 @@ public class LRAClient implements LRAClientAPI, Closeable {
                                 Path pathAnnotation,
                                 Annotation annotationClass,
                                 String uriPrefix) {
-        if (annotationClass == null)
+            /*
+             * If the annotationClass is null the requested compensator annotation is not present,
+             * but we also need to check for conformance with the interoperability spec,
+             * ie look for paths of the form:
+             * `<compensator URL>/compensate`
+             * `<compensator URL>/complete`
+             * etc
+             */
+        if (annotationClass == null) {
+            // TODO support standard compenators with: && !pathAnnotation.value().endsWith(rel)) {
+            // ie ones that do not use the @Compensate annotation
             return 0;
+        }
 
         paths.put(rel, uriPrefix + pathAnnotation.value());
 
@@ -651,9 +664,8 @@ public class LRAClient implements LRAClientAPI, Closeable {
         try {
             response = getTarget().path(confirmUrl).request().put(Entity.text(""));
 
-            assertEquals(response, Response.Status.OK.getStatusCode(),
-                    response.getStatus(), "LRA finished with an unexpected status code: "
-                            + response.getStatus());
+            checkStatus(lra, response,"LRA finished with an unexpected status code: %d",
+                    Response.Status.OK, Response.Status.ACCEPTED);
 
             String responseData = response.readEntity(String.class);
 
@@ -699,10 +711,14 @@ public class LRAClient implements LRAClientAPI, Closeable {
                     message, null);
     }
 
-    private void assertEquals(Response response, Object expected, Object actual, String messageFormat) {
-        if (!actual.equals(expected))
-            throw new GenericLRAException(null, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                    String.format(messageFormat, expected, actual), null);
+    private void checkStatus(URL lraId, Response response, String messageFormat, Response.Status... expected) {
+        for (Response.Status anExpected : expected) {
+            if (response.getStatus() == anExpected.getStatusCode())
+                return;
+        }
+
+        throw new GenericLRAException(lraId, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                String.format(messageFormat, response.getStatus()), null);
     }
 
     public String getUrl() {

--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClientAPI.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClientAPI.java
@@ -168,9 +168,9 @@ public interface LRAClientAPI {
      *                -  Completing: the Compensator is tidying up after being told to complete.
      *                -  Completed: the coordinator/participant has confirmed.
      *                -  FailedToComplete: the Compensator was unable to tidy-up.
-     *                     Performing a POST on URL/compensate will cause the compensator to compensate
+     *                     Performing a PUT on URL/compensate will cause the compensator to compensate
      *                     the work that was done within the scope of the LRA.
-     *                     Performing a POST on URL/complete will cause the compensator to tidy up and
+     *                     Performing a PUT on URL/complete will cause the compensator to tidy up and
      *                  it can forget this LRA.  (optional)
      *
      * @param compensatorData
@@ -187,9 +187,9 @@ public interface LRAClientAPI {
      * @param lraId The unique identifier of the LRA (required)
      * @param timelimit The time limit (in seconds) that the Compensator can guarantee that it
      *                can compensate the work performed by the service
-     * @param compensateUrl Performing a POST onthis URL will cause the participant to compensate the work that
+     * @param compensateUrl Performing a PUT onthis URL will cause the participant to compensate the work that
      *                      was done within the scope of the LRA.
-     * @param completeUrl Performing a POST on this URL  will cause the participant to tidy up and it can forget this transaction.
+     * @param completeUrl Performing a PUT on this URL  will cause the participant to tidy up and it can forget this transaction.
      * @param leaveUrl Performing a PUT on this URL with cause the compensator to leave the LRA
      * @param statusUrl Performing a GET on this URL will return the status of the compensator {@see joinLRA}
      *

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -249,19 +249,19 @@ public class Coordinator {
         return Response.ok(lra.getLRAStatus().name()).build();
     }
 
-    @POST
+    @PUT
     @Path("{NestedLraId}/complete")
     public Response completeNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         return endLRA(toURL(nestedLraId), false, true);
     }
 
-    @POST
+    @PUT
     @Path("{NestedLraId}/compensate")
     public Response compensateNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         return endLRA(toURL(nestedLraId), true, true);
     }
 
-    @POST
+    @PUT
     @Path("{NestedLraId}/forget")
     public Response forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
         lraService.remove(null, toURL(nestedLraId));
@@ -449,9 +449,9 @@ public class Coordinator {
                     + "-  Completed: the coordinator/participant has confirmed.\n"
                     + "-  FailedToComplete: the Compensator was unable to tidy-up.\n"
                     + "\n"
-                    + "Performing a POST on <URL>/compensate will cause the compensator to compensate\n"
+                    + "Performing a PUT on <URL>/compensate will cause the compensator to compensate\n"
                     + "  the work that was done within the scope of the LRA.\n"
-                    + "Performing a POST on <URL>/complete will cause the compensator to tidy up and\n"
+                    + "Performing a PUT on <URL>/complete will cause the compensator to tidy up and\n"
                     + "   it can forget this LRA.\n")
                     String compensatorUrl) throws NotFoundException {
         // test to see if the join request contains any compensator specific data

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
@@ -22,6 +22,7 @@
 package io.narayana.lra.coordinator.api;
 
 import io.narayana.lra.client.GenericLRAException;
+import io.narayana.lra.coordinator.domain.model.LRAStatus;
 import io.narayana.lra.coordinator.domain.service.LRAService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 @ApplicationScoped
 @Path(LRAClient.RECOVERY_COORDINATOR_PATH_NAME)
@@ -127,5 +129,18 @@ public class RecoveryCoordinator {
         }
 
         throw new NotFoundException(rcvCoordId);
+    }
+
+    @GET
+    @Path("recovery")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "List recovering Long Running Actions",
+            notes = "Returns LRAs that are recovering (ie some compensators still need to be ran)",
+            response = LRAStatus.class, responseContainer = "List")
+    @ApiResponses( {
+            @ApiResponse( code = 200, message = "The request was successful" )
+    } )
+    public List<LRAStatus> getRecoveringLRAs() {
+        return lraService.getAllRecovering(true);
     }
 }

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -182,6 +182,10 @@ public class Transaction extends AtomicAction {
 
                 if (record == null || !record.restore_state(os, ot) || !list.insert(record))
                     return false;
+
+                if (record instanceof LRARecord)
+                    ((LRARecord) record).setLRAService(lraService);
+
             }
         } catch (IOException e1) {
             return false;
@@ -434,7 +438,7 @@ public class Transaction extends AtomicAction {
         if (findLRAParticipant(participantUrl, false) != null)
             return null;    // already enlisted
 
-        LRARecord p = new LRARecord(coordinatorUrl.toExternalForm(), participantUrl, compensatorData);
+        LRARecord p = new LRARecord(lraService, coordinatorUrl.toExternalForm(), participantUrl, compensatorData);
         String pid = p.get_uid().fileStringForm();
 
         String txId = URLEncoder.encode(coordinatorUrl.toExternalForm(), "UTF-8");

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -86,8 +86,15 @@ public class LRAService {
         return lras.values().stream().map(LRAStatus::new).collect(toList());
     }
 
-    public List<LRAStatus> getAllRecovering() {
+    public List<LRAStatus> getAllRecovering(boolean scan) {
+        if (scan)
+            RecoveryManager.manager().scan();
+
         return recoveringLRAs.values().stream().map(LRAStatus::new).collect(toList());
+    }
+
+    public List<LRAStatus> getAllRecovering() {
+        return getAllRecovering(false);
     }
 
     public void addTransaction(Transaction lra) {

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
@@ -118,42 +118,6 @@ public class LRARecoveryModule implements RecoveryModule {
             }
     }
 
-    private boolean isTransactionInMidFlight( int status )
-    {
-        boolean inFlight;
-
-        switch ( status )
-        {
-            // these states can only come from a process that is still alive
-            case ActionStatus.RUNNING    :
-            case ActionStatus.ABORT_ONLY :
-            case ActionStatus.PREPARING  :
-            case ActionStatus.COMMITTING :
-            case ActionStatus.ABORTING   :
-            case ActionStatus.PREPARED   :
-                inFlight = true ;
-                break ;
-
-            // the transaction is apparently still there, but has completed its
-            // phase2. should be safe to redo it.
-            case ActionStatus.COMMITTED  :
-            case ActionStatus.H_COMMIT   :
-            case ActionStatus.H_MIXED    :
-            case ActionStatus.H_HAZARD   :
-            case ActionStatus.ABORTED    :
-            case ActionStatus.H_ROLLBACK :
-                inFlight = false ;
-                break ;
-
-            // this shouldn't happen
-            case ActionStatus.INVALID :
-            default:
-                inFlight = false ;
-        }
-
-        return inFlight ;
-    }
-
     private Vector<Uid> processTransactions( InputObjectState uids ) {
         Vector<Uid> uidVector = new Vector<>() ;
 

--- a/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/model/Activity.java
+++ b/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/model/Activity.java
@@ -24,17 +24,63 @@ package io.narayana.lra.participant.model;
 import io.narayana.lra.annotation.CompensatorStatus;
 
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Activity implements Serializable {
-
     public String id;
     public String rcvUrl;
     public String statusUrl;
     public CompensatorStatus status;
     public boolean registered;
     public String registrationStatus;
+    private String userData;
+    private String endData;
+    private final AtomicInteger acceptedCount = new AtomicInteger(0);
 
     public Activity(String txId) {
         this.id = txId;
+    }
+
+    public void setUserData(String userData) {
+        this.userData = userData;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+
+    public void setEndData(String endData) {
+        this.endData = endData;
+    }
+
+    public String getEndData() {
+        return endData;
+    }
+
+    @Override
+    public String toString() {
+        return "Activity{" +
+                "id='" + id + '\'' +
+                ", rcvUrl='" + rcvUrl + '\'' +
+                ", statusUrl='" + statusUrl + '\'' +
+                ", status=" + status +
+                ", registered=" + registered +
+                ", registrationStatus='" + registrationStatus + '\'' +
+                ", userData='" + userData + '\'' +
+                ", endData='" + endData + '\'' +
+                '}';
+    }
+
+    public int getAcceptedCount() {
+        return acceptedCount.get();
+    }
+
+    public void setAcceptedCount(int acceptedCount) {
+        this.acceptedCount.set(acceptedCount);
+    }
+
+
+    public int getAndDecrementAcceptCount() {
+        return acceptedCount.getAndDecrement();
     }
 }

--- a/rts/sra/src/main/java/io/narayana/sra/annotation/SRA.java
+++ b/rts/sra/src/main/java/io/narayana/sra/annotation/SRA.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * An annotation for controlling the lifecycle of Short Running Actions (SRAs).
  *
  * Newly created SRAs are uniquely identified and the id is referred to as the SRA context. The context
- * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("X-io.narayana.sra").
+ * is passed around using a JAX-RS request/response header called SRAClient#SRA_HTTP_HEADER ("Short-Running-Action").
  * The implementation (of the SRA specification) is expected to manage this context and the application
  * developer is expected to declaratively control the creation, propagation and destruction of SRAs
  * using the @SRA annotation. When a JAX-RS bean method is invoked in the context of an SRA any JAX-RS

--- a/rts/sra/src/main/java/io/narayana/sra/annotation/TimeLimit.java
+++ b/rts/sra/src/main/java/io/narayana/sra/annotation/TimeLimit.java
@@ -44,5 +44,5 @@ import java.util.concurrent.TimeUnit;
 public @interface TimeLimit {
     long limit() default 0;
 
-    TimeUnit unit() default TimeUnit.MILLISECONDS;
+    TimeUnit unit() default TimeUnit.SECONDS;
 }

--- a/rts/sra/src/main/java/io/narayana/sra/client/SRAClient.java
+++ b/rts/sra/src/main/java/io/narayana/sra/client/SRAClient.java
@@ -67,8 +67,8 @@ import java.util.concurrent.TimeUnit;
  */
 @RequestScoped
 public class SRAClient implements SRAClientAPI, Closeable {
-    public static final String SRA_HTTP_HEADER = "X-io.narayana.sra";
-    public static final String RTS_HTTP_RECOVERY_HEADER = "X-io.narayana.sra-recovery";
+    public static final String SRA_HTTP_HEADER = "Short-Running-Action";
+    public static final String RTS_HTTP_RECOVERY_HEADER = "Short-Running-Action-Recovery";
 
     public static final String COORDINATOR_PATH_NAME = "tx/transaction-manager";
     public static final String RECOVERY_COORDINATOR_PATH_NAME = "tx/transaction-manager";


### PR DESCRIPTION
!BLACKTIE !XTS !PERF NO_WIN !JTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !AS_TESTS !QA_JTS_OPENJDKORB !RTS

These changes implement the spec updates made in https://github.com/jbosstm/microprofile-sandbox/pull/5 (my plan is to raise the spec PR today).

https://issues.jboss.org/browse/JBTM-2934 LRA nested and parent coordinators should optimise calls when in a single VM
https://issues.jboss.org/browse/JBTM-2935 Make LRA @complete optional
https://issues.jboss.org/browse/JBTM-2937 Do not recommend "X-" prefixed headers
https://issues.jboss.org/browse/JBTM-2938 LRA participant complete/compensate methods should use HTTP PUT
https://issues.jboss.org/browse/JBTM-2940 Ensure recovery handles participants that reply with 202 Accepted