### PR TITLE
[JBTM-2969] lra annotation checker - windows fix

### DIFF
--- a/rts/lra/lra-annotation-checker/src/main/java/io/narayana/lra/checker/CheckerUtil.java
+++ b/rts/lra/lra-annotation-checker/src/main/java/io/narayana/lra/checker/CheckerUtil.java
@@ -105,7 +105,7 @@ public final class CheckerUtil {
     private static List<Class<?>> processStream(Stream<? extends String> stream, ClassLoader classLoader, File streamedFile) {
         return stream
             .filter(fileName -> fileName.endsWith(".class"))
-            .map(fileName -> fileName.replace('/', '.'))
+            .map(fileName -> fileName.replace((CharSequence) File.separator, "."))
             .map(fileName -> fileName.substring(0, fileName.length() - ".class".length()))
             .map(className -> loadClass(className, streamedFile, classLoader))
             .filter(clazz -> clazz != null)

--- a/rts/lra/lra-annotation-checker/src/test/java/io/narayana/lra/checker/LraCdiCheckIT.java
+++ b/rts/lra/lra-annotation-checker/src/test/java/io/narayana/lra/checker/LraCdiCheckIT.java
@@ -138,7 +138,7 @@ public class LraCdiCheckIT {
     private void assertFailureCatalogContains(Class<?> beanClass, String failureStringToCheck) {
         Assert.assertFalse("Failure on checking bean " + beanClass.getName() + " should happen",
                 FailureCatalog.INSTANCE.isEmpty());
-        Assert.assertThat(FailureCatalog.INSTANCE.formatCatalogContent().split("\n"),
+        Assert.assertThat(FailureCatalog.INSTANCE.formatCatalogContent().split(System.lineSeparator()),
                 HamcrestRegexpMatcher.matches(failureStringToCheck));
     }
 }

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -147,6 +147,7 @@
                     <plugin>
                         <groupId>org.honton.chas</groupId>
                         <artifactId>process-exec-maven-plugin</artifactId>
+                        <version>0.9.2</version>
                         <executions>
                             <execution>
                                 <id>start-swarm-lra-coordinator</id>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2969

I badly missed the fact of the path separator. Fixing this ommision.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF  !AS_TESTS !mysql !postgres !db2 !oracle

NO_TEST