### PR TITLE
JBTM-3028 Retry recovery on slow networks

### DIFF
--- a/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/api/ActivityController.java
+++ b/rts/lra/lra-test/src/main/java/io/narayana/lra/participant/api/ActivityController.java
@@ -425,7 +425,7 @@ public class ActivityController {
         activityService.add(new Activity(lraId));//NarayanaLRAClient.getLRAId(lraId)));
 
         try {
-            Thread.sleep(300); // sleep for 200 miliseconds (should be longer than specified in the @TimeLimit annotation)
+            Thread.sleep(1000); // sleep for a period that is longer than specified in the @TimeLimit annotation
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3028

!TOMCAT !RTS !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !AS_TESTS !mysql !postgres !db2 !oracle

@ochaloup The tests that fail are ones that expect a single recovery pass to be sufficient to finish the LRA. Due to artificial network delays recovery is no longer guaranteed in a single pass. I added some retry logic to do multiple recovery passes if required. But if the network issue continues then recovery may never complete and I argue (in the linked JIRA) that such a test setup is invalid.

I think the test only fix should be sufficient for the purposes of our CI.