### PR TITLE
JBTM-2961 Temporarily disabling the lra cdi checker (fails on mac builds)

### DIFF
--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -137,7 +137,9 @@
         <module>lra-coordinator</module>
         <module>lra-filters</module>
         <module>lra-test</module>
+        <!-- temporarily disable since it is failing the mac builds
         <module>lra-cdi-rest</module>
+        -->
     </modules>
 
     <profiles>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2961

NO_TEST