### PR TITLE
JBTM-3046 Upgrade undertow version for the tests

### DIFF
--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -32,7 +32,7 @@
     <maven.build.timestamp.format>yyyyMMdd'T'HHmmss</maven.build.timestamp.format>
     <javaee6.with.tools.version>1.0.0.M7</javaee6.with.tools.version>
 
-    <undertow.io.version>1.0.1.Final</undertow.io.version>
+    <undertow.io.version>2.0.11.Final</undertow.io.version>
 
     <!-- ssl debug: -Djavax.net.debug=ssl:handshake  http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Debug
      -->


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3046

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !TOMCAT !mysql !postgres !db2 !oracle

The bug relates to a hang when an HTTP request is made to the REST-AT coordinator running in undertow. The test currently use an ancient version of undertow so this PR upgrades undertow to a more recent version.