### PR TITLE
[JBTM-3031] enhancing error messages for the XTS registration

### DIFF
--- a/XTS/WS-C/dev/src/com/arjuna/webservices/logging/wscI18NLogger.java
+++ b/XTS/WS-C/dev/src/com/arjuna/webservices/logging/wscI18NLogger.java
@@ -22,6 +22,8 @@ package com.arjuna.webservices.logging;
 
 import org.jboss.logging.annotations.*;
 
+import com.arjuna.webservices11.wsarj.InstanceIdentifier;
+
 import javax.xml.namespace.QName;
 
 import static org.jboss.logging.Logger.Level.*;
@@ -289,7 +291,7 @@ public interface wscI18NLogger {
 	@Message(id = 42080, value = "Invalid create coordination context parameters", format = MESSAGE_FORMAT)
 	public String get_wsc11_messaging_ActivationCoordinatorProcessorImpl_1();
 
-	@Message(id = 42081, value = "Participant already registered", format = MESSAGE_FORMAT)
+	@Message(id = 42081, value = "Participant already registered for this protocol identifier", format = MESSAGE_FORMAT)
 	public String get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_1();
 
 	@Message(id = 42082, value = "Invalid protocol identifier", format = MESSAGE_FORMAT)
@@ -304,11 +306,19 @@ public interface wscI18NLogger {
 	@Message(id = 42085, value = "Failed to create service instance: {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
 	public void warn_cannot_create_service_instance(Class arg0, @Cause() Throwable arg1);
-        
-        @Message(id = 42086, value = "Empty messageId received by an async endpoint", format = MESSAGE_FORMAT)
-        @LogMessage(level = ERROR)
-        public void error_empty_messageId_received_by_async_endpoint();
-        
+
+	@Message(id = 42086, value = "Empty messageId received by an async endpoint", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	public void error_empty_messageId_received_by_async_endpoint();
+
+	@Message(id = 42087, value = "Failure to register protocol {0} and instance {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	public void error_failure_to_register_protocol(String protocol, InstanceIdentifier instance, @Cause() Throwable t);
+
+	@Message(id = 42088, value = "Failure to create coordination context of type {0}", format = MESSAGE_FORMAT)
+	@LogMessage(level = ERROR)
+	public void error_failure_to_create_coordination_context(String coordinationType, @Cause() Throwable t);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/XTS/WS-C/dev/src/com/arjuna/wsc/InvalidProtocolException.java
+++ b/XTS/WS-C/dev/src/com/arjuna/wsc/InvalidProtocolException.java
@@ -36,4 +36,14 @@ public class InvalidProtocolException extends Exception
     {
         super(message);
     }
+
+    public InvalidProtocolException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public InvalidProtocolException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
 }

--- a/XTS/WS-C/dev/src/com/arjuna/wsc/InvalidStateException.java
+++ b/XTS/WS-C/dev/src/com/arjuna/wsc/InvalidStateException.java
@@ -36,4 +36,14 @@ public class InvalidStateException extends Exception
     {
         super(message);
     }
+
+    public InvalidStateException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public InvalidStateException(Throwable cause)
+    {
+        super(cause);
+    }
 }

--- a/XTS/WS-C/dev/src/com/arjuna/wsc/NoActivityException.java
+++ b/XTS/WS-C/dev/src/com/arjuna/wsc/NoActivityException.java
@@ -36,4 +36,14 @@ public class NoActivityException extends Exception
     {
         super(message);
     }
+
+    public NoActivityException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public NoActivityException(Throwable cause)
+    {
+        super(cause);
+    }
 }

--- a/XTS/WS-C/dev/src/com/arjuna/wsc11/messaging/ActivationCoordinatorProcessorImpl.java
+++ b/XTS/WS-C/dev/src/com/arjuna/wsc11/messaging/ActivationCoordinatorProcessorImpl.java
@@ -74,6 +74,10 @@ public class ActivationCoordinatorProcessorImpl extends ActivationCoordinatorPro
                 }
                 catch (final InvalidCreateParametersException invalidCreateParametersException)
                 {
+                    if (WSCLogger.logger.isTraceEnabled())
+                        WSCLogger.logger.tracev(invalidCreateParametersException, "{0}, type {1} and context {2}",
+                                WSCLogger.i18NLogger.get_wsc11_messaging_ActivationCoordinatorProcessorImpl_1(), coordinationType, contextFactory);
+
 	                SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PARAMETERS_QNAME);
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PARAMETERS_QNAME).addTextNode(WSCLogger.i18NLogger.get_wsc11_messaging_ActivationCoordinatorProcessorImpl_1());
@@ -82,9 +86,9 @@ public class ActivationCoordinatorProcessorImpl extends ActivationCoordinatorPro
                 catch (final Throwable th)
                 {
                     if (WSCLogger.logger.isTraceEnabled())
-                    {
-                        WSCLogger.logger.tracev("Unexpected exception thrown from create:", th) ;
-                    }
+                        WSCLogger.logger.tracev(th, "Unexpected exception thrown from create coordination context: type {1} and context {2}",
+                            coordinationType, contextFactory);
+
                     SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_CREATE_CONTEXT_QNAME) ;
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_CREATE_CONTEXT_QNAME).addTextNode(th.getMessage());
@@ -94,9 +98,8 @@ public class ActivationCoordinatorProcessorImpl extends ActivationCoordinatorPro
             else
             {
                 if (WSCLogger.logger.isTraceEnabled())
-                {
-                    WSCLogger.logger.tracev("CreateCoordinationContext called for unknown coordination type: {0}", new Object[] {coordinationType}) ;
-                }
+                    WSCLogger.logger.tracev("CreateCoordinationContext called for unknown coordination type: {0} [{1}]",
+                        coordinationType, WSCLogger.i18NLogger.get_wsc11_messaging_ActivationCoordinatorProcessorImpl_1());
 
                 SOAPFactory factory = SOAPFactory.newInstance();
                 SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PARAMETERS_QNAME) ;
@@ -106,7 +109,8 @@ public class ActivationCoordinatorProcessorImpl extends ActivationCoordinatorPro
         }
         catch (SOAPException se)
         {
-            se.printStackTrace(System.err);
+            WSCLogger.i18NLogger.error_failure_to_create_coordination_context(
+                createCoordinationContext == null ? null : createCoordinationContext.getCoordinationType(),se);
             throw new ProtocolException(se);
         }
     }

--- a/XTS/WS-C/dev/src/com/arjuna/wsc11/messaging/RegistrationCoordinatorProcessorImpl.java
+++ b/XTS/WS-C/dev/src/com/arjuna/wsc11/messaging/RegistrationCoordinatorProcessorImpl.java
@@ -77,6 +77,10 @@ public class RegistrationCoordinatorProcessorImpl extends RegistrationCoordinato
                 }
                 catch (final AlreadyRegisteredException alreadyRegisteredException)
                 {
+                    if (WSCLogger.logger.isTraceEnabled())
+                        WSCLogger.logger.tracev(alreadyRegisteredException, "{0}, of protocol {1}, of instance {2}",
+                            WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_1(), protocolIdentifier, arjunaContext.getInstanceIdentifier());
+
                     SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_REGISTER_QNAME);
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_REGISTER_QNAME).addTextNode(WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_1());
@@ -84,13 +88,21 @@ public class RegistrationCoordinatorProcessorImpl extends RegistrationCoordinato
                 }
                 catch (final InvalidProtocolException invalidProtocolException)
                 {
+                    if (WSCLogger.logger.isTraceEnabled())
+                        WSCLogger.logger.tracev(invalidProtocolException, "{0}, of protocol {1}, of instance {2}",
+                            WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_2(), protocolIdentifier, arjunaContext.getInstanceIdentifier());
+
                     SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PROTOCOL_QNAME);
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PARAMETERS_QNAME).addTextNode(WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_2());
                     throw new SOAPFaultException(soapFault);
                 }
-                catch (final InvalidStateException InvalidStateException)
+                catch (final InvalidStateException invalidStateException)
                 {
+                    if (WSCLogger.logger.isTraceEnabled())
+                        WSCLogger.logger.tracev(invalidStateException, "{0}, of protocol {1}, of instance {2}",
+                            WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_3(), protocolIdentifier, arjunaContext.getInstanceIdentifier());
+
                     SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_STATE_QNAME);
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_STATE_QNAME).addTextNode(WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_3());
@@ -98,6 +110,10 @@ public class RegistrationCoordinatorProcessorImpl extends RegistrationCoordinato
                 }
                 catch (final NoActivityException noActivityException)
                 {
+                    if (WSCLogger.logger.isTraceEnabled())
+                        WSCLogger.logger.tracev(noActivityException, "{0}, of protocol {1}, of instance {2}",
+                            WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_4(), protocolIdentifier, arjunaContext.getInstanceIdentifier());
+
                     SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_REGISTER_QNAME);
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_REGISTER_QNAME).addTextNode(WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_4());
@@ -106,9 +122,9 @@ public class RegistrationCoordinatorProcessorImpl extends RegistrationCoordinato
                 catch (final Throwable th)
                 {
                     if (WSCLogger.logger.isTraceEnabled())
-                    {
-                        WSCLogger.logger.tracev("Unexpected exception thrown from create:", th) ;
-                    }
+                        WSCLogger.logger.tracev(th, "Unexpected exception thrown from create: protocol {1}, identifier {2}",
+                            protocolIdentifier, arjunaContext == null ? null : arjunaContext.getInstanceIdentifier());
+
                     SOAPFactory factory = SOAPFactory.newInstance();
                     SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_REGISTER_QNAME);
                     soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_CANNOT_REGISTER_QNAME).addTextNode(th.getMessage());
@@ -117,10 +133,11 @@ public class RegistrationCoordinatorProcessorImpl extends RegistrationCoordinato
             }
             else
             {
-                if (WSCLogger.logger.isTraceEnabled())
-                {
-                    WSCLogger.logger.tracev("Register called for unknown protocol identifier: {0}", new Object[] {protocolIdentifier}) ;
+                if (WSCLogger.logger.isTraceEnabled()) {
+                    WSCLogger.logger.tracev("Register called for unknown protocol identifier: {0} [{1}]",
+                        protocolIdentifier, WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_2()) ;
                 }
+
                 SOAPFactory factory = SOAPFactory.newInstance();
                 SOAPFault soapFault = factory.createFault(SoapFaultType.FAULT_SENDER.getValue(), CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PROTOCOL_QNAME);
                 soapFault.addDetail().addDetailEntry(CoordinationConstants.WSCOOR_ERROR_CODE_INVALID_PARAMETERS_QNAME).addTextNode(WSCLogger.i18NLogger.get_wsc11_messaging_RegistrationCoordinatorProcessorImpl_2());
@@ -129,7 +146,8 @@ public class RegistrationCoordinatorProcessorImpl extends RegistrationCoordinato
         }
         catch (SOAPException se)
         {
-            se.printStackTrace(System.err);
+            WSCLogger.i18NLogger.error_failure_to_register_protocol(register == null ? null : register.getProtocolIdentifier(),
+                arjunaContext == null ? null : arjunaContext.getInstanceIdentifier(), se);
             throw new ProtocolException(se);
         }
     }

--- a/XTS/WSAS/classes/com/arjuna/mwlabs/wsas/UserActivityImple.java
+++ b/XTS/WSAS/classes/com/arjuna/mwlabs/wsas/UserActivityImple.java
@@ -495,7 +495,7 @@ public class UserActivityImple implements UserActivity
                 }
                 catch (Exception ex)
                 {
-                    ex.printStackTrace();
+                    wsasLogger.logger.warnv(ex, "Error on resuming activity from hierarchy {0}", tx);
 		    
                     purge();
                 }

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/RegistrarImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/RegistrarImple.java
@@ -3,6 +3,7 @@ package com.arjuna.mwlabs.wst11.at;
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.mw.wsas.activity.ActivityHierarchy;
 import com.arjuna.mw.wsas.exceptions.SystemException;
+import com.arjuna.mw.wsas.logging.wsasI18NLogger;
 import com.arjuna.mw.wscf.exceptions.ProtocolNotRegisteredException;
 import com.arjuna.mw.wscf11.model.twophase.CoordinatorManagerFactory;
 import com.arjuna.mw.wscf.model.twophase.api.CoordinatorManager;
@@ -104,7 +105,8 @@ public class RegistrarImple implements Registrar
 		ActivityHierarchy hier = (ActivityHierarchy) tx;
 
 		if (hier == null)
-			throw new NoActivityException();
+			throw new NoActivityException("No activity for protocol "
+		        + protocolIdentifier + " and instance " + instanceIdentifier);
 
 		try
 		{
@@ -112,11 +114,11 @@ public class RegistrarImple implements Registrar
 		}
 		catch (com.arjuna.mw.wsas.exceptions.InvalidActivityException ex)
 		{
-			throw new NoActivityException();
+			throw new NoActivityException(ex);
 		}
 		catch (SystemException ex)
 		{
-			throw new InvalidProtocolException();
+			throw new InvalidProtocolException(ex);
 		}
 
 		// TODO check for AlreadyRegisteredException
@@ -137,7 +139,7 @@ public class RegistrarImple implements Registrar
 			}
 			catch (Exception ex)
 			{
-				throw new InvalidStateException();
+				throw new InvalidStateException("Cannot enlist durable 2PC participant with id " + participantId, ex);
 			}
 		}
 		else if (AtomicTransactionConstants.WSAT_SUB_PROTOCOL_VOLATILE_2PC.equals(protocolIdentifier))
@@ -156,7 +158,7 @@ public class RegistrarImple implements Registrar
 			}
 			catch (Exception ex)
 			{
-				throw new InvalidStateException();
+				throw new InvalidStateException("Cannot enlist volatile 2PC participant with id " + participantId, ex);
 			}
 		}
 		else if (AtomicTransactionConstants.WSAT_SUB_PROTOCOL_COMPLETION.equals(protocolIdentifier))
@@ -172,9 +174,7 @@ public class RegistrarImple implements Registrar
 			}
 			catch (Exception ex)
 			{
-				ex.printStackTrace();
-
-				throw new InvalidStateException(ex.toString());
+				throw new InvalidStateException(ex.toString(), ex);
 			}
 		}
         else if (AtomicTransactionConstants.WSAT_SUB_PROTOCOL_COMPLETION_RPC.equals(protocolIdentifier))
@@ -190,15 +190,13 @@ public class RegistrarImple implements Registrar
             }
             catch (Exception ex)
             {
-                ex.printStackTrace();
-
-                throw new InvalidStateException(ex.toString());
+                throw new InvalidStateException(ex.toString(), ex);
             }
         }
 		else {
             wstxLogger.i18NLogger.warn_mwlabs_wst_at_Registrar11Imple_1(AtomicTransactionConstants.WSAT_PROTOCOL, protocolIdentifier);
 
-            throw new InvalidProtocolException();
+            throw new InvalidProtocolException("Invalid identifier " + protocolIdentifier + " of protocol " + AtomicTransactionConstants.WSAT_PROTOCOL);
         }
 	}
 

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/arq/RegistrationServiceTest.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/arq/RegistrationServiceTest.java
@@ -65,7 +65,7 @@ public class RegistrationServiceTest extends BaseWSCTest {
         return RegistrationCoordinator.register(coordinationContext, messageId, participantEndpoint, protocolIdentifier);
     }
     
-    public void testKnownCoordinationTypeInternal()
+    public void testKnownProtocolIdentifierInternal()
             throws Exception
     {
         final String messageId = "testKnownCoordinationType" ;
@@ -82,7 +82,7 @@ public class RegistrationServiceTest extends BaseWSCTest {
         }
     }
 
-    public void testUnknownCoordinationTypeInternal()
+    public void testUnknownProtocolIdentifierInternal()
             throws Exception
     {
         final String messageId = "testUnknownCoordinationType" ;
@@ -91,6 +91,7 @@ public class RegistrationServiceTest extends BaseWSCTest {
         try
         {
             sendRegistration(messageId, protocolIdentifier);
+            fail("Expecting exception being thrown as identifier was " + protocolIdentifier);
         }
         catch (final InvalidProtocolException ipe) {}
         catch (final Throwable th)
@@ -100,42 +101,42 @@ public class RegistrationServiceTest extends BaseWSCTest {
     }
     
     @Test
-    public void testKnownCoordinationTypeSync()
+    public void testKnownProtocolIdentifierSync()
             throws Exception
     {
         final String previousValue = XTSPropertyManager.getWSCEnvironmentBean().getUseAsynchronousRequest();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(WSCEnvironmentBean.NO_ASYNC_REQUEST);
-        testKnownCoordinationTypeInternal();
+        testKnownProtocolIdentifierInternal();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(previousValue);
     }
 
     @Test
-    public void testUnknownCoordinationTypeSync()
+    public void testUnknownProtocolIdentifierSync()
             throws Exception
     {
         final String previousValue = XTSPropertyManager.getWSCEnvironmentBean().getUseAsynchronousRequest();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(WSCEnvironmentBean.NO_ASYNC_REQUEST);
-        testUnknownCoordinationTypeInternal();
+        testUnknownProtocolIdentifierInternal();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(previousValue);
     }
     
     @Test
-    public void testKnownCoordinationTypeAsync()
+    public void testKnownProtocolIdentifierAsync()
             throws Exception
     {
         final String previousValue = XTSPropertyManager.getWSCEnvironmentBean().getUseAsynchronousRequest();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(WSCEnvironmentBean.PLAIN_ASYNC_REQUEST);
-        testKnownCoordinationTypeInternal();
+        testKnownProtocolIdentifierInternal();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(previousValue);
     }
 
     @Test
-    public void testUnknownCoordinationTypeAsync()
+    public void testUnknownProtocolIdentifierAsync()
             throws Exception
     {
         final String previousValue = XTSPropertyManager.getWSCEnvironmentBean().getUseAsynchronousRequest();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(WSCEnvironmentBean.PLAIN_ASYNC_REQUEST);
-        testUnknownCoordinationTypeInternal();
+        testUnknownProtocolIdentifierInternal();
         XTSPropertyManager.getWSCEnvironmentBean().setUseAsynchronousRequest(previousValue);
     }
 }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCompletionCoordinatorProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCompletionCoordinatorProcessor.java
@@ -31,7 +31,7 @@ import org.oasis_open.docs.ws_tx.wsat._2006._06.Notification;
 
 public class TestCompletionCoordinatorProcessor extends CompletionCoordinatorProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,CompletionCoordinatorDetails> messageIdMap = new HashMap<>() ;
 
     public CompletionCoordinatorDetails getCompletionCoordinatorDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCoordinatorCompletionCoordinatorProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCoordinatorCompletionCoordinatorProcessor.java
@@ -34,7 +34,7 @@ import org.oasis_open.docs.ws_tx.wsba._2006._06.StatusType;
 
 public class TestCoordinatorCompletionCoordinatorProcessor extends CoordinatorCompletionCoordinatorProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,CoordinatorCompletionCoordinatorDetails> messageIdMap = new HashMap<>() ;
 
     public CoordinatorCompletionCoordinatorDetails getCoordinatorCompletionCoordinatorDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCoordinatorCompletionParticipantProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCoordinatorCompletionParticipantProcessor.java
@@ -34,7 +34,7 @@ import org.oasis_open.docs.ws_tx.wsba._2006._06.StatusType;
 
 public class TestCoordinatorCompletionParticipantProcessor extends CoordinatorCompletionParticipantProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,CoordinatorCompletionParticipantDetails> messageIdMap = new HashMap<>() ;
 
     public CoordinatorCompletionParticipantDetails getCoordinatorCompletionParticipantDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCoordinatorProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestCoordinatorProcessor.java
@@ -33,7 +33,7 @@ import org.oasis_open.docs.ws_tx.wsat._2006._06.Notification;
 
 public class TestCoordinatorProcessor extends CoordinatorProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,CoordinatorDetails> messageIdMap = new HashMap<>() ;
 
     public CoordinatorDetails getCoordinatorDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestParticipantCompletionCoordinatorProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestParticipantCompletionCoordinatorProcessor.java
@@ -34,7 +34,7 @@ import org.oasis_open.docs.ws_tx.wsba._2006._06.StatusType;
 
 public class TestParticipantCompletionCoordinatorProcessor extends ParticipantCompletionCoordinatorProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,ParticipantCompletionCoordinatorDetails> messageIdMap = new HashMap<>() ;
 
     public ParticipantCompletionCoordinatorDetails getParticipantCompletionCoordinatorDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestParticipantCompletionParticipantProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestParticipantCompletionParticipantProcessor.java
@@ -33,7 +33,7 @@ import org.oasis_open.docs.ws_tx.wsba._2006._06.StatusType;
 
 public class TestParticipantCompletionParticipantProcessor extends ParticipantCompletionParticipantProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,ParticipantCompletionParticipantDetails> messageIdMap = new HashMap<>() ;
 
     public ParticipantCompletionParticipantDetails getParticipantCompletionParticipantDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestParticipantProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/arq/TestParticipantProcessor.java
@@ -32,7 +32,7 @@ import org.oasis_open.docs.ws_tx.wsat._2006._06.Notification;
 
 public class TestParticipantProcessor extends ParticipantProcessor
 {
-    private Map messageIdMap = new HashMap() ;
+    private Map<String,ParticipantDetails> messageIdMap = new HashMap<>() ;
 
     public ParticipantDetails getParticipantDetails(final String messageId, final long timeout)
     {

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestFaultedExceptionBusinessAgreementWithParticipantCompletionParticipant.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestFaultedExceptionBusinessAgreementWithParticipantCompletionParticipant.java
@@ -57,6 +57,7 @@ public class TestFaultedExceptionBusinessAgreementWithParticipantCompletionParti
     {
     }
 
+    @Deprecated
     public void unknown () throws SystemException
     {
     }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestNoExceptionBusinessAgreementWithCoordinatorCompletionParticipant.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestNoExceptionBusinessAgreementWithCoordinatorCompletionParticipant.java
@@ -58,7 +58,8 @@ public class TestNoExceptionBusinessAgreementWithCoordinatorCompletionParticipan
     public void complete () throws WrongStateException, SystemException
     {
     }
-    
+
+    @Deprecated
     public void unknown () throws SystemException
     {
     }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestNoExceptionBusinessAgreementWithParticipantCompletionParticipant.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestNoExceptionBusinessAgreementWithParticipantCompletionParticipant.java
@@ -56,6 +56,7 @@ public class TestNoExceptionBusinessAgreementWithParticipantCompletionParticipan
     {
     }
 
+    @Deprecated
     public void unknown () throws SystemException
     {
     }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestSystemExceptionBusinessAgreementWithCoordinatorCompletionParticipant.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/common/TestSystemExceptionBusinessAgreementWithCoordinatorCompletionParticipant.java
@@ -64,6 +64,7 @@ public class TestSystemExceptionBusinessAgreementWithCoordinatorCompletionPartic
 	return Status.STATUS_ACTIVE;
     }
 
+    @Deprecated
     public void unknown () throws SystemException
     {
 	throw new SystemException();


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3031

this is follow up to the JBTM-2928 as discussed at EAP7-911 where messages and tracability of errors during registration should be enhanced

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !TOMCAT !mysql !postgres !db2 !oracle