### PR TITLE
[JBTM-3034] removing xid from processing when to be committed by AtomicActionRecoveryModule

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/CommitMarkableResourceRecordRecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/CommitMarkableResourceRecordRecoveryModule.java
@@ -446,6 +446,10 @@ public class CommitMarkableResourceRecordRecoveryModule implements
 
 	@Override
 	public synchronized void periodicWorkSecondPass() {
+		if (tsLogger.logger.isTraceEnabled()) {
+			tsLogger.logger.trace("CommitMarkableResourceRecordRecoveryModule second pass");
+		}
+
 		/**
 		 * This is the list of AtomicActions that were prepared but not
 		 * completed.

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/XARecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/XARecoveryModule.java
@@ -321,10 +321,10 @@ public class XARecoveryModule implements ExtendedRecoveryModule
 
 				// JBTM-1255 moved stale check back to bottomUpRecovery
 				if (xids.contains(xid)) {
-					// This Xid will hopefully be recovered by the AtomicAction
-					// We do not remove it from the map as there is garbage collection in RecoveryXids already
-					// and it is possible that the Xid is recovered by both txbridge and XATerminator - the second
+					// This Xid is going to be recovered by the AtomicAction
+					// it is possible that the Xid is recovered by both txbridge and XATerminator - the second
 					// would get noxaresource error message
+					xids.remove(xid);
 					return theKey;
 				}
 			}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3034

This reverts the change from JBTM-2734 at https://github.com/jbosstm/narayana/pull/1059/files#diff-8487f43e773b3321c5396187b559bfffL261 as it caused the regression for CMR processing. By reverting of the change there is, hopefully, no functionality harm - tested with XATerminator usecases, will be seen on this PR when test finishes too.

!QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !TOMCAT !mysql !postgres !db2 !oracle