### PR TITLE
[JBTM-2973] direct recoverable connection to be recoverable

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/recovery/JDBCXARecovery.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/recovery/JDBCXARecovery.java
@@ -149,9 +149,7 @@ public class JDBCXARecovery implements XAResourceRecovery
      * property file provided at input to this instance.
      */
 
-    private final void createDataSource()
-        throws SQLException
-    {
+    private final void createDataSource() throws SQLException {
         try
         {
             if (_dataSource == null)
@@ -161,18 +159,18 @@ public class JDBCXARecovery implements XAResourceRecovery
                 _dataSource = (XADataSource) context.lookup(_dbName);
 
                 if (_dataSource == null)
-                    throw new SQLException(jdbcLogger.i18NLogger.get_xa_recjndierror());
+                    throw new SQLException(jdbcLogger.i18NLogger.get_cant_resolve_ds_jndi_lookup(_dbName, env));
             }
         }
         catch (SQLException ex)
         {
-            ex.printStackTrace();
+            jdbcLogger.i18NLogger.error_cannot_create_datasource(_dbName, ex);
 
             throw ex;
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            jdbcLogger.i18NLogger.error_cannot_create_datasource(_dbName, e);
 
             SQLException sqlException = new SQLException(e.toString());
             sqlException.initCause(e);
@@ -184,13 +182,13 @@ public class JDBCXARecovery implements XAResourceRecovery
      * Create the XAConnection from the XADataSource.
      */
 
-    private final void createConnection()
-        throws SQLException
+    private final void createConnection() throws SQLException
     {
+        if (_dataSource == null)
+            createDataSource();
+
         try
         {
-            if (_dataSource == null)
-                createDataSource();
 
             if (_connection == null)
             {
@@ -204,13 +202,13 @@ public class JDBCXARecovery implements XAResourceRecovery
         }
         catch (SQLException ex)
         {
-            ex.printStackTrace();
+            jdbcLogger.i18NLogger.error_cannot_create_connection(_dataSource, _user, _password, ex);
 
             throw ex;
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            jdbcLogger.i18NLogger.error_cannot_create_connection(_dataSource, _user, _password, e);
 
             SQLException sqlException = new SQLException(e.toString());
             sqlException.initCause(e);

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/jdbc/logging/jdbcI18NLogger.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/jdbc/logging/jdbcI18NLogger.java
@@ -23,7 +23,12 @@ package com.arjuna.ats.jdbc.logging;
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
+import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT;
+
+import java.util.Hashtable;
+
+import javax.sql.XADataSource;
 
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -179,6 +184,17 @@ public interface jdbcI18NLogger {
 
 	@Message(id = 17039, value = "BasicXARecovery did not have enough connection configuration", format = MESSAGE_FORMAT)
 	String insufficientConnectionInformation();
+
+	@Message(id = 17040, value = "Cannot create JDBCXARecovery datasource of jndi name '{0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	void error_cannot_create_datasource(String jndiName, @Cause Throwable arg0);
+
+	@Message(id = 17041, value = "Cannot create JDBCXARecovery connection of datasource '{0}', user: {1}, password: {2}", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	void error_cannot_create_connection(XADataSource ds, String user, String password, @Cause Throwable arg0);
+
+	@Message(id = 17042, value = "Could not resolve JNDI '{0}' of XADataSource from jndi properties '{1}'", format = MESSAGE_FORMAT)
+	String get_cant_resolve_ds_jndi_lookup(String jndi, Hashtable jndiProperties);
 
     /*
         Allocate new messages directly above this notice.

--- a/ArjunaJTA/jdbc/src/test/resources/ds-direct.properties
+++ b/ArjunaJTA/jdbc/src/test/resources/ds-direct.properties
@@ -1,0 +1,4 @@
+xaDataSourceClassName=org.h2.jdbcx.JdbcDataSource
+URL=jdbc:h2:mem:testdirect;DB_CLOSE_DELAY=-1
+User=sa
+Password=sa

--- a/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/recovery/DummyXAResource.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/recovery/DummyXAResource.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jdbc.recovery;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+class DummyXAResource implements XAResource {
+
+    @Override
+    public void commit(Xid arg0, boolean arg1) throws XAException {
+    }
+
+    @Override
+    public void end(Xid arg0, int arg1) throws XAException {
+    }
+
+    @Override
+    public void forget(Xid arg0) throws XAException {
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return 0;
+    }
+
+    @Override
+    public boolean isSameRM(XAResource arg0) throws XAException {
+        return false;
+    }
+
+    @Override
+    public int prepare(Xid arg0) throws XAException {
+        return 0;
+    }
+
+    @Override
+    public Xid[] recover(int arg0) throws XAException {
+        return null;
+    }
+
+    @Override
+    public void rollback(Xid arg0) throws XAException {
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int arg0) throws XAException {
+        return false;
+    }
+
+    @Override
+    public void start(Xid arg0, int arg1) throws XAException {
+    }
+}

--- a/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/recovery/RecoveryTest.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/recovery/RecoveryTest.java
@@ -1,37 +1,28 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2006, Red Hat Middleware LLC, and individual contributors
- * as indicated by the @author tags.
- * See the copyright.txt in the distribution for a
- * full listing of individual contributors.
- * This copyrighted material is made available to anyone wishing to use,
- * modify, copy, or redistribute it subject to the terms and conditions
- * of the GNU Lesser General Public License, v. 2.1.
- * This program is distributed in the hope that it will be useful, but WITHOUT A
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License,
- * v.2.1 along with this distribution; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
- * MA  02110-1301, USA.
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
- * (C) 2005-2006,
- * @author JBoss Inc.
- */
-/*
- * Copyright (C) 1998, 1999, 2000,
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
  *
- * Arjuna Solutions Limited,
- * Newcastle upon Tyne,
- * Tyne and Wear,
- * UK.
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
  *
- * $Id: JDBC2Test.java 2342 2006-03-30 13:06:17Z  $
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
 package com.hp.mwtests.ts.jdbc.recovery;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.sql.Connection;
@@ -46,33 +37,58 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-import com.arjuna.ats.arjuna.common.Uid;
-import com.arjuna.ats.arjuna.coordinator.ActionManager;
 import org.h2.Driver;
 import org.h2.jdbcx.JdbcDataSource;
 import org.jboss.byteman.agent.Transformer;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.jboss.logging.Logger;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.coordinator.ActionManager;
 import com.arjuna.ats.arjuna.recovery.RecoveryManager;
 import com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule;
+import com.arjuna.ats.internal.jdbc.drivers.PropertyFileDynamicClass;
 import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
 import com.arjuna.ats.jdbc.TransactionalDriver;
 import com.arjuna.ats.jta.recovery.XAResourceRecoveryHelper;
 
 @RunWith(BMUnitRunner.class)
 public class RecoveryTest {
+    private static final Logger log = Logger.getLogger(RecoveryTest.class);
+    private TransactionalDriver transactionalDriver;
+
+    @After
+    public void cleanUp() {
+        try {
+            if(transactionalDriver != null)
+                DriverManager.deregisterDriver(transactionalDriver);
+        } catch (Exception e) {
+            log.errorf(e, "Can't deregister driver '%s'", transactionalDriver);
+        } finally {
+            transactionalDriver = null;
+        }
+    }
+
 	@Test
-	@BMRule(name = "throw exception", targetClass = "org.h2.jdbcx.JdbcXAConnection", targetMethod = "commit", action = "throw new java.lang.Error()", targetLocation = "AT ENTRY")
+	@BMRule(
+        name = "throw lang error exception",
+        targetClass = "org.h2.jdbcx.JdbcXAConnection",
+        targetMethod = "commit",
+        action = "throw new java.lang.Error()",
+        targetLocation = "AT ENTRY"
+    )
 	public void test() throws Exception {
 		String url = "jdbc:arjuna:";
 		Properties p = System.getProperties();
 		p.put("jdbc.drivers", Driver.class.getName());
 
 		System.setProperties(p);
-		DriverManager.registerDriver(new TransactionalDriver());
+		transactionalDriver = new TransactionalDriver();
+		DriverManager.registerDriver(transactionalDriver);
 
 		Properties dbProperties = new Properties();
 
@@ -80,80 +96,14 @@ public class RecoveryTest {
 		ds.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
 		dbProperties.put(TransactionalDriver.XADataSource, ds);
 
-		// 0. Setup tables
-		{
-			Connection conn = DriverManager.getConnection(url, dbProperties);
+		step0_setupTables(url, dbProperties);
 
-			Statement stmt = conn.createStatement(); // non-tx statement
+        // We need to do this in a different thread as otherwise the transaction would still be associated with the connection due to the java.lang.Error
+	    // RMFAIL on it's own will cause H2 to close connection and that seems to discard the indoubt transactions
+		step1_leaveXidsInDbTable(url, dbProperties);
 
-			try {
-				stmt.executeUpdate("DROP TABLE test_table");
-			} catch (SQLException e) {
-				if (e.getErrorCode() != 42102) {
-					throw e;
-				}
-			} finally {
-				stmt.executeUpdate("CREATE TABLE test_table (a INTEGER,b INTEGER)");
-				stmt.close();
-			}
 
-			conn.close();
-		}
-
-		// 1. Leave a Xid in the DB
-		{
-      // We need to do this in a different thread as otherwise the transaction would still be associated with the connection due to the java.lang.Error
-      // RMFAIL on it's own will cause H2 to close connection and that seems to discard the indoubt transactions
-			Thread thread = new Thread(() -> {
-				try {
-					Uid[] uid = new Uid[1];
-					Connection conn = DriverManager.getConnection(url, dbProperties);
-					TransactionManager tx = com.arjuna.ats.jta.TransactionManager
-							.transactionManager();
-
-					tx.begin();
-					tx.getTransaction().enlistResource(new DummyXAResource() {
-						@Override
-						public void start(Xid arg0, int arg1) throws XAException {
-							uid[0] = new Uid(arg0.getGlobalTransactionId());
-						}
-					});
-
-					Statement stmtx = conn.createStatement(); // will be a tx-statement
-
-					stmtx.executeUpdate("INSERT INTO test_table (a, b) VALUES (1,2)");
-
-					try {
-						tx.commit();
-					} catch (Error e) {
-						// expected
-						ActionManager.manager().remove(uid[0]);
-					}
-					// conn.close();
-				} catch (Throwable t) {
-					fail();
-				}
-			});
-			thread.start();
-			thread.join();
-		}
-
-		// 2. Check its not in the DB already
-		{
-			Connection conn = DriverManager.getConnection(url, dbProperties);
-			Statement stmt = conn.createStatement(); // non-tx statement
-
-			ResultSet res1 = stmt.executeQuery("SELECT * FROM test_table");
-
-			int rowCount = 0;
-
-			while (res1.next()) {
-				rowCount++;
-			}
-
-			assertTrue(rowCount == 0);
-			conn.close();
-		}
+		step2_checkDbIsNotCommitted(url, dbProperties);
 
 		// 3. Perform recovery
 		{
@@ -174,6 +124,7 @@ public class RecoveryTest {
 			});
 
 			RecoveryManager manager = RecoveryManager.manager();
+			manager.removeAllModules(true);
 			manager.addModule(xarm);
 			AtomicActionRecoveryModule aarm = new AtomicActionRecoveryModule();
 
@@ -183,71 +134,156 @@ public class RecoveryTest {
 			Transformer.enableTriggers(true);
 		}
 
-		// 4. See if its there now
-		{
-
-			Connection conn = DriverManager.getConnection(url, dbProperties);
-			Statement stmt = conn.createStatement(); // non-tx statement
-
-			ResultSet res1 = stmt.executeQuery("SELECT * FROM test_table");
-
-			int rowCount = 0;
-
-			while (res1.next()) {
-				rowCount++;
-			}
-
-			assertTrue(rowCount == 1);
-			conn.close();
-		}
-
+		step4_finalDbCommitCheck(url, dbProperties);
 	}
 
-	private class DummyXAResource implements XAResource {
+    @Test
+    @BMRule(
+        name = "throw rmfail xaexception",
+        targetClass = "org.h2.jdbcx.JdbcXAConnection",
+        targetMethod = "commit",
+        action = "throw new javax.transaction.xa.XAException(javax.transaction.xa.XAException.XAER_RMFAIL)",
+        targetLocation = "AT ENTRY"
+    )
+    public void directRecoverableConnection() throws Exception {
+        //jdbc:arjuna: <path to properties file>, path starting at System.getProperty("user.dir")
+        String url = TransactionalDriver.arjunaDriver + "ds-direct.properties";
+        Properties dbProperties = new Properties();
+        dbProperties.put(TransactionalDriver.dynamicClass, PropertyFileDynamicClass.class.getName());
+        dbProperties.put(TransactionalDriver.userName, "");
+        dbProperties.put(TransactionalDriver.password, "");
 
-		@Override
-		public void commit(Xid arg0, boolean arg1) throws XAException {
-		}
+        Properties p = System.getProperties();
+        p.put("jdbc.drivers", Driver.class.getName());
+        System.setProperties(p);
+        transactionalDriver = new TransactionalDriver();
+        DriverManager.registerDriver(transactionalDriver);
 
-		@Override
-		public void end(Xid arg0, int arg1) throws XAException {
-		}
+        step0_setupTables(url, dbProperties);
 
-		@Override
-		public void forget(Xid arg0) throws XAException {
-		}
+        // rmfail means the db connection was left to be recovered
+        step1_leaveXidsInDbTable(url, dbProperties);
 
-		@Override
-		public int getTransactionTimeout() throws XAException {
-			return 0;
-		}
+        step2_checkDbIsNotCommitted(url, dbProperties);
 
-		@Override
-		public boolean isSameRM(XAResource arg0) throws XAException {
-			return false;
-		}
+        // 3. Perform recovery - checking only top down XARecoveryModule functionality
+        {
+            XARecoveryModule xarm = new XARecoveryModule();
+            RecoveryManager manager = RecoveryManager.manager();
+            manager.removeAllModules(true);
+            manager.addModule(xarm);
+            AtomicActionRecoveryModule aarm = new AtomicActionRecoveryModule();
 
-		@Override
-		public int prepare(Xid arg0) throws XAException {
-			return 0;
-		}
+            aarm.periodicWorkFirstPass();
+            Transformer.disableTriggers(true);
+            aarm.periodicWorkSecondPass();
+            Transformer.enableTriggers(true);
+        }
 
-		@Override
-		public Xid[] recover(int arg0) throws XAException {
-			return null;
-		}
+        step4_finalDbCommitCheck(url, dbProperties);
+    }
 
-		@Override
-		public void rollback(Xid arg0) throws XAException {
-		}
 
-		@Override
-		public boolean setTransactionTimeout(int arg0) throws XAException {
-			return false;
-		}
+	/**
+	 * 0. Setup tables
+	 */
+	private void step0_setupTables(String url, Properties dbProperties) throws Exception {
+        Connection conn = DriverManager.getConnection(url, dbProperties);
 
-		@Override
-		public void start(Xid arg0, int arg1) throws XAException {
-		}
+        Statement stmt = conn.createStatement(); // non-tx statement
+
+        try {
+            stmt.executeUpdate("DROP TABLE test_table");
+        } catch (SQLException e) {
+            if (e.getErrorCode() != 42102) {
+                throw e;
+            }
+        } finally {
+            stmt.executeUpdate("CREATE TABLE test_table (a INTEGER,b INTEGER)");
+            stmt.close();
+            conn.close();
+        }
 	}
+
+	/**
+	 * 1. Leave a Xid in the DB
+	 */
+	private void step1_leaveXidsInDbTable(String url, Properties dbProperties) throws Exception {
+        Thread thread = new Thread(() -> {
+            try {
+                Uid[] uid = new Uid[1];
+                Connection conn = DriverManager.getConnection(url, dbProperties);
+                TransactionManager tx = com.arjuna.ats.jta.TransactionManager
+                        .transactionManager();
+
+                tx.begin();
+                tx.getTransaction().enlistResource(new DummyXAResource() {
+                    @Override
+                    public void start(Xid arg0, int arg1) throws XAException {
+                        uid[0] = new Uid(arg0.getGlobalTransactionId());
+                    }
+                });
+
+                Statement stmtx = conn.createStatement(); // will be a tx-statement
+
+                stmtx.executeUpdate("INSERT INTO test_table (a, b) VALUES (1,2)");
+
+                try {
+                    tx.commit();
+                } catch (Throwable e) {
+                    // expected
+                    ActionManager.manager().remove(uid[0]);
+                } finally {
+                    conn.close();
+                }
+                // conn.close();
+            } catch (Throwable t) {
+                fail("Error on leaving xids in db table of connection url: " + url);
+            }
+        });
+        thread.start();
+        thread.join();
+	}
+
+    /**
+     * 2. Check its not in the DB already
+     */
+	private void step2_checkDbIsNotCommitted(String url, Properties dbProperties) throws Exception {
+        Connection conn = DriverManager.getConnection(url, dbProperties);
+        Statement stmt = conn.createStatement(); // non-tx statement
+
+        ResultSet res1 = stmt.executeQuery("SELECT * FROM test_table");
+
+        int rowCount = 0;
+
+        while (res1.next()) {
+            rowCount++;
+        }
+
+        try {
+            assertEquals("Failure on commit of '" + url + "' means no record in db",
+                0 , rowCount);
+        } finally {
+            conn.close();
+        }
+    }
+
+    /**
+     * 4. See if its there now
+     */
+	private void step4_finalDbCommitCheck(String url, Properties dbProperties) throws Exception {
+        Connection conn = DriverManager.getConnection(url, dbProperties);
+        Statement stmt = conn.createStatement(); // non-tx statement
+
+        ResultSet res1 = stmt.executeQuery("SELECT * FROM test_table");
+
+        int rowCount = 0;
+
+        while (res1.next()) {
+            rowCount++;
+        }
+
+        assertEquals("Recovery should commit the jdbc resource url: " + url, 1, rowCount);
+        conn.close();
+    }
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
@@ -1270,7 +1270,6 @@ public class XAResourceRecord extends AbstractRecord implements ExceptionDeferre
 		if (_recoveryObject != null)
 		{
 			_recoveryObject.close();
-			_recoveryObject = null;
 		}
 
 		if (_theTransaction != null)

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/CrashRecovery2.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/CrashRecovery2.java
@@ -31,9 +31,8 @@
 
 package com.hp.mwtests.ts.jta.recovery;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import javax.transaction.HeuristicMixedException;
@@ -44,19 +43,45 @@ import javax.transaction.SystemException;
 
 import org.jboss.byteman.contrib.bmunit.BMScript;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
 import com.arjuna.ats.arjuna.common.recoveryPropertyManager;
 import com.arjuna.ats.arjuna.recovery.RecoveryManager;
-import com.arjuna.ats.internal.jta.recovery.arjunacore.RecoveryXids;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
 
 @RunWith(BMUnitRunner.class)
-@BMScript("fail2pc")
 public class CrashRecovery2 {
+
+    @Before
+    public void setUp() {
+        RecoveryEnvironmentBean recoveryEnvironmentBean = recoveryPropertyManager
+                .getRecoveryEnvironmentBean();
+        recoveryEnvironmentBean
+                .setRecoveryModuleClassNames(Arrays
+                        .asList(new String[] {
+                                "com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule",
+                                "com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule" }));
+
+        JTAEnvironmentBean jtaEnvironmentBean = jtaPropertyManager
+                .getJTAEnvironmentBean();
+        jtaEnvironmentBean
+                .setXaResourceRecoveryClassNames(Arrays
+                        .asList(new String[] { "com.hp.mwtests.ts.jta.recovery.TestXAResourceRecovery" }));
+        jtaEnvironmentBean
+                .setXaResourceOrphanFilterClassNames(Arrays
+                        .asList(new String[] {
+                                "com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter",
+                                "com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter" }));
+        jtaEnvironmentBean.setXaRecoveryNodes(Arrays
+                .asList(new String[] { "1" }));
+    }
+    
+
+    @BMScript("fail2pc")
 	@Test
 	public void test() throws NotSupportedException, SystemException,
 			IllegalStateException, RollbackException, SecurityException,
@@ -87,31 +112,10 @@ public class CrashRecovery2 {
 
 		TestXAResourceRecovery.setResources(firstResource, secondResource);
 
-		assertTrue(firstResource.commitCount() == 0);
-		assertTrue(firstResource.commitCount() == 0);
-		assertTrue(secondResource.rollbackCount() == 0);
-		assertTrue(secondResource.rollbackCount() == 0);
-
-		RecoveryEnvironmentBean recoveryEnvironmentBean = recoveryPropertyManager
-				.getRecoveryEnvironmentBean();
-		recoveryEnvironmentBean
-				.setRecoveryModuleClassNames(Arrays
-						.asList(new String[] {
-								"com.arjuna.ats.internal.arjuna.recovery.AtomicActionRecoveryModule",
-								"com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule" }));
-
-		JTAEnvironmentBean jtaEnvironmentBean = jtaPropertyManager
-				.getJTAEnvironmentBean();
-		jtaEnvironmentBean
-				.setXaResourceRecoveryClassNames(Arrays
-						.asList(new String[] { "com.hp.mwtests.ts.jta.recovery.TestXAResourceRecovery" }));
-		jtaEnvironmentBean
-				.setXaResourceOrphanFilterClassNames(Arrays
-						.asList(new String[] {
-								"com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter",
-								"com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter" }));
-		jtaEnvironmentBean.setXaRecoveryNodes(Arrays
-				.asList(new String[] { "1" }));
+		assertEquals(0, firstResource.commitCount());
+		assertEquals(0, secondResource.commitCount());
+		assertEquals(0, firstResource.rollbackCount());
+		assertEquals(0, secondResource.rollbackCount());
 
 		RecoveryManager manager = RecoveryManager
 				.manager(RecoveryManager.DIRECT_MANAGEMENT);
@@ -119,9 +123,51 @@ public class CrashRecovery2 {
 
 		manager.scan();
 
-		assertTrue(firstResource.rollbackCount() == 0);
-		assertTrue(secondResource.rollbackCount() == 0);
-		assertTrue(firstResource.commitCount() == 1);
-		assertTrue(secondResource.commitCount() == 1);
+		assertEquals(0, firstResource.rollbackCount());
+		assertEquals(0, secondResource.rollbackCount());
+		assertEquals(1, firstResource.commitCount());
+		assertEquals(1, secondResource.commitCount());
 	}
+
+    /**
+     * Test of top-down recovery with serializable XAResource.
+     */
+    @Test
+    public void testRmFailXAResourceSerializable() throws Exception {
+        
+        recoveryPropertyManager.getRecoveryEnvironmentBean()
+                .setRecoveryBackoffPeriod(1);
+
+        TestXAResource firstResource = new TestXAResourceRmFail().clearCounters();
+        TestXAResource secondResource = new TestXAResource();
+
+        javax.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager
+                .transactionManager();
+
+        tm.begin();
+
+        javax.transaction.Transaction theTransaction = tm.getTransaction();
+
+        theTransaction.enlistResource(firstResource);
+        theTransaction.enlistResource(secondResource);
+
+        tm.commit();
+
+        assertEquals("first resource failed with rmfail, no commit expected", 0, firstResource.commitCount());
+        assertEquals("second resource should be committed", 1, secondResource.commitCount());
+        assertEquals("first resource: no rollback expected on rmfail", 0, firstResource.rollbackCount());
+        assertEquals("second resource: expected to be committed", 0, secondResource.rollbackCount());
+
+        RecoveryManager manager = RecoveryManager
+                .manager(RecoveryManager.DIRECT_MANAGEMENT);
+        manager.initialize();
+
+        manager.scan();
+
+        assertEquals("no rollback expecte on first resource", 0, firstResource.rollbackCount());
+        assertEquals("no rollback expecte on second resource", 0, secondResource.rollbackCount());
+        assertEquals("serializable first resource should be committed on recovery", 1, firstResource.commitCount());
+        assertEquals("second resource should be already committed even without recovery",
+                1, secondResource.commitCount());
+    }
 }

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/TestXAResourceRmFail.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/TestXAResourceRmFail.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.jta.recovery;
+
+import java.io.Serializable;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.Xid;
+
+public class TestXAResourceRmFail extends TestXAResource implements Serializable {
+    private static int commitCount;
+    private static int rollbackCount;
+    
+    private static final long serialVersionUID = 1L;
+    private boolean wasThrown = false;
+
+    @Override
+    public void commit(Xid id, boolean onePhase) throws XAException {
+        if(!wasThrown) {
+            wasThrown = true;
+            throw new XAException(XAException.XAER_RMFAIL);
+        }
+        TestXAResourceRmFail.commitCount++;
+        super.commit(id, onePhase);
+    }
+
+    public void rollback(Xid xid) throws XAException {
+        TestXAResourceRmFail.rollbackCount++;
+        super.rollback(xid);
+    }
+
+    public int commitCount() {
+        return TestXAResourceRmFail.commitCount;
+    }
+
+    public int rollbackCount() {
+        return TestXAResourceRmFail.rollbackCount;
+    }
+
+    public TestXAResourceRmFail clearCounters() {
+        commitCount = 0;
+        rollbackCount = 0;
+        return this;
+    }
+}


### PR DESCRIPTION
when try to commit fails with RETRY. Then recoverable should be still
saved in object store in way that recovery manager is capable to
deserialize it and use it for committing.

The most of the PR are tests the fix is only the line
https://github.com/jbosstm/narayana/pull/1264/files#diff-9613cb84dbca3e6a76d760b2b4626befL1273

https://issues.jboss.org/browse/JBTM-2973

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF  !RTS !AS_TESTS !mysql !postgres !db2 !oracle