### PR TITLE
JBTM-2949 - Remove synchronization from ThreadUtil.getThreadId

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/utils/ThreadUtil.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/utils/ThreadUtil.java
@@ -20,23 +20,11 @@
  */
 package com.arjuna.ats.arjuna.utils;
 
-import java.util.WeakHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-
 /**
  * Provides utilities to manage thread ids.
  */
 public class ThreadUtil
 {
-    /**
-     * The ID associated with the thread.
-     */
-    private static final WeakHashMap<Thread,String> THREAD_ID = new WeakHashMap<Thread,String>() ;
-    /**
-     * The thread id counter.
-     */
-    private static AtomicLong id = new AtomicLong();
-    
     /**
      * Get the string ID for the current thread.
      * @return The thread id
@@ -51,25 +39,8 @@ public class ThreadUtil
      * @param thread The thread.
      * @return The thread id
      */
-    public static synchronized String getThreadId(final Thread thread)
+    public static String getThreadId(final Thread thread)
     {
-	final String id = THREAD_ID.get(thread) ;
-	if (id != null)
-	{
-	    return id ;
-	}
-	
-	final String newId = getNextId() ;
-	THREAD_ID.put(thread,newId) ;
-	return newId ;
-    }
-    
-    /**
-     * Get the next thread id to use.
-     * @return The next thread id.
-     */
-    private static String getNextId()
-    {
-	return Long.toHexString(id.incrementAndGet()) ;
+	return Long.toHexString(thread.getId()) ;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2949

This uses the strategy defined in the issue as number 2, to use Thread.getId().
Although the javadoc from Thread.getId() mentiones the following:

> Returns the identifier of this Thread. The thread ID is a positive long number generated when this thread was created. The thread ID is unique and remains unchanged during its lifetime. When a thread is terminated, this thread ID may be reused.

The reality is that IDs are generated from a counter, just like what ThreadUtil does now, and therefore both solutions have roughly the same behavior.

!RTS !XTS !BLACKTIE !QA_JTS_JDKORB !QA_JTS_JACORB !QA_JTS_OPENJDKORB !MAIN !AS_TESTS NO_WIN !QA_JTA
