### PR TITLE
[JBTM-3027] removing dependency to lra annotations

### DIFF
--- a/rts/lra/lra-annotation-checker/pom.xml
+++ b/rts/lra/lra-annotation-checker/pom.xml
@@ -71,7 +71,7 @@
             <version>${version.org.jboss.weld}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${version.microprofile.lra}</version>
         </dependency>

--- a/rts/lra/lra-client/pom.xml
+++ b/rts/lra/lra-client/pom.xml
@@ -32,13 +32,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.narayana.rts</groupId>
-            <artifactId>lra-annotations</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${version.microprofile.lra}</version>
         </dependency>

--- a/rts/lra/lra-coordinator/pom.xml
+++ b/rts/lra/lra-coordinator/pom.xml
@@ -67,7 +67,7 @@
             <artifactId>swagger</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${version.microprofile.lra}</version>
         </dependency>

--- a/rts/lra/lra-filters/pom.xml
+++ b/rts/lra/lra-filters/pom.xml
@@ -31,14 +31,7 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.narayana.rts</groupId>
-            <artifactId>lra-annotations</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${version.microprofile.lra}</version>
             <scope>provided</scope>

--- a/rts/lra/lra-proxy/api/pom.xml
+++ b/rts/lra/lra-proxy/api/pom.xml
@@ -63,7 +63,7 @@
 	    </dependency>
         <!-- LRA API -->
         <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${version.microprofile.lra}</version>
         </dependency>

--- a/rts/lra/lra-proxy/test/pom.xml
+++ b/rts/lra/lra-proxy/test/pom.xml
@@ -100,7 +100,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.lra</groupId>
+            <groupId>io.narayana.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
             <version>${version.microprofile.lra}</version>
         </dependency>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -32,7 +32,7 @@
         <version.arquillian>1.1.12.Final</version.arquillian>
 
         <version.narayana>${project.version}</version.narayana>
-        <version.microprofile.lra>1.0-SNAPSHOT</version.microprofile.lra>
+        <version.microprofile.lra>0.0.1.Final</version.microprofile.lra>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -40,6 +40,14 @@
 
         <test.logs.to.file>false</test.logs.to.file>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>jboss-public-releases-repository-group</id>
+            <name>JBoss Public Releases Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/repositories/releases</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -60,8 +60,6 @@ function init_test_options {
     is_ibm
     ISIBM=$?
     [ $NARAYANA_CURRENT_VERSION ] || NARAYANA_CURRENT_VERSION="5.8.3.Final-SNAPSHOT"
-    [ $MICROPROFILE_LRA_VERSION ] || MICROPROFILE_LRA_VERSION="1.0-SNAPSHOT"
-    [ $MICROPROFILE_LRA_BRANCH ] || MICROPROFILE_LRA_BRANCH="microprofile-lra-v2"
     [ $CODE_COVERAGE ] || CODE_COVERAGE=0
     [ x"$CODE_COVERAGE_ARGS" != "x" ] || CODE_COVERAGE_ARGS=""
     [ $ARQ_PROF ] || ARQ_PROF=arq	# IPv4 arquillian profile
@@ -273,22 +271,6 @@ function kill_qa_suite_processes
   done
 }
 
-# ensure the microprofile-lra artifact is in the local maven repository
-function build_microprofile_lra {
-    if [ -d microprofile-lra ]; then
-      rm -rf microprofile-lra
-    fi
-
-    git clone https://github.com/jbosstm/microprofile-lra
-    [ $? = 0 ] || fatal "git clone https://github.com/jbosstm/microprofile-lra failed"
-    cd microprofile-lra/
-    git checkout $MICROPROFILE_LRA_BRANCH
-    [ $? = 0 ] || fatal "git checkout $MICROPROFILE_LRA_BRANCH failed"
-    cd ..
-    ./build.sh -f microprofile-lra/pom.xml -B clean install
-    [ $? = 0 ] || fatal "Build of microprofile-lra failed"
-}
-
 function build_narayana {
   echo "Checking if need SPI PR"
   if [ -n "$SPI_BRANCH" ]; then
@@ -308,9 +290,6 @@ function build_narayana {
     [ $? = 0 ] || fatal "Build of SPI failed"
   fi
   
-  cd $WORKSPACE
-  build_microprofile_lra
-
   echo "Building Narayana"
   cd $WORKSPACE
 


### PR DESCRIPTION
as their existence in `pom.xml` pushes depreated code to the swarm factions depending on the project (e.g. on projects depending on lra-filters)

https://issues.jboss.org/browse/JBTM-3027

The change in quickstart will be realized when this PR is merged and could be observed at:
https://github.com/jbosstm/quickstart/pull/227

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle