### PR TITLE
JBTM-3017 RecoveryMonitor should call System.exit(n) with a non zero …

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/RecoveryMonitor.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/tools/RecoveryMonitor.java
@@ -47,6 +47,11 @@ public class RecoveryMonitor
 	private static String systemOutput = "";
 
 	public static void main (String[] args)
+	{
+		System.exit(main2(args));
+	}
+
+	public static int main2 (String[] args)
     {
 	String host = null;
 	int port = 0;
@@ -54,13 +59,14 @@ public class RecoveryMonitor
 	int timeout = 20000;
         boolean test = false;
 	boolean verbose = false;
+	int status = 1; // program return status. By convention a nonzero value indicates abnormal termination
 
 	for (int i = 0; i < args.length; i++)
 	{
 	    if (args[i].compareTo("-help") == 0)
 	    {
 		usage();
-		System.exit(0);
+		return status;
 	    }
 	    else if (args[i].compareTo("-verbose") == 0)
 		{
@@ -120,7 +126,7 @@ public class RecoveryMonitor
 				    System.out.println("Unknown option "+args[i]);
 				    usage();
 
-				    System.exit(0);
+				    return status;
 				}
 			    }
 			}
@@ -154,14 +160,17 @@ public class RecoveryMonitor
 
         response = fromServer.readLine();
 
-        if (response.equals("DONE"))
-            systemOutput = asyncScan ? "RecoveryManager scan begun." : "DONE";
-        else
-            systemOutput = verbose ? "ERROR" : "RecoveryManager did not understand request: " + response;
-
         System.out.println(systemOutput);
 
 	    connectorSocket.close() ;
+
+		if (response.equals("DONE")) {
+			systemOutput = asyncScan ? "RecoveryManager scan begun." : "DONE";
+			status = 0;
+		} else {
+			systemOutput = verbose ? "ERROR" : "RecoveryManager did not understand request: " + response;
+			status = 2;
+		}
 	}
 	catch (java.net.ConnectException e)
 	{
@@ -174,6 +183,8 @@ public class RecoveryMonitor
 
 	if ( test )
 	    System.out.println("Ready");
+
+	return status;
     }
 
     private static void usage ()

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/RecoveryMonitorTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/RecoveryMonitorTest.java
@@ -30,9 +30,6 @@ import com.arjuna.ats.jta.common.jtaPropertyManager;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
 import org.junit.Test;
 
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
@@ -76,11 +73,12 @@ public class RecoveryMonitorTest {
             String rcPort = String.valueOf(recoveryEnvironmentBean.getRecoveryPort()); // the recovery listener port
 
             // trigger a recovery scan with verbose output
-            RecoveryMonitor.main(new String [] {"-verbose", "-port", rcPort, "-host", host});
+            int status = RecoveryMonitor.main2(new String[] {"-verbose", "-port", rcPort, "-host", host});
 
             // check the output of the scan
             assertEquals("ERROR", RecoveryMonitor.getResponse());
             assertEquals("ERROR", RecoveryMonitor.getSystemOutput());
+            assertEquals(2, status);
         } finally {
             manager.terminate();
         }

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/RecoveryMonitorTest2.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/RecoveryMonitorTest2.java
@@ -27,13 +27,11 @@ import com.arjuna.ats.arjuna.recovery.RecoveryManager;
 import com.arjuna.ats.arjuna.tools.RecoveryMonitor;
 import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
-import com.arjuna.ats.jta.common.jtaPropertyManager;
 import org.junit.Test;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
-import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -116,11 +114,12 @@ public class RecoveryMonitorTest2 {
             String rcPort = String.valueOf(recoveryEnvironmentBean.getRecoveryPort()); // the recovery listener port
 
             // trigger a recovery scan with verbose output
-            RecoveryMonitor.main(new String [] {"-verbose", "-port", rcPort, "-host", host});
+            int status = RecoveryMonitor.main2(new String[] {"-verbose", "-port", rcPort, "-host", host});
 
             // check the output of the scan
             assertEquals("DONE", RecoveryMonitor.getResponse());
             assertEquals("DONE", RecoveryMonitor.getSystemOutput());
+            assertEquals(0, status);
         } finally {
             manager.terminate();
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3017

!TOMCAT !RTS !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !AS_TESTS !mysql !postgres !db2 !oracle

I have reopened JBTM-3017 so that the program returns a standard code according to the conventions defined in System.exit(n).