### PR TITLE
[JBTM-2951] providers are registered twice - by annotation and by descriptor

### DIFF
--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRARequestFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRARequestFilter.java
@@ -25,10 +25,8 @@ import io.narayana.lra.client.Current;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 
-@Provider
 public class ClientLRARequestFilter implements ClientRequestFilter {
     @Override
     public void filter(ClientRequestContext context) throws IOException {

--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRAResponseFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRAResponseFilter.java
@@ -26,13 +26,11 @@ import io.narayana.lra.client.Current;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
-import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.net.URL;
 
 import static io.narayana.lra.client.LRAClient.LRA_HTTP_HEADER;
 
-@Provider
 public class ClientLRAResponseFilter implements ClientResponseFilter {
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {


### PR DESCRIPTION
Proposing a fix for not getting WARN messages on app startup using LRACLient which normally shows duplicate warns.

https://issues.jboss.org/browse/JBTM-2951

Warning means that registration of the REST provider is done several times - only `@Provider` annotation should be enough.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !mysql !postgres !db2 !oracle