### PR TITLE
[JBTM-2932] lra cdi checker add waiting a while to be sure weld container was stopped

### DIFF
--- a/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
+++ b/rts/lra/lra-cdi-rest/src/test/java/io/narayana/lra/cdi/StartCdiCheckIT.java
@@ -127,7 +127,7 @@ public class StartCdiCheckIT {
         try {
             swarm.deploy(getBaseDeployment().addClasses(LraJoinFalseBean.class));
         } finally {
-            swarm.stop();
+            stopSwarm(swarm);
         }
     }
 
@@ -137,7 +137,7 @@ public class StartCdiCheckIT {
         try {
             swarm.deploy(getBaseDeployment().addClasses(LraJoinFalseMethodLRABean.class));
         } finally {
-            swarm.stop();
+            stopSwarm(swarm);
         }
     }
 
@@ -147,7 +147,7 @@ public class StartCdiCheckIT {
         try {
             swarm.deploy(getBaseDeployment().addClasses(CorrectBean.class));
         } finally {
-            swarm.stop();
+            stopSwarm(swarm);
         }
     }
 
@@ -157,7 +157,7 @@ public class StartCdiCheckIT {
         try {
             swarm.deploy(getBaseDeployment().addClasses(CorrectMethodLRABean.class));
         } finally {
-            swarm.stop();
+            stopSwarm(swarm);
         }
     }
 
@@ -167,7 +167,7 @@ public class StartCdiCheckIT {
         try {
             swarm.deploy(getBaseDeployment().addClasses(LRANoContextBean.class));
         } finally {
-            swarm.stop();
+            stopSwarm(swarm);
         }
     }
 
@@ -203,7 +203,7 @@ public class StartCdiCheckIT {
                 log.errorf(startE, "Error starting swarm '%s' for test '%s'", swarm, testMethodName);
                 runWithTimeout(() -> {
                     try {
-                        swarm.stop();
+                        stopSwarm(swarm);
                     } catch (Exception stopE) {
                         log.debugf(stopE, "Error stopping swarm '%s' for test '%s'", swarm, testMethodName);
                     }
@@ -212,6 +212,12 @@ public class StartCdiCheckIT {
         }, SWARM_START_TIMEOUT, TimeUnit.MINUTES);
 
         return swarm;
+    }
+
+    private void stopSwarm(Swarm swarm) throws Exception {
+        swarm.stop();
+        // sleeping a sec to be sure that weld container shutdown hook was processed
+        Thread.sleep(1500);
     }
 
     private static void runWithTimeout(Runnable r, int timeout, TimeUnit timeUnit) {
@@ -244,7 +250,7 @@ public class StartCdiCheckIT {
         } catch (org.wildfly.swarm.container.DeploymentException de) {
             // expected
         } finally {
-            swarm.stop();
+            stopSwarm(swarm);
         }
 
         assertLogLine(new File(LOG_FILE_NAME), stringToMatch);


### PR DESCRIPTION
this is a follow-up for https://issues.jboss.org/browse/JBTM-2932

The issue on the Newcastle cluster is that for some tests cdi container is not stopped. Now it seems there is not enough time to be done so and this is a hot fix to get cdi container more time to be stopped. 

The follow-up solution should be probably to run the whole Swarm as separate process and not as embedded.

FYI NO_TEST should include all of the following

!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !mysql !postgres !db2 !oracle