### PR TITLE
JBTM-3066 nested LRAs via the API

### DIFF
--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/Current.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/Current.java
@@ -25,7 +25,9 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.core.MultivaluedMap;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
@@ -127,10 +129,20 @@ public class Current {
         if (current == null) {
             lraContexts.set(new Current(lraId));
         } else {
-            if (!current.stack.peek().equals(lraId)) {
+            if (!current.stack.contains(lraId)) {
                 current.stack.push(lraId);
             }
         }
+    }
+
+    public static List<Object> getContexts() {
+        Current current = lraContexts.get();
+
+        if (current == null) {
+            return new ArrayList<>();
+        }
+
+        return new ArrayList<>(current.stack);
     }
 
     /**
@@ -142,7 +154,7 @@ public class Current {
         URL lraId = Current.peek();
 
         if (lraId != null) {
-            responseContext.getHeaders().putSingle(LRA_HTTP_HEADER, lraId);
+            responseContext.getHeaders().put(LRA_HTTP_HEADER, getContexts());
         } else {
             responseContext.getHeaders().remove(LRA_HTTP_HEADER);
         }
@@ -182,5 +194,9 @@ public class Current {
     public static void clearContext(MultivaluedMap<String, String> headers) {
         headers.remove(LRA_HTTP_HEADER);
         popAll();
+    }
+
+    public static <T> T getLast(List<T> objects) {
+        return objects == null ? null : objects.stream().reduce((a, b) -> b).orElse(null);
     }
 }

--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -371,7 +371,7 @@ public class NarayanaLRAClient implements LRAClient, Closeable {
 
     @Override
     public URL startLRA(String clientID, Long timeout, TimeUnit unit) throws GenericLRAException {
-        return startLRA(null, clientID, timeout, unit);
+        return startLRA(getCurrent(), clientID, timeout, unit);
     }
 
     @Override
@@ -412,7 +412,7 @@ public class NarayanaLRAClient implements LRAClient, Closeable {
             }
 
             // validate that there is an LRAInfo response header holding the LRAInfo id
-            Object lraObject = response.getHeaders().getFirst(LRA_HTTP_HEADER);
+            Object lraObject = Current.getLast(response.getHeaders().get(LRA_HTTP_HEADER));
 
             if (lraObject == null) {
                 LRALogger.i18NLogger.error_nullLraOnCreation(response);

--- a/rts/lra/lra-coordinator/pom.xml
+++ b/rts/lra/lra-coordinator/pom.xml
@@ -60,10 +60,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
-            <artifactId>transactions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.swarm</groupId>
             <artifactId>swagger</artifactId>
         </dependency>
         <dependency>

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -268,7 +268,7 @@ public class Coordinator {
 
         return Response.status(Response.Status.CREATED)
                 .entity(lraId)
-                .header(LRA_HTTP_HEADER, lraId)
+                .header(LRA_HTTP_HEADER, Current.getContexts())
                 .build();
     }
 

--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRAResponseFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ClientLRAResponseFilter.java
@@ -34,7 +34,7 @@ import static io.narayana.lra.client.NarayanaLRAClient.LRA_HTTP_HEADER;
 public class ClientLRAResponseFilter implements ClientResponseFilter {
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-        Object incomingLRA = responseContext.getHeaders().getFirst(LRA_HTTP_HEADER);
+        Object incomingLRA = Current.getLast(responseContext.getHeaders().get(LRA_HTTP_HEADER));
 
         if (incomingLRA == null) {
             incomingLRA = requestContext.getProperty(LRA_HTTP_HEADER);

--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -166,10 +166,10 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 
         if (headers.containsKey(LRA_HTTP_HEADER)) {
             try {
-                incommingLRA = new URL(headers.getFirst(LRA_HTTP_HEADER));
+                incommingLRA = new URL(Current.getLast(headers.get(LRA_HTTP_HEADER)).toString());
             } catch (MalformedURLException e) {
                 String msg = String.format("header %s contains an invalid URL %s",
-                        LRA_HTTP_HEADER, headers.getFirst(LRA_HTTP_HEADER));
+                        LRA_HTTP_HEADER, Current.getLast(headers.get(LRA_HTTP_HEADER)));
 
                 throw new GenericLRAException(null, Response.Status.PRECONDITION_FAILED.getStatusCode(), msg, e);
             }
@@ -414,7 +414,8 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                         newLRA = null; // don't try to cancle newKRA twice
                     }
 
-                    if (current.toExternalForm().equals(requestContext.getHeaders().getFirst(LRA_HTTP_HEADER))) {
+                    if (current.toExternalForm().equals(
+                            Current.getLast(requestContext.getHeaders().get(LRA_HTTP_HEADER)))) {
                         // the callers context is closed so invalidate it
                         requestContext.getHeaders().remove(LRA_HTTP_HEADER);
                     }
@@ -426,7 +427,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                 try {
                     lraClient.closeLRA((URL) newLRA);
 
-                    if (current.toExternalForm().equals(requestContext.getHeaders().getFirst(LRA_HTTP_HEADER))) {
+                    if (current.toExternalForm().equals(Current.getLast(requestContext.getHeaders().get(LRA_HTTP_HEADER)))) {
                         // the callers context is closed so invalidate it
                         requestContext.getHeaders().remove(LRA_HTTP_HEADER);
                     }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3066

Enables: jbosstm/quickstart#235

!QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !TOMCAT !mysql !postgres !db2 !oracle !JACOCO !QA_JTA NO_WIN !AS_TESTS 

The issue here is that I maintain LRA contexts in a java.util.Stack (see io.narayana.lra.client.Current) so if there is already a context present when a new LRA is started then the new one gets pushed onto the stack. The intention is that as the child finishes it gets popped so the previous one becomes the current one.

But when the JAX-RS filters need to propagate the contexts via JAX-RS headers the code is only looking at the first header instance to obtain the active context, for example:

> response.getHeaders().getFirst(LRA_HTTP_HEADER);

There were other similar errors too in how these contexts were getting shuffled between the current thread and the JAX-RS headers.

NB I also removed a pointless dependency in the (lra-coordinator pom) on the swarm transaction fraction which was causing me a problem with the LRA quickstarts I am writing.