### PR TITLE
[JBTM-3025] Xid created from imported transaction should not change node name

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/FormatConstants.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/FormatConstants.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.internal.arjuna;
+
+/**
+ * Class with constants definitions for Xid formats and others.
+ */
+public final class FormatConstants {
+
+    public static final int JTA_FORMAT_ID = 131077;
+
+    public static final int JTS_FORMAT_ID = 131072;
+    public static final int JTS_STRICT_FORMAT_ID = 131073;
+    public static final int JTS_RESTRICTED_FORMAT_ID = 131074;
+
+    public static final int XTS_BRIDGE_FORMAT_ID = 131080;
+
+    public static final int RTS_BRIDGE_FORMAT_ID = 131081;
+
+    /**
+     * Returning true if format id corresponds with Narayana specific ids.
+     */
+    public static boolean isNarayanaFormatId(int xidFormatId) {
+        return xidFormatId == JTA_FORMAT_ID
+            || xidFormatId == JTS_FORMAT_ID
+            || xidFormatId == XTS_BRIDGE_FORMAT_ID
+            || xidFormatId == RTS_BRIDGE_FORMAT_ID;
+    }
+}

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/utils/XAUtils.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/utils/XAUtils.java
@@ -34,6 +34,7 @@ package com.arjuna.ats.internal.jta.utils;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
+import com.arjuna.ats.internal.jta.xa.XID;
 import com.arjuna.ats.jta.xa.XATxConverter;
 import com.arjuna.ats.jta.xa.XidImple;
 
@@ -76,15 +77,49 @@ public class XAUtils
 		return optimize;
 	}
 
+	/**
+	 * Trying to convert {@link Xid} to Narayana implementation
+	 * for being able to access the internal byte array
+	 * in order to return node name codified inside of the Xid.
+	 *
+	 * @param xid  the xid to check the node name
+	 * @return  node name saved in the xid
+	 */
 	public static final String getXANodeName (Xid xid)
 	{
-        XidImple xidImple;
-        if(xid instanceof XidImple) {
-            xidImple = (XidImple)xid;
-        } else {
-            xidImple = new XidImple(xid);
-        }
-        return XATxConverter.getNodeName(xidImple.getXID());
+        return XATxConverter.getNodeName(getXIDfromXid(xid));
+	}
+
+	/**
+	 * Returning subordinate node name codified inside of the Xid.
+	 *
+	 * @param xid  the xid to check the subordinate node name
+	 * @return  subordinate node name saved in the xid
+	 */
+	public static final String getSubordinateNodeName (Xid xid)
+	{
+	    return XATxConverter.getSubordinateNodeName(getXIDfromXid(xid));
+	}
+
+	/**
+	 * Returning eis name codified inside of the Xid.
+	 *
+	 * @param xid  the xid to check the eis name
+	 * @return  eis name integer saved in the xid
+	 */
+	public static final Integer getEisName (Xid xid)
+	{
+	    return XATxConverter.getEISName(getXIDfromXid(xid));
+	}
+
+	private static final XID getXIDfromXid(Xid xid) {
+         XidImple xidImple;
+         if(xid instanceof XidImple) {
+             xidImple = (XidImple)xid;
+         } else {
+             xidImple = new XidImple(xid);
+         }
+         return xidImple.getXID();
 	}
 
 	private static final String ORACLE = "oracle";

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/extensions/Arjuna.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/extensions/Arjuna.java
@@ -31,6 +31,7 @@
 
 package com.arjuna.ats.jts.extensions;
 
+import com.arjuna.ats.internal.arjuna.FormatConstants;
 import com.arjuna.ats.jts.logging.jtsLogger;
 
 /**
@@ -47,17 +48,17 @@ public class Arjuna
     
 public static final int XID ()
     {
-	return 131072;
+	return FormatConstants.JTS_FORMAT_ID;
     }
 
 public static final int strictXID ()
     {
-	return 131073;
+	return FormatConstants.JTS_STRICT_FORMAT_ID;
     }
 
 public static final int restrictedXID ()
     {
-	return 131074;
+    return FormatConstants.JTS_RESTRICTED_FORMAT_ID;
     }
     
 public static final String arjunaXID ()

--- a/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridge.java
+++ b/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridge.java
@@ -35,6 +35,7 @@ import javax.transaction.xa.Xid;
 import com.arjuna.ats.jta.recovery.SerializableXAResourceDeserializer;
 import org.jboss.logging.Logger;
 
+import com.arjuna.ats.internal.arjuna.FormatConstants;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManager;
 import com.arjuna.ats.jta.TransactionManager;
 
@@ -46,7 +47,7 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
     /**
      * Unique (well, hopefully) formatId so we can distinguish our own Xids.
      */
-    public static final int XARESOURCE_FORMAT_ID = 131081;
+    public static final int XARESOURCE_FORMAT_ID = FormatConstants.RTS_BRIDGE_FORMAT_ID;
 
     private static final Logger LOG = Logger.getLogger(InboundBridge.class);
 

--- a/txbridge/src/main/java/org/jboss/jbossts/txbridge/inbound/BridgeDurableParticipant.java
+++ b/txbridge/src/main/java/org/jboss/jbossts/txbridge/inbound/BridgeDurableParticipant.java
@@ -26,6 +26,7 @@ package org.jboss.jbossts.txbridge.inbound;
 import com.arjuna.ats.jta.utils.XAHelper;
 import com.arjuna.wst.*;
 import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.internal.arjuna.FormatConstants;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManager;
 import org.jboss.jbossts.txbridge.utils.txbridgeLogger;
 
@@ -57,7 +58,7 @@ public class BridgeDurableParticipant implements Durable2PCParticipant, Serializ
     /*
      * Uniq (well, hopefully) formatId so we can distinguish our own Xids.
      */
-    public static final int XARESOURCE_FORMAT_ID = 131080;
+    public static final int XARESOURCE_FORMAT_ID = FormatConstants.XTS_BRIDGE_FORMAT_ID;
 
     private transient volatile XATerminator xaTerminator;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3025

This is a proposal for the fix for regression coming from https://issues.jboss.org/browse/JBTM-2893. The import JTS transaction changes node name of the Xid created for XAResource to the current node name and not leaving that set as it was in the inflow transaction.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle