### PR TITLE
JBTM-2947 LRA end calls return the status

### DIFF
--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClient.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/LRAClient.java
@@ -36,11 +36,9 @@ import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.narayana.lra.annotation.TimeLimit;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.io.StringReader;
 
 import javax.ws.rs.Path;
@@ -66,7 +64,6 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +119,7 @@ public class LRAClient implements LRAClientAPI, Closeable {
     private Client client;
     private boolean isUseable;
     private boolean connectionInUse;
-    private Map<URL, List<String>> responseDataMap;
+    private Map<URL, String> responseDataMap;
 
     public LRAClient() throws URISyntaxException {
         this("http",
@@ -847,6 +844,8 @@ public class LRAClient implements LRAClientAPI, Closeable {
     }
 
     private void setResponseData(URL lraId, String responseData) {
+        responseDataMap.put(lraId, responseData);
+/*
         if (responseData == null || responseData.isEmpty())
             return;
 
@@ -863,9 +862,10 @@ public class LRAClient implements LRAClientAPI, Closeable {
         } catch (IOException e) {
             e.printStackTrace();
         }
+*/
     }
 
-    public List<String> getResponseData(URL lraId) {
-        return responseDataMap.containsKey(lraId) ? responseDataMap.get(lraId) : Collections.emptyList();
+    public String getResponseData(URL lraId) {
+        return responseDataMap.containsKey(lraId) ? responseDataMap.get(lraId) : null;
     }
 }

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -342,12 +342,6 @@ public class Coordinator {
 
     private Response endLRA(URL lraId, boolean compensate, boolean fromHierarchy) throws NotFoundException {
         LRAStatus status = lraService.endLRA(lraId, compensate, fromHierarchy);
-        String compensatorData;
-        try {
-            compensatorData = status.getEncodedResponseData();
-        } catch (IOException e) {
-            compensatorData = "Unable to encode as JSON";
-        }
 
         return Response.ok(status.getStatus().name()).build();
 //        return compensatorData == null

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAStatus.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAStatus.java
@@ -47,7 +47,7 @@ public class LRAStatus {
     //    @ApiModelProperty( value = "Indicates whether or not this LRA is top level", required = false )
     private boolean isTopLevel;
     private int httpStatus;
-    private List<String> responseData;
+    private String responseData;
 
     private CompensatorStatus status;
 
@@ -120,19 +120,11 @@ public class LRAStatus {
         return httpStatus;
     }
 
-    public List<String> getResponseData() {
+    public String getResponseData() {
         return responseData;
     }
 
     public String getEncodedResponseData() throws IOException {
-        if (responseData == null || responseData.size() == 0)
-            return null;
-
-        final StringWriter sw = new StringWriter();
-        final ObjectMapper mapper = new ObjectMapper();
-
-        mapper.writeValue(sw, responseData);
-
-        return sw.toString();
+        return responseData;
     }
 }

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -70,7 +70,7 @@ public class Transaction extends AtomicAction {
     private String clientId;
     private List<LRARecord> pending;
     private CompensatorStatus status; // reuse commpensator states for the LRA
-    private List<String> responseData;
+    private String responseData;
     private LocalDateTime cancelOn; // TODO make sure this acted upon during restore_state()
     private ScheduledFuture<?> scheduledAbort;
     private boolean inFlight;
@@ -351,12 +351,6 @@ public class Transaction extends AtomicAction {
         ObjectMapper mapper = new ObjectMapper();
 
         if (pending != null && pending.size() != 0) {
-            responseData = pending.stream()
-                    .map(LRARecord::getResponseData)
-                    .map(s -> getCompensatorResponse(mapper, s)) // some compensators may be for nested LRAs so their response data will be an encoded array
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toList());
-
             if (!nested)
                 pending.clear(); // TODO we will loose this data if we need recovery
         }
@@ -373,6 +367,8 @@ public class Transaction extends AtomicAction {
                 lraService.finished(this, false);
         else
             System.out.printf("WARNING null LRAService in LRA#end");
+
+        responseData = status == null ? null : status.name();
 
         return res;
     }
@@ -538,7 +534,7 @@ public class Transaction extends AtomicAction {
         return parentId == null;
     }
 
-    public List<String> getResponseData() {
+    public String getResponseData() {
         return responseData;
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2947

!BLACKTIE !XTS !PERF NO_WIN !JTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !AS_TESTS !QA_JTS_OPENJDKORB !RTS

The specification used to return participant completion data to the client that closed an LRA. The spec has changed and now it just returns the status of the LRA.

Enables:  jbosstm/quickstart#208