### PR TITLE
[JBTM-3020] xa read only optimization

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
@@ -440,6 +440,28 @@ public abstract class AbstractRecord extends StateManager
 		}
 	}
 
+	/**
+	 * <p>
+	 * This method serves for optimization at the {@link BasicAction#doPrepare(boolean)} method.
+	 * This is optional to be implemented by any child Record class.
+	 * The main purpose is to optimize 1PC handling in way to know if
+	 * prepare call is needed before it's really called.
+	 * If we know the prepare could not be called on all except one resource
+	 * then we do not care of order the prepare call is executed.
+	 * The reason why the prepare is not needed is mostly because
+	 * no work was done and the prepare would return {@link TwoPhaseOutcome#PREPARE_READONLY}
+	 * by all means.
+	 *
+	 * @return integer of state that the call ended. The default value is {@link TwoPhaseOutcome#NO_PRE_PREPARED}
+	 *   which signalizes that there was no try to do any pre preparation work.
+	 *   If the implementation of this method want to announce there was not done any work
+	 *   on the its behalf then {@link TwoPhaseOutcome#PREPARE_READONLY} is expected to be returned.
+	 */
+	public int beforeTopLevelPrepare ()
+	{
+	    return TwoPhaseOutcome.NO_PRE_PREPARED;
+	}
+
 	
 	@SuppressWarnings("unchecked")
         public static AbstractRecord create (int type)

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TwoPhaseOutcome.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TwoPhaseOutcome.java
@@ -71,6 +71,8 @@ public class TwoPhaseOutcome
     public static final int ONE_PHASE_ERROR = 10;  // WARNING this has different meanings depending upon nested or top-level usage.
     public static final int INVALID_TRANSACTION = 11;  // invalid!
     public static final int PREPARE_ONE_PHASE_COMMITTED = 12;  // dynamic one-phase commit optimisation during prepare
+    public static final int NO_PRE_PREPARED = 13;  // there was processed no action at before prepare of the AbstractRecord
+                                                   // this signalizes pre-prepare 1PC optimization can be taken
 
     public TwoPhaseOutcome (int outcome)
     {

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -49,6 +49,7 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 import org.jboss.tm.ConnectableResource;
+import org.jboss.tm.XAResourceEndWithResult;
 import org.jboss.tm.XAResourceWrapper;
 
 import com.arjuna.ats.arjuna.common.Uid;
@@ -68,6 +69,7 @@ import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecord;
 import com.arjuna.ats.internal.jta.resources.arjunacore.XAResourceRecordWrappingPlugin;
 import com.arjuna.ats.internal.jta.utils.XAUtils;
 import com.arjuna.ats.internal.jta.utils.arjunacore.StatusConverter;
+import com.arjuna.ats.internal.jta.xa.PrePrepareState;
 import com.arjuna.ats.internal.jta.xa.TxInfo;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
@@ -1086,8 +1088,16 @@ public class TransactionImple implements javax.transaction.Transaction,
 
 	private void doEnd(Xid _tranID, XAResource xar, int xaState, int txInfoState) throws XAException {
 		try {
-			xar.end(_tranID, xaState);
-			setXAResourceState(xar, txInfoState);
+		    PrePrepareState prePrepareStateToSet = PrePrepareState.END_ASSOCIATION_CALLED;
+		    if(xar instanceof XAResourceEndWithResult) {
+		        if(((XAResourceEndWithResult) xar).endWithResult(_tranID, xaState) == XAResource.XA_RDONLY) {
+		            prePrepareStateToSet = PrePrepareState.END_ASSOCIATION_READ_ONLY_RESULT;
+		        }
+		    } else {
+		        xar.end(_tranID, xaState);
+		    }
+		    setPrePrepareState(xar, prePrepareStateToSet);
+		    setXAResourceState(xar, txInfoState);
 		} catch (XAException e1) {
 			switch (e1.errorCode) {
 				case XAException.XA_RBROLLBACK:
@@ -1109,23 +1119,41 @@ public class TransactionImple implements javax.transaction.Transaction,
 	{
 		int state = TxInfo.UNKNOWN;
 
-		if (xaRes != null)
-		{
-			TxInfo info = (TxInfo) _resources.get(xaRes);
+		TxInfo txInfo = getXAResourceTxInfo(xaRes);
 
-			if (info == null)
-			{
-				info = (TxInfo) _duplicateResources.get(xaRes);
-			}
-
-			if (info != null)
-				state = info.getState();
-		}
+		if (txInfo != null)
+		    return txInfo.getState();
 
 		return state;
 	}
 
-	public void setXAResourceState(XAResource xaRes, int state)
+	public PrePrepareState getPrePrepareState(XAResource xaRes)
+	{
+	    TxInfo txInfo = getXAResourceTxInfo(xaRes);
+
+	    if (txInfo != null)
+	        return txInfo.getPrePrepareState();
+
+	    return PrePrepareState.NO_STATE;
+	}
+
+    public void setXAResourceState(XAResource xaRes, int state)
+    {
+        TxInfo txInfo = getXAResourceTxInfo(xaRes);
+
+        if (txInfo != null)
+            txInfo.setState(state);
+    }
+
+	public void setPrePrepareState(XAResource xaRes, PrePrepareState state)
+	{
+	    TxInfo txInfo = getXAResourceTxInfo(xaRes);
+
+	    if (txInfo != null)
+	        txInfo.setPrePrepareState(state);
+	}
+
+	public TxInfo getXAResourceTxInfo(XAResource xaRes)
 	{
 		if (xaRes != null)
 		{
@@ -1136,9 +1164,10 @@ public class TransactionImple implements javax.transaction.Transaction,
 				info = (TxInfo) _duplicateResources.get(xaRes);
 			}
 
-			if (info != null)
-				info.setState(state);
+			return info;
 		}
+
+		return null;
 	}
 
 	public static final TransactionImple getTransaction()

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/xa/PrePrepareState.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/xa/PrePrepareState.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.internal.jta.xa;
+
+import javax.transaction.xa.XAResource;
+
+import com.arjuna.ats.arjuna.coordinator.AbstractRecord;
+
+/**
+ * Describing the state that the {@link TxInfo} bound to a {@link XAResource}
+ * can obtain in regards of {@link AbstractRecord#beforeTopLevelPrepare()} handling.
+ */
+public enum PrePrepareState {
+    /**
+     * there was called end association for the resource
+     */
+    END_ASSOCIATION_CALLED,
+    /**
+     * there was called end association for the resource and finished with read only
+     */
+    END_ASSOCIATION_READ_ONLY_RESULT,
+    /**
+     * end association not called for the resource, state is unknown,
+     * possibly there is not implemented the pre-prepare handling
+     */
+    NO_STATE
+}

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/xa/TxInfo.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/xa/TxInfo.java
@@ -46,7 +46,8 @@ public class TxInfo
     public static final int FAILED = 3;
     public static final int OPTIMIZED_ROLLBACK = 4;
     public static final int UNKNOWN = 5;
-    
+
+
     public TxInfo (Xid xid)
     {
         this(xid, TxInfo.ASSOCIATED);
@@ -83,8 +84,19 @@ public class TxInfo
 	    _state = TxInfo.UNKNOWN;
     }
 
+    public final PrePrepareState getPrePrepareState ()
+    {
+    return _prePrepareState;
+    }
+
+    public final void setPrePrepareState (PrePrepareState state)
+    {
+    this._prePrepareState = state;
+    }
+
     private Xid    _xid;
     private int    _state;
     private Thread _thread;
+    private PrePrepareState _prePrepareState = PrePrepareState.NO_STATE;
     
 }

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
     <version.org.jboss.arquillian.container.tomcat>1.0.1.Final</version.org.jboss.arquillian.container.tomcat>
     <version.org.apache.tomcat>9.0.7</version.org.apache.tomcat>
     <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
-    <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
+    <version.org.jboss.jboss-transaction-spi>7.6.1.Final-SNAPSHOT</version.org.jboss.jboss-transaction-spi>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
     <version.org.mockito>1.10.19</version.org.mockito>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3020
https://issues.jboss.org/browse/WFLY-10258

This is PoC to get working pre-prepare optimization for 1PC as discussed at https://developer.jboss.org/thread/277738.

I was twiddling with the code to come with this changeset where my purpose to not touching existing code too much (not sure if some outer world systems use some of the public methods, not sure about dependencies some more refactoring of `BasicAction` or `AbstractRecord`, still there could be consequences of this making some tests failing).

@mmusgrov @tomjenkinson : as asking for review, would you think is there some better direction for handling this?

The related changes are in SPI where new `XAResource` interface is added
https://github.com/ochaloup/jboss-transaction-spi/commit/d1aa4301bbb62e3b0154fd276227df31a86ad204
And just testing proposal for WFLY txn client here
https://github.com/ochaloup/wildfly-transaction-client/commit/6a1b2564137eb56bb90364cc4b50bc8ded4449a5

!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle