### PR TITLE
[JWS-883] not throwing NPE when wrong db test type is provided

### DIFF
--- a/tomcat/tomcat-jta/src/test/java/org/jboss/narayana/tomcat/jta/integration/AbstractCase.java
+++ b/tomcat/tomcat-jta/src/test/java/org/jboss/narayana/tomcat/jta/integration/AbstractCase.java
@@ -111,7 +111,7 @@ public abstract class AbstractCase {
             dba.deallocateDB(db);
         }
         // @see https://issues.jboss.org/browse/JWS-976
-        if (libFiles[0] != null) {
+        if (libFiles != null && libFiles[0] != null) {
             final String file0 = catalinaHome + File.separator + "lib" + File.separator + libFiles[0].getName();
             try {
                 Files.delete(Paths.get(file0));

--- a/tomcat/tomcat-jta/src/test/java/org/jboss/narayana/tomcat/jta/integration/app/TestExecutor.java
+++ b/tomcat/tomcat-jta/src/test/java/org/jboss/narayana/tomcat/jta/integration/app/TestExecutor.java
@@ -47,6 +47,7 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -149,6 +150,7 @@ public class TestExecutor {
              ResultSet result = statement.executeQuery(query)) {
             return result.next() && result.getInt(1) > 0;
         } catch (SQLException e) {
+            LOGGER.log(Level.WARNING, e, () -> String.format("Cannot get result when querying entry '%s'", entry));
             return false;
         }
     }


### PR DESCRIPTION
When tomcat is run and a non-existent test type is specified (e.g. `psql` instead of `pgsql`, aka. `-Dtest.db.type=psql`) then  NPE is thrown at the end of the test instead of being reported only(!) the test fails because of non-existent test type.

!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !mysql !postgres !db2 !oracle