### PR TITLE
Refactoring: removing unused commons-logging dependency declaration

### DIFF
--- a/STM/pom.xml
+++ b/STM/pom.xml
@@ -42,15 +42,6 @@
       <artifactId>txoj</artifactId>
       <version>${project.version}</version>
     </dependency>
-<!--    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging-api</artifactId>
-      <version>1.0.4</version> 
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>-->
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,6 @@
     <version.javax.inject>1</version.javax.inject>
     <version.javax.servlet>3.0.1</version.javax.servlet>
     <version.commons-httpclient>3.1-jbossorg-1</version.commons-httpclient>
-    <version.commons-logging>1.1.0.jboss</version.commons-logging>
     <version.log4j>1.2.17</version.log4j>
     <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
     <version.dom4j>1.6.1</version.dom4j>

--- a/rts/at/integration/pom.xml
+++ b/rts/at/integration/pom.xml
@@ -112,13 +112,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>${version.commons-logging}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <version>${version.org.jboss.arquillian.core}</version>


### PR DESCRIPTION
There is no class of depdencency `commons-logging:commons-logging` used in the project. It's not needed to be mentioned in `pom.xml`.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle