### PR TITLE
[JBTM-2991] fixing javadoc @deprecated annotation

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/resources/StartXAResource.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/resources/StartXAResource.java
@@ -34,7 +34,7 @@ package com.arjuna.ats.jta.resources;
 import javax.transaction.xa.XAResource;
 
 /**
- * @Deprecated This interface is replaced by org.jboss.tm.FirstResource in the SPI
+ * @deprecated This interface is replaced by org.jboss.tm.FirstResource in the SPI
  */
 public interface StartXAResource extends XAResource
 {


### PR DESCRIPTION
PR https://github.com/jbosstm/narayana/pull/1279 introduced annotation `@Deprecated` to javadoc of `StartXAResource` but it causes errors on builds

```
[ERROR] /home/jenkins/workspace/btny-pulls-narayana/PROFILE/XTS/jdk/jdk8.latest/label/linux/ArjunaJTA/jta/classes/com/arjuna/ats/jta/resources/StartXAResource.java:37: error: unknown tag: Deprecated
[ERROR] * @Deprecated This interface is replaced by org.jboss.tm.FirstResource in the SPI
[ERROR] ^
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.151-1.b12.el7_4.x86_64/jre/../bin/javadoc @options
```

and the profile `-Prelease` just fails. Changing for the javadoc correct lower-case version which passes now.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !mysql !postgres !db2 !oracle