### PR TITLE
[JBTM-2948] for failed beforeCompletion failure it could happen

### DIFF
--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/subordinate/SubordinateATCoordinator.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/subordinate/SubordinateATCoordinator.java
@@ -240,6 +240,12 @@ public class SubordinateATCoordinator extends ATCoordinator
      */
 	public void rollback ()
 	{
+		// as this coordinator could be called as normal XAResource by topLeveRecord
+		// this rollback call could be part of the prevent commit when beforeCompletion fails
+		// in such case the heuristicList was not created by prepare call and may throw NPE
+		if(heuristicList == null)
+		    heuristicList = new RecordList();
+
 		super.phase2Abort(true);
 		
 		int status;

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/common/AbstractBasicTests.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/common/AbstractBasicTests.java
@@ -96,11 +96,11 @@ public abstract class AbstractBasicTests {
     }
 
 
-    protected void execute(String url) throws Exception {
-        execute(url, true);
+    protected String execute(String url) throws Exception {
+        return execute(url, true);
     }
 
-    protected void execute(String url, boolean expectResponse) throws Exception {
+    protected String execute(String url, boolean expectResponse) throws Exception {
         try {
             DefaultHttpClient httpclient = new DefaultHttpClient();
             HttpGet httpget = new HttpGet(url);
@@ -108,13 +108,16 @@ public abstract class AbstractBasicTests {
             String response = httpclient.execute(httpget, responseHandler);
 
             if (expectResponse) {
-                Assert.assertEquals("Invalid response!", "finished", response.trim());
+                Assert.assertTrue("Invalid response! Expected to start with 'finished' but it's: "
+                    + response, response.trim().startsWith("finished"));
+                return response;
             }
         } catch (IOException e) {
             if (expectResponse) {
                 throw e;
             }
         }
+        return null;
     }
 
 }

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/client/TestClient.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/client/TestClient.java
@@ -95,6 +95,7 @@ public class TestClient extends HttpServlet {
     }
 
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String result = "OK";
         try {
             log.info("starting the transaction...");
 
@@ -111,13 +112,15 @@ public class TestClient extends HttpServlet {
             terminateTransaction(false);
         } catch (final RollbackException re) {
             log.info("Transaction rolled back");
+            result = re.getClass().getName();
         } catch (Exception e) {
             log.info("problem: ", e);
+            result = e.getClass().getName();
         }
 
         response.setContentType("text/plain");
         PrintWriter out = response.getWriter();
-        out.println("finished");
+        out.println("finished : " + result);
         out.close();
     }
 

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/service/TestServiceImpl.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/service/TestServiceImpl.java
@@ -55,6 +55,7 @@ public class TestServiceImpl {
     }
 
     public void enlistVolatileParticipant(int count) {
+        log.tracef("enlisting %s of %s", count, TestVolatileParticipant.class.getName());
         TransactionManager tm = TransactionManagerFactory.transactionManager();
         try {
             for (int i = 0; i < count; i++) {
@@ -67,6 +68,7 @@ public class TestServiceImpl {
     }
 
     public void enlistDurableParticipant(int count) {
+        log.tracef("enlisting %s of %s", count, TestDurableParticipant.class.getName());
         TransactionManager tm = TransactionManagerFactory.transactionManager();
         try {
             for (int i = 0; i < count; i++) {


### PR DESCRIPTION
having empty heuristics list which then fails with NPE

This issue came from the observation on customer log.

I would like present the fix of the issue but currently I do not have a reproducer. I would like to check with you about this issue and if you are okI would prepare a testcase.

https://issues.jboss.org/browse/JBTM-2948

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF