### PR TITLE
JBTM-3074 Fail gracefully if a test fails

### DIFF
--- a/STM/src/test/java/org/jboss/stm/TaxonomyTest.java
+++ b/STM/src/test/java/org/jboss/stm/TaxonomyTest.java
@@ -28,6 +28,7 @@ import org.jboss.stm.annotations.WriteLock;
 import org.jboss.stm.internal.RecoverableContainer;
 
 import com.arjuna.ats.arjuna.AtomicAction;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 // these tests are discussed in the article https://jbossts.blogspot.com/2018/09/tips-on-how-to-evaluate-stm.html
 public class TaxonomyTest extends TestCase {
@@ -111,40 +112,42 @@ public class TaxonomyTest extends TestCase {
         AtomicInt ai = new RecoverableContainer<AtomicInt>().enlist(new AtomicIntImpl());
         AtomicAction outer = new AtomicAction();
         AtomicAction inner = new AtomicAction();
+        final AtomicBoolean aiUpdated = new AtomicBoolean(false);
 
         Thread ot = new Thread(() -> {
             try {
-                synchronized (inner) {
-                    inner.wait();
-                }
+                waitForCondition(aiUpdated); // wait for the other thread to set the value
+
                 assertEquals(2, ai.get());
             } catch (Exception e) {
                 e.printStackTrace();
             }
         });
 
-        ai.set(1);
-        outer.begin();
-        {
-            ai.set(2);
-
-            ot.start();
-
-            outer.addThread(ot);
-
-            inner.begin();
+        try {
+            ai.set(1);
+            outer.begin();
             {
-                ai.set(3);
-                // the outer transaction should still see the value as 2
-                synchronized (inner) {
-                    inner.notify();
+                ai.set(2);
+
+                ot.start();
+
+                outer.addThread(ot);
+
+                inner.begin();
+                {
+                    ai.set(3);
+                    // the outer transaction should still see the value as 2
+                    updateCondition(aiUpdated); // tell the other thread to continue
+
+                    inner.abort();
                 }
 
-                inner.abort();
+                outer.removeThread(ot);
+                outer.commit();
             }
-
-            outer.removeThread(ot);
-            outer.commit();
+        } finally {
+            updateCondition(aiUpdated);
         }
 
         assertEquals(2, ai.get());
@@ -157,12 +160,12 @@ public class TaxonomyTest extends TestCase {
         AtomicInt ai = new RecoverableContainer<AtomicInt>().enlist(new AtomicIntImpl());
         AtomicAction outer = new AtomicAction();
         AtomicAction inner = new AtomicAction();
+        final AtomicBoolean aiUpdated = new AtomicBoolean(false);
 
         Thread ot = new Thread(() -> {
             try {
-                synchronized (inner) {
-                    inner.wait();
-                }
+                waitForCondition(aiUpdated); // wait for the other thread to set the value
+
                 assertEquals(2, ai.get());
                 ai.set(4);
             } catch (Exception e) {
@@ -170,29 +173,31 @@ public class TaxonomyTest extends TestCase {
             }
         });
 
-        ai.set(1);
-        outer.begin();
-        {
-            ai.set(2);
-
-            ot.start();
-
-            outer.addThread(ot);
-
-            inner.begin();
+        try {
+            ai.set(1);
+            outer.begin();
             {
-                ai.set(3);
-                // the outer transaction should still see the value as 2
-                synchronized (inner) {
-                    inner.notify();
+                ai.set(2);
+
+                ot.start();
+
+                outer.addThread(ot);
+
+                inner.begin();
+                {
+                    ai.set(3);
+                    // the outer transaction should still see the value as 2
+                    updateCondition(aiUpdated); // tell the other thread to continue
+
+                    assertEquals(3, ai.get()); // must not see the value 4
+                    inner.abort();
                 }
 
-                assertEquals(3, ai.get()); // must not see the value 4
-                inner.abort();
+                outer.removeThread(ot);
+                outer.commit();
             }
-
-            outer.removeThread(ot);
-            outer.commit();
+        } finally {
+            updateCondition(aiUpdated);
         }
 
         assertEquals(2, ai.get());
@@ -210,17 +215,19 @@ public class TaxonomyTest extends TestCase {
         // with the container returns a proxy which will enforce STM semantics
         AtomicInt ai = new RecoverableContainer<AtomicInt>().enlist(aiImple);
         AtomicAction tx = new AtomicAction();
+        final AtomicBoolean aiUpdated = new AtomicBoolean(false);
+        final AtomicBoolean aiUpdatedInOtherThread = new AtomicBoolean(false);
 
         // set up code that will access the memory outside of a transaction
         Thread ot = new Thread(() -> {
             try {
-                synchronized (tx) {
-                    tx.wait();
+                synchronized (aiUpdated) {
+                    waitForCondition(aiUpdated); // wait for the other thread to set the value
 
                     // non transactional code should see changes
                     assertEquals(2, aiImple.get());
                     aiImple.set(10);
-                    tx.notify();
+                    updateCondition(aiUpdatedInOtherThread); // tell the other thread the update happened
                 }
             } catch (Exception e) {
                 e.printStackTrace();
@@ -229,19 +236,21 @@ public class TaxonomyTest extends TestCase {
 
         ot.start();
 
-        ai.set(1); // initialise the shared mmeory
-        tx.begin(); // start a transaction
-        {
-            ai.set(2); // conditionally set the value to 2
+        try {
+            ai.set(1); // initialise the shared mmeory
+            tx.begin(); // start a transaction
+            {
+                ai.set(2); // conditionally set the value to 2
 
-            synchronized (tx) {
-                tx.notify(); // trigger the non-transactional code to update the memory
-                tx.wait();
+                updateCondition(aiUpdated); // trigger the non-transactional code to update the memory
+                waitForCondition(aiUpdatedInOtherThread); // and wait for it to do the update
+
+                // weak isolation means that transactional code should see the changes made by non transactional code
+                assertEquals(10, ai.get());
+                tx.commit(); // commit the changes made to the shared memory
             }
-
-            // weak isolation means that transactional code should see the changes made by non transactional code
-            assertEquals(10, ai.get());
-            tx.commit(); // commit the changes made to the shared memory
+        } finally {
+            updateCondition(aiUpdated);
         }
 
         // changes made by non transactional code are visible even after commit
@@ -272,4 +281,32 @@ public class TaxonomyTest extends TestCase {
 
         assertEquals(3, ai.get());
     }
+
+    private void waitForCondition(AtomicBoolean condition) {
+        int waitAttempts = MAX_WAIT_ATTEMPTS;
+
+        synchronized (condition) {
+            while (!condition.get() && waitAttempts-- > 0) {
+                try {
+                    condition.wait(WAIT_INTERVAL);
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        }
+
+        if (!condition.get()) {
+            fail("Did not receive condition notify");
+        }
+    }
+
+    private void updateCondition(AtomicBoolean condition) {
+        synchronized (condition) {
+            condition.set(true);
+            condition.notify();
+        }
+    }
+
+    private final static int MAX_WAIT_ATTEMPTS = 1;
+    private final static long WAIT_INTERVAL = 1000L;
 }


### PR DESCRIPTION
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle !JACOCO

https://issues.jboss.org/browse/JBTM-3074

Fixes test hang (caused by a thread waiting for a notification from another thread) on windows which has been seen twice. NB If there is still a bug in the test then the changes also do a notify() at the end of the test so at least it should not hang.