### PR TITLE
[JBTM-2880] replacing some of the exception print stacktrace calls for logger

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -1452,6 +1452,7 @@ public interface arjunaI18NLogger {
 //    @LogMessage(level = WARN)
 //    public void warn_recovery_ExpiredEntryMonitor_6(@Cause() Throwable arg0);
 
+    @Deprecated
     @Message(id = 12361, value = "Error constructing mbean", format = MESSAGE_FORMAT)
     @LogMessage(level = INFO)
     public void info_osb_MBeanCtorFail(@Cause() Throwable arg0);
@@ -1557,6 +1558,10 @@ public interface arjunaI18NLogger {
     @Message(id = 12389, value = "OSB: Error constructing record header reader: {0}", format = MESSAGE_FORMAT)
     @LogMessage(level = INFO)
     public void info_osb_HeaderStateCtorInfo(String reason);
+
+    @Message(id = 12390, value = "Error constructing mbean", format = MESSAGE_FORMAT)
+    @LogMessage(level = WARN)
+    public void warn_osb_MBeanCtorFail(@Cause() Throwable arg0);
 
     /*
         Allocate new messages directly above this notice.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/osb/mbean/UidWrapper.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/osb/mbean/UidWrapper.java
@@ -195,7 +195,7 @@ public class UidWrapper {
 			Constructor<OSEntryBean> constructor = cl.getConstructor(UidWrapper.class);
 			mbean = constructor.newInstance(this);
 		} catch (Throwable e) { // ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException
-			tsLogger.i18NLogger.info_osb_MBeanCtorFail(e);
+			tsLogger.i18NLogger.warn_osb_MBeanCtorFail(e);
 			mbean = new OSEntryBean(this);           
         }
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/SubordinateJTAXAResourceOrphanFilter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/SubordinateJTAXAResourceOrphanFilter.java
@@ -120,7 +120,7 @@ public class SubordinateJTAXAResourceOrphanFilter implements XAResourceOrphanFil
 						try {
 							uid = UidHelper.unpackFrom(states);
 						} catch (IOException ex) {
-							ex.printStackTrace();
+							jtaLogger.i18NLogger.warn_unpacking_xid_state(theXid, recoveryStore, transactionType, ex);
 
 							finished = true;
 						}
@@ -145,11 +145,9 @@ public class SubordinateJTAXAResourceOrphanFilter implements XAResourceOrphanFil
 					jtaLogger.i18NLogger.info_recovery_notaxid(XAHelper.xidToString(recoveredResourceXid));
 				}
 			} catch (ObjectStoreException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				jtaLogger.i18NLogger.warn_reading_from_object_store(recoveryStore, theXid, e);
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				jtaLogger.i18NLogger.warn_reading_from_object_store(recoveryStore, theXid, e);
 			}
 		}
 		return false;

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -764,8 +764,7 @@ public class TransactionImple implements javax.transaction.Transaction,
         }
 		catch (Exception e)
 		{
-			e.printStackTrace();
-
+			jtaLogger.i18NLogger.warn_failed_to_enlist_xa_resource(xaRes, e);
 			/*
 			 * Some exceptional condition arose and we probably could not enlist
 			 * the resouce. So, for safety mark the transaction as rollback
@@ -1631,7 +1630,7 @@ public class TransactionImple implements javax.transaction.Transaction,
 			}
 			catch (Exception e)
 			{
-				e.printStackTrace();
+				jtaLogger.i18NLogger.warn_cant_create_xid_of_branch(_theTransaction.get_uid(), branch, eisName, e);
 			}
 		}
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/TransactionImporterImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/TransactionImporterImple.java
@@ -44,6 +44,7 @@ import javax.transaction.xa.Xid;
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.subordinate.jca.TransactionImple;
+import com.arjuna.ats.jta.logging.jtaLogger;
 import com.arjuna.ats.jta.xa.XATxConverter;
 import com.arjuna.ats.jta.xa.XidImple;
 import org.jboss.tm.TransactionImportResult;
@@ -177,7 +178,7 @@ public class TransactionImporterImple implements TransactionImporter
 				throw new XAException(XAException.XA_RBROLLBACK);
 			}
 		} catch (SystemException e) {
-			e.printStackTrace();
+			jtaLogger.i18NLogger.error_failed_to_get_transaction_status(tx, e);
 			throw new XAException(XAException.XA_RBROLLBACK);
 		}
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
@@ -404,7 +404,7 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
                     }
                     catch (IOException ex)
                     {
-                        ex.printStackTrace();
+                        jtaLogger.i18NLogger.warn_unpacking_xid_state(xid, recoveryStore, SubordinateAtomicAction.getType(), ex);
 
                         finished = true;
                     }
@@ -476,7 +476,7 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
         }
         catch (Exception ex)
         {
-            ex.printStackTrace();
+            jtaLogger.i18NLogger.warn_reading_from_object_store(StoreManager.getRecoveryStore(), xid, ex);
         }
 
         return indoubt;

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/TransactionImple.java
@@ -125,7 +125,7 @@ public class TransactionImple extends
 		}
 		catch (ClassCastException ex)
 		{
-			ex.printStackTrace();
+			jtaLogger.i18NLogger.error_transaction_class_cast_fail(super._theTransaction, ex);
 
 			return TwoPhaseOutcome.INVALID_TRANSACTION;
 		}
@@ -170,7 +170,7 @@ public class TransactionImple extends
 		}
 		catch (ClassCastException ex)
 		{
-			ex.printStackTrace();
+            jtaLogger.i18NLogger.error_transaction_class_cast_fail(super._theTransaction, ex);
 
             UnexpectedConditionException unexpectedConditionException = new UnexpectedConditionException(ex.toString());
             unexpectedConditionException.initCause(ex);
@@ -214,7 +214,7 @@ public class TransactionImple extends
 		}
 		catch (ClassCastException ex)
 		{
-			ex.printStackTrace();
+			jtaLogger.i18NLogger.error_transaction_class_cast_fail(super._theTransaction, ex);
 
             UnexpectedConditionException unexpectedConditionException = new UnexpectedConditionException(ex.toString());
             unexpectedConditionException.initCause(ex);
@@ -282,7 +282,7 @@ public class TransactionImple extends
 		}
 		catch (ClassCastException ex)
 		{
-			ex.printStackTrace();
+            jtaLogger.i18NLogger.error_transaction_class_cast_fail(super._theTransaction, ex);
 
             UnexpectedConditionException unexpectedConditionException = new UnexpectedConditionException(ex.toString());
             unexpectedConditionException.initCause(ex);
@@ -300,7 +300,7 @@ public class TransactionImple extends
 	    }
 	    catch (final Exception ex)
 	    {
-	        ex.printStackTrace();
+			jtaLogger.i18NLogger.error_transaction_class_cast_fail(super._theTransaction, ex);
 
 	        UnexpectedConditionException unexpectedConditionException = new UnexpectedConditionException(ex.toString());
 	        unexpectedConditionException.initCause(ex);
@@ -375,7 +375,7 @@ public class TransactionImple extends
 			}
 			catch (Exception e)
 			{
-				e.printStackTrace();
+				jtaLogger.i18NLogger.warn_cant_create_xid_of_xid(xid, branch, eisName, e);
 			}
 		}
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -26,16 +26,20 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT;
 
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
+import com.arjuna.ats.arjuna.StateManager;
 import com.arjuna.ats.arjuna.common.Uid;
-
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
+import com.arjuna.ats.arjuna.objectstore.RecoveryStore;
+import com.arjuna.ats.arjuna.state.OutputObjectState;
 
 /**
  * i18n log messages for the jta module.
@@ -426,8 +430,8 @@ public interface jtaI18NLogger {
 	@Message(id = 16100, value = "Xid unset", format = MESSAGE_FORMAT)
 	public String get_xa_xidunset();
 
-	@Message(id = 16101, value = "Could not pack XidImple.", format = MESSAGE_FORMAT)
-	public String get_xid_packerror();
+	@Message(id = 16101, value = "Could not pack XidImple {0}", format = MESSAGE_FORMAT)
+	public String get_xid_packerror(Xid xid);
 
     @Message(id = 16102, value = "The transaction is not active! Uid is {0}", format = MESSAGE_FORMAT)
    	public String get_transaction_arjunacore_inactive(Uid arg0);
@@ -532,7 +536,39 @@ public interface jtaI18NLogger {
 
 	@Message(id = 16131, value = "Subordinate transaction was not recovered successfully {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = FATAL)
-    void warn_could_not_recover_subordinate(Uid uid, @Cause() Exception e);
+	void warn_could_not_recover_subordinate(Uid uid, @Cause() Exception e);
+
+	@Message(id = 16132, value = "Can't packt into output object state {0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_cant_pack_into_output_object_state(OutputObjectState os, @Cause() Exception e);
+
+	@Message(id = 16133, value = "Can't create a new instance of Xid of uid {0}, is branch: {1}, eisname: {2}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_cant_create_xid_of_branch(Uid id, Boolean branch, Integer eisName, @Cause() Exception e);
+
+	@Message(id = 16134, value = "Can't create a new instance of Xid of base xid {0}, is branch: {1}, eisname: {2}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_cant_create_xid_of_xid(Xid id, Boolean branch, Integer eisName, @Cause() Exception e);
+
+	@Message(id = 16135, value = "Can't read object {0} store for xid {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_reading_from_object_store(RecoveryStore recoveryStore, Xid xid, @Cause() Exception e);
+
+	@Message(id = 16136, value = "Cannot unpact state of the xid {0} loaded from recovery store {1} of txn type {2}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_unpacking_xid_state(Xid xid, RecoveryStore recoveryStore, String type, @Cause() Exception e);
+
+	@Message(id = 16137, value = "Failed to get transaction status of {0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	void error_failed_to_get_transaction_status(Transaction txn, @Cause() Exception e);
+
+	@Message(id = 16138, value = "Failed to enlist XA resource {0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_failed_to_enlist_xa_resource(XAResource xares, @Cause() Exception e);
+
+	@Message(id = 16139, value = "Fail to cast class of transaction action {0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	void error_transaction_class_cast_fail(StateManager action, @Cause() Exception e);
 
 
     /*

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XidImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XidImple.java
@@ -92,7 +92,8 @@ public class XidImple implements javax.transaction.xa.Xid, Serializable {
 			_theXid = XATxConverter.getXid(id, branch, eisName);
 		} catch (Exception e) {
 			_theXid = null;
-			e.printStackTrace();
+
+			jtaLogger.i18NLogger.warn_cant_create_xid_of_branch(id, branch, eisName, e);
 
 			// abort or throw exception?
 		}
@@ -249,7 +250,7 @@ public class XidImple implements javax.transaction.xa.Xid, Serializable {
 
 			result = true;
 		} catch (Exception e) {
-			e.printStackTrace();
+			jtaLogger.i18NLogger.warn_cant_pack_into_output_object_state(os, e);
 
 			result = false;
 		}
@@ -273,6 +274,7 @@ public class XidImple implements javax.transaction.xa.Xid, Serializable {
 
 			result = true;
 		} catch (Exception e) {
+			jtaLogger.logger.debug("Can't unpack from input object state " + os, e);
 			result = false;
 		}
 
@@ -287,7 +289,7 @@ public class XidImple implements javax.transaction.xa.Xid, Serializable {
 			os.packBoolean(true);
 
 			if (!x.packInto(os))
-				throw new IOException(jtaLogger.i18NLogger.get_xid_packerror());
+				throw new IOException(jtaLogger.i18NLogger.get_xid_packerror(xid));
 		} else {
 			os.packBoolean(false);
 
@@ -319,6 +321,7 @@ public class XidImple implements javax.transaction.xa.Xid, Serializable {
 
 				return x;
 			} catch (Exception e) {
+				jtaLogger.logger.debug("Can't unpack input object state " + os, e);
 				IOException ioException = new IOException(e.toString());
 				ioException.initCause(e);
 				throw ioException;

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
@@ -239,6 +239,7 @@ public class TransactionImple implements javax.transaction.Transaction,
 			}
 			catch (WrongTransaction wt)
 			{
+                jtaxLogger.i18NLogger.warn_get_jtax_transaction_jts_wrongstatetx(_theTransaction, wt);
                 InactiveTransactionException inactiveTransactionException = new InactiveTransactionException(
                         jtaxLogger.i18NLogger.get_jtax_transaction_jts_wrongstatetx());
                 inactiveTransactionException.initCause(wt);

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/coordinator/ServerTransaction.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/subordinate/jca/coordinator/ServerTransaction.java
@@ -38,6 +38,7 @@ import javax.transaction.xa.Xid;
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.utils.jtaxLogger;
 import com.arjuna.ats.jta.xa.XidImple;
 
 /**
@@ -115,7 +116,7 @@ public class ServerTransaction extends com.arjuna.ats.internal.jts.orbspecific.i
 		}
 		catch (IOException e)
 		{
-			e.printStackTrace();
+			jtaxLogger.i18NLogger.warn_cant_save_state(os, ot, e);
 		}
 
 		return false;
@@ -140,7 +141,7 @@ public class ServerTransaction extends com.arjuna.ats.internal.jts.orbspecific.i
 		}
 		catch (IOException ex)
 		{
-			ex.printStackTrace();
+			jtaxLogger.i18NLogger.warn_cant_restore_state(os, ot, ex);
 		}
 
 		return false;

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
@@ -24,14 +24,21 @@ import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT;
 
+import java.io.IOException;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.state.InputObjectState;
+import com.arjuna.ats.arjuna.state.OutputObjectState;
+import com.arjuna.ats.internal.jta.transaction.jts.AtomicTransaction;
 
 /**
  * i18n log messages for the jtax module.
@@ -282,6 +289,17 @@ public interface jtaxI18NLogger {
 	@Message(id = 24063, value = "Can't save state of xid {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
 	public void warn_jtax_resources_jts_cant_save_state(Xid xid, @Cause() Throwable e);
+
+	@Message(id = 24064, value = "The current transaction {0} does not match this transaction", format = MESSAGE_FORMAT)
+	public String warn_get_jtax_transaction_jts_wrongstatetx(AtomicTransaction txn, @Cause() Exception e);
+
+	@Message(id = 24065, value = "Can't save state of output object state {0} of object type {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	public void warn_cant_save_state(OutputObjectState os, int ot, @Cause() IOException e);
+
+	@Message(id = 24066, value = "Can't restore state of input object state {0} of object type {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	public void warn_cant_restore_state(InputObjectState os, int ot, @Cause() IOException ex);
 
     /*
         Allocate new messages directly above this notice.

--- a/ArjunaJTS/jtax/pom.xml
+++ b/ArjunaJTS/jtax/pom.xml
@@ -41,6 +41,12 @@
               <id>default-test</id>
               <configuration>
                 <skip>true</skip>
+                <systemProperties combine.children="append">
+                   <property>
+                     <name>java.util.logging.config.file</name>
+                     <value>${basedir}/src/test/resources/logging.properties</value>
+                   </property>
+                </systemProperties>
               </configuration>
             </execution>
           </executions>
@@ -193,7 +199,12 @@
                 </goals>
                 <configuration>
                   <skip>false</skip>
-                  <systemProperties combine.children="append"/>
+                  <systemProperties combine.children="append">
+                     <property>
+                       <name>java.util.logging.config.file</name>
+                       <value>${basedir}/src/test/resources/logging.properties</value>
+                     </property>
+                  </systemProperties>
                   <excludes>
                     <exclude>**/common/**</exclude>
                     <exclude>**/ExampleXAResource.java</exclude>
@@ -252,7 +263,12 @@
                 </goals>
                 <configuration>
                   <skip>false</skip>
-                  <systemProperties combine.children="append" />
+                  <systemProperties combine.children="append">
+                     <property>
+                       <name>java.util.logging.config.file</name>
+                       <value>${basedir}/src/test/resources/logging.properties</value>
+                     </property>
+                  </systemProperties>
                   <excludes>
                     <exclude>**/common/**</exclude>
                     <exclude>**/ExampleXAResource.java</exclude>
@@ -328,7 +344,12 @@
                 <configuration>
                   <argLine>${idlj.boot.args}</argLine>
                   <skip>false</skip>
-                  <systemProperties combine.children="append" />
+                  <systemProperties combine.children="append">
+                     <property>
+                       <name>java.util.logging.config.file</name>
+                       <value>${basedir}/src/test/resources/logging.properties</value>
+                     </property>
+                  </systemProperties>
                   <excludes>
                     <exclude>**/common/**</exclude>
                     <exclude>**/ExampleXAResource.java</exclude>
@@ -394,7 +415,12 @@
                 </goals>
                 <configuration>
                   <skip>false</skip>
-                  <systemProperties combine.children="append" />
+                  <systemProperties combine.children="append">
+                     <property>
+                       <name>java.util.logging.config.file</name>
+                       <value>${basedir}/src/test/resources/logging.properties</value>
+                     </property>
+                  </systemProperties>
                   <excludes>
                     <exclude>**/common/**</exclude>
                     <exclude>**/ExampleXAResource.java</exclude>

--- a/ArjunaJTS/jtax/src/test/resources/logging.properties
+++ b/ArjunaJTS/jtax/src/test/resources/logging.properties
@@ -1,0 +1,10 @@
+# setting what handlers to use and what is root logging level
+handlers=java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+.level=ALL
+java.util.logging.SimpleFormatter.format = %4$s: [%1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS] [%2$s] [%3$s] %5$s%6s%n
+# settings the console formatter
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+# settings the file formatter
+java.util.logging.FileHandler.level = ALL
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2880

Some changes to reduce number of places where sysout println is used instead of logger. This is "a long running" task as the code base still contains places where logger is not prioritized.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle