### PR TITLE
JBTM-3037 Ensure the LRA context is set correctly in the JAX-RS respo…

### DIFF
--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRAResponseFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRAResponseFilter.java
@@ -46,6 +46,10 @@ public class ClientLRAResponseFilter implements ClientResponseFilter {
          */
         if (incomingLRA != null) {
             Current.push(new URL(incomingLRA.toString()));
+        } else {
+            // any previous context must have been ended by the invoked service otherwise incomingLRA
+            // would have been present
+            Current.pop();
         }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3037

!TOMCAT !RTS !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !AS_TESTS !mysql !postgres !db2 !oracle

Notes for the reviewer:

LRA transaction propagation is implemented using a combination of thread locals and JAX-RS filters. The following text describes how the implementation keeps track of the currently active LRA:

Client Side:

When a service makes a JAX-RS invocation the ClientLRARequestFilter is triggered. This filter
checks to see if there is an LRA on the calling thread and, if so, it includes it in the outgoing headers.

When the invocation returns the ClientLRAResponseFilter is triggered. If the response header
contains an LRA then it is put on the thread as a thread local. Otherwise the filter checks whether
or not there was an LRA on the outgoing invocation and, if so, it puts that back on the thread.

**The current code does not perform this last check and this PR provides the fix for that.**

Server Side:

When a request enters a JAX-RS server the ServerLRAFilter is triggered. This filter checks for
LRA annotations on the target resouce method and decides whether a new LRA needs to be started
or whether an existing one needs to be suspended or ended (this is explained in the javadoc for @LRA).
The thread local context is then modified accordingly.
