### PR TITLE
JBTM-3000 Adding support for Oracle Wallet

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ConnectionImple.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ConnectionImple.java
@@ -100,8 +100,8 @@ public class ConnectionImple implements Connection
         boolean poolingEnabled = false;
 
         if (info != null) {
-            user = info.getProperty(TransactionalDriver.userName, "");
-            passwd = info.getProperty(TransactionalDriver.password, "");
+            user = info.getProperty(TransactionalDriver.userName);
+            passwd = info.getProperty(TransactionalDriver.password);
             dynamic = info.getProperty(TransactionalDriver.dynamicClass);
             xaDataSource = info.get(TransactionalDriver.XADataSource);
             poolingEnabled = Boolean.valueOf(info.getProperty(TransactionalDriver.poolConnections, "true")).booleanValue();

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ConnectionManager.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/ConnectionManager.java
@@ -37,10 +37,7 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 /*
  * Only ever create a single instance of a given connection, based upon the
@@ -55,8 +52,8 @@ public class ConnectionManager {
      */
     public static synchronized Connection create (String dbUrl, Properties info) throws SQLException
     {
-        String user = info.getProperty(TransactionalDriver.userName, "");
-        String passwd = info.getProperty(TransactionalDriver.password, "");
+        String user = info.getProperty(TransactionalDriver.userName);
+        String passwd = info.getProperty(TransactionalDriver.password);
         String dynamic = info.getProperty(TransactionalDriver.dynamicClass, "");
         String poolConnections = info.getProperty(TransactionalDriver.poolConnections, "true");
         Object xaDataSource = info.get(TransactionalDriver.XADataSource);
@@ -88,7 +85,7 @@ public class ConnectionManager {
 
                     /* Check transaction and database connection. */
                     if ((tx1 != null && tx1.equals(tx2))
-                            && isSameConnection(dbUrl, user, passwd, dynamic, xaDataSource, connControl))
+                        && isSameConnection(dbUrl, user, passwd, dynamic, xaDataSource, connControl))
                     {
                         try {
                             /*
@@ -174,13 +171,13 @@ public class ConnectionManager {
     }
 
     private static boolean isSameConnection(String dbUrl, String user, String passwd, String dynamic, Object xaDataSource, ConnectionControl connControl) {
-        return 
+        return
             dbUrl.equals(connControl.url())
-            && user.equals(connControl.user())
-            && passwd.equals(connControl.password())
-            && dynamic.equals(connControl.dynamicClass())
-            // equal ProvidedXADataSourceConnection instances should have the same data source
-            && (xaDataSource == null || xaDataSource.equals(connControl.xaDataSource()));
+                && Objects.equals(user, connControl.user())
+                && Objects.equals(passwd, connControl.password())
+                && dynamic.equals(connControl.dynamicClass())
+                // equal ProvidedXADataSourceConnection instances should have the same data source
+                && (xaDataSource == null || xaDataSource.equals(connControl.xaDataSource()));
     }
 
     private static Set<ConnectionImple> _connections = new HashSet<ConnectionImple>();


### PR DESCRIPTION
I created a corresponding jira ticket: https://issues.jboss.org/browse/JBTM-3000 to track this issue. Basically we want to be able to use Narayana with Oracle Wallet, but the default username and passwords being set are preventing the JDBC driver from using the wallet. This change makes it so that Narayana will not replace null username/password with an empty string.