### PR TITLE
JBTM-2987 XAER_NOTA return code handling

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/XARecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/XARecoveryModule.java
@@ -846,7 +846,16 @@ public class XARecoveryModule implements RecoveryModule
         }
         catch (XAException e1)
         {
-        	jtaLogger.i18NLogger.warn_recovery_xarecovery1(_logName+".xaRecovery", XAHelper.printXAErrorCode(e1), e1);
+            if(e1.errorCode == XAException.XAER_NOTA)
+            {
+                if(jtaLogger.logger.isDebugEnabled()) {
+                    jtaLogger.logger.debug("XAER_NOTA received while rolling back " + XAHelper.xidToString(xid));
+                }
+            }
+            else
+            {
+                jtaLogger.i18NLogger.warn_recovery_xarecovery1(_logName+".xaRecovery", XAHelper.printXAErrorCode(e1), e1);
+            }
 
             switch (e1.errorCode)
             {

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/XARecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/XARecoveryModule.java
@@ -849,7 +849,7 @@ public class XARecoveryModule implements RecoveryModule
             if(e1.errorCode == XAException.XAER_NOTA)
             {
                 if(jtaLogger.logger.isDebugEnabled()) {
-                    jtaLogger.logger.debug("XAER_NOTA received while rolling back " + XAHelper.xidToString(xid));
+                    jtaLogger.logger.debug(_logName+".xaRecovery: XAER_NOTA received while rolling back " + XAHelper.xidToString(xid));
                 }
             }
             else


### PR DESCRIPTION
When doing rollback from Recovery Manager treat XAER_NOTA return code as debug instead of warning

!QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !mysql !postgres !db2 !oracle