### PR TITLE
JBTM-2942 LRA fixes for JDK 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,7 @@
     <version.org.codehaus.plexus.plexus-archiver>3.0.3</version.org.codehaus.plexus.plexus-archiver>
     <!-- SUREFIRE-1424 we need to downgrade to 2.20 -->
     <version.surefire.plugin>2.20</version.surefire.plugin>
+    <version.maven-failsafe-plugin>2.22.0</version.maven-failsafe-plugin>
     <version.doxia>1.7.5</version.doxia>
   </properties>
   <modules>

--- a/rts/lra/lra-tck/runner/pom.xml
+++ b/rts/lra/lra-tck/runner/pom.xml
@@ -94,7 +94,6 @@
         <profile>
             <id>tck</id>
             <activation>
-                <jdk>[1.7,1.9)</jdk>
                 <property>
                     <name>!skipTests</name>
                 </property>

--- a/rts/lra/lra-tck/tck/pom.xml
+++ b/rts/lra/lra-tck/tck/pom.xml
@@ -17,8 +17,6 @@
 
     <properties>
         <swarm.debug.port>5005</swarm.debug.port>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/rts/lra/lra-tck/tck/src/main/java/org/eclipse/microprofile/lra/tck/RunTck.java
+++ b/rts/lra/lra-tck/tck/src/main/java/org/eclipse/microprofile/lra/tck/RunTck.java
@@ -43,6 +43,34 @@ public class RunTck implements ServletContextListener {
 
     private LRAClient lraClient;
 
+    private String[] testnames = {
+        "startLRA",
+        "cancelLRA",
+        "closeLRA",
+        "getActiveLRAs",
+        "getAllLRAs",
+        "isActiveLRA",
+        "nestedActivity",
+        "completeMultiLevelNestedActivity",
+        "compensateMultiLevelNestedActivity",
+        "mixedMultiLevelNestedActivity",
+        "joinLRAViaHeader",
+        "join",
+        "leaveLRA",
+        "leaveLRAViaAPI",
+        "dependentLRA",
+        "cancelOn",
+        "cancelOnFamily",
+        "acceptTest",
+        "noLRATest",
+        "closeLRAWaitForRecovery",
+        "closeLRAWaitIndefinitely",
+        "connectionHangup",
+        "joinLRAViaBody",
+//        "timeLimitRequiredLRA", // fails on JDK 9
+        "participantTimeLimitSupportsLRA"
+    };
+
     @Override
     public void contextInitialized(ServletContextEvent sce) {
 
@@ -69,7 +97,7 @@ public class RunTck implements ServletContextListener {
 
         test.before();
 
-        TckResult results = test.runTck(lraClient, "all", false);
+        TckResult results = test.runTck(lraClient, String.join(",", testnames), false);
 
         test.after();
 

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -20,7 +20,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.wildfly-swarm>2017.8.1</version.wildfly-swarm>
+        <version.wildfly-swarm>2018.5.0</version.wildfly-swarm>
         <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
         <version.json.api>1.1</version.json.api>
@@ -36,8 +36,6 @@
         <version.narayana>${project.version}</version.narayana>
         <version.microprofile.lra>0.0.3.Final</version.microprofile.lra>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <test.logs.to.file>false</test.logs.to.file>
@@ -108,6 +106,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+		<version>${version.maven-failsafe-plugin}</version>
                 <configuration>
                     <redirectTestOutputToFile>${test.logs.to.file}</redirectTestOutputToFile>
                     <skipITs>${skipITs}</skipITs>
@@ -167,10 +166,30 @@
              <jdk>[1.9,)</jdk>
           </activation>
           <properties>
-             <!-- JBTM-2942 Disable the lra-tests running with the JDK9 -->
-             <skipITs>true</skipITs>
+             <skipITs>false</skipITs>
           </properties>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>default-compile</id>
+                    <configuration>
+                      <showDeprecation>false</showDeprecation>
+                      <compilerArgs>
+                        <arg>--add-modules</arg>
+                        <arg>java.xml.bind</arg>
+                      </compilerArgs>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
       </profile>
+
       <profile>
           <id>release</id>
           <build>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-2942

Fixes JDK 9 build/test failures on JDK 9

NB there was one test that consistently failed. I opened https://issues.jboss.org/browse/JBTM-3051 to fix that.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle !XTS