### PR TITLE
[JBTM-3050] fixing the cmr standalone.xml configuration as it does not need iiop

### DIFF
--- a/ArjunaJTA/jta/src/test/resources/standalone-cmr.xml
+++ b/ArjunaJTA/jta/src/test/resources/standalone-cmr.xml
@@ -31,7 +31,6 @@
         <extension module="org.wildfly.extension.request-controller"/>
         <extension module="org.wildfly.extension.security.manager"/>
         <extension module="org.wildfly.extension.undertow"/>
-        <extension module="org.wildfly.iiop-openjdk"/>
     </extensions>
 
 
@@ -271,9 +270,6 @@
                 </local-cache>
                 <local-cache name="timestamps"/>
             </cache-container>
-        </subsystem>
-        <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-            <initializers transactions="spec" security="identity"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:4.0">


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3050

Removing the IIOP subsystem from configuration of the `standalone-cmr.xml` as it not needed as the tests are part of the `ArjuntaJTA/jta` and CMR is not supported for the JTS.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle