### PR TITLE
[JBTM-3078] Enriching jdbc transactional driver for MSSQL 

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/drivers/modifiers/list.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/drivers/modifiers/list.java
@@ -42,7 +42,8 @@ public class list
 				"MySQL-AB JDBC Driver",
 				"MariaDB connector/J",
 				"H2 JDBC Driver",
-				"IBM Data Server Driver for JDBC and SQLJ"}) {
+				"IBM Data Server Driver for JDBC and SQLJ",
+				"Microsoft JDBC Driver 6.4 for SQL Server"}) {
 			ModifierFactory.putModifier(driver, -1, -1,
 					IsSameRMModifier.class.getName());
 		}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3078

The jdbc transactional driver checks what the jdbc connection `DatabaseMetaData.getDriverName()` gets.
Adding string returned by jdbc driver from MSSQL database.

!QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !XTS !JACOCO