### PR TITLE
Made getTransactionManager() protected instead of private

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionContext.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionContext.java
@@ -134,7 +134,7 @@ public class TransactionContext implements Context {
         }
     }
 
-    private TransactionManager getTransactionManager() {
+    protected TransactionManager getTransactionManager() {
 
         //  ignore findbugs warning about incorrect lazy initialization of static field since the values are looked up via JNDI
         // (ie there is no object construction during initialization)


### PR DESCRIPTION
This pull request makes the `getTransactionManager()` method in `TransactionContext` `protected` instead of `private`.  In my use case, I have no need of JNDI.  It would be nice to be able to override this method so that I can simply use, for example, `com.arjuna.ats.jta.common.TransactionManager.transactionManager()`.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>