### PR TITLE
[JBTM-3138] XTS txbridge does not run commit during recovery when 1PC is used

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
@@ -417,6 +417,22 @@ public abstract class AbstractRecord extends StateManager
 	}
 
 	/**
+	 * <p>
+	 * Defines if the participant record permits
+	 * the use of the one phase commit optimization.
+	 * <p>
+	 * By default it's expected this to be true
+	 * but the children records can override this
+	 * if it's necessary for them to forbid 1PC to be run.
+	 *
+	 * @return true if 1PC could be run for the participant,
+	 *         otherwise false
+	 */
+	public boolean isPermittedTopLevelOnePhaseCommit() {
+	    return true;
+	}
+
+	/**
 	 * Perform a top-level one phase commit.
 	 *
 	 * @return <code>TwoPhaseOutcome</code> to indicate success/failure.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -3677,11 +3677,14 @@ public class BasicAction extends StateManager
     {
         if (TxControl.onePhase)
         {
-            return (((pendingList == null) || (pendingList.size() == 1)) ? true
-                    : false);
+            if(pendingList == null) {
+                return true;
+            }
+            if (pendingList.size() == 1) {
+                return pendingList.peekFront().isPermittedTopLevelOnePhaseCommit();
+            }
         }
-        else
-            return false;
+        return false;
     }
 
     /*

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/PeriodicRecovery.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/PeriodicRecovery.java
@@ -773,7 +773,7 @@ public class PeriodicRecovery extends Thread
             }
 
             if (tsLogger.logger.isDebugEnabled()) {
-                tsLogger.logger.debug(" ");
+                tsLogger.logger.debugf("Recovery module '%s' first pass processed", m);
             }
         }
 
@@ -819,7 +819,7 @@ public class PeriodicRecovery extends Thread
             }
 
             if (tsLogger.logger.isDebugEnabled()) {
-                tsLogger.logger.debugf("PeriodicRecovery: recovery module '%s' second pass processed", m);
+                tsLogger.logger.debugf("Recovery module '%s' second pass processed", m);
             }
         }
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/XATerminatorImple.java
@@ -196,8 +196,11 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
             SubordinateTransaction tx = SubordinationManager
                     .getTransactionImporter().getImportedTransaction(xid);
 
-            if (tx == null)
-                throw new XAException(XAException.XAER_INVAL);
+            if (tx == null) {
+                XAException xaException = new XAException(jtaLogger.i18NLogger.get_no_subordinate_txn_for("forget", xid));
+                xaException.errorCode = XAException.XAER_INVAL;
+                throw xaException;
+            }
 
             tx.doForget();
         }
@@ -243,8 +246,11 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
         try
         {
 
-            if (tx == null)
-                throw new XAException(XAException.XAER_INVAL);
+            if (tx == null) {
+                XAException xaException = new XAException(jtaLogger.i18NLogger.get_no_subordinate_txn_for("prepare", xid));
+                xaException.errorCode = XAException.XAER_INVAL;
+                throw xaException;
+            }
 
             switch (tx.doPrepare())
             {
@@ -522,8 +528,11 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
         try
         {
 
-            if (tx == null)
-                throw new XAException(XAException.XAER_INVAL);
+            if (tx == null) {
+                XAException xaException = new XAException(jtaLogger.i18NLogger.get_no_subordinate_txn_for("rollback", xid));
+                xaException.errorCode = XAException.XAER_INVAL;
+                throw xaException;
+            }
 
             if (tx.activated())
             {
@@ -590,8 +599,9 @@ public class XATerminatorImple implements javax.resource.spi.XATerminator, XATer
             SubordinateTransaction tx = SubordinationManager
                     .getTransactionImporter().getImportedTransaction(xid);
 
-            if (tx == null)
-                throw new UnexpectedConditionException();
+            if (tx == null) {
+                throw new UnexpectedConditionException(jtaLogger.i18NLogger.get_no_subordinate_txn_for("beforeCompletion", xid));
+            }
 
            return tx.doBeforeCompletion();
         }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -584,6 +584,9 @@ public interface jtaI18NLogger {
     @LogMessage(level = WARN)
     public void warn_intteruptedExceptionOnWaitingXARecoveryModuleLock(XARecoveryModule recModule, String state, @Cause() InterruptedException arg0);
 
+    @Message(id = 16144, value = "No subordinate transaction to drive {0}, xid: {1}", format = MESSAGE_FORMAT)
+    String get_no_subordinate_txn_for(String actionToDrive, Xid xid);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in sequence. Don't reuse ids.

--- a/XTS/WS-C/dev/src/com/arjuna/services/framework/task/TaskManager.java
+++ b/XTS/WS-C/dev/src/com/arjuna/services/framework/task/TaskManager.java
@@ -117,7 +117,7 @@ public class TaskManager
             {
                 if (debugEnabled)
                 {
-                    WSCLogger.logger.tracev("Shutdown in progress, ignoring task") ;
+                    WSCLogger.logger.tracef("Shutdown in progress, ignoring task '%s'", task) ;
                 }
                 return false ;
             }
@@ -132,8 +132,8 @@ public class TaskManager
             {
                 if (debugEnabled)
                 {
-                    WSCLogger.logger.tracev("queueTask: notifying waiting workers ({0})",
-                            new Object[] {new Integer(waitingCount)}) ;
+                    WSCLogger.logger.tracef("queueTask: notifying waiting workers (%s) for task '%s'",
+                            new Integer(waitingCount), task) ;
                 }
                 taskList.notify() ;
             }
@@ -150,13 +150,13 @@ public class TaskManager
         {
             if (debugEnabled)
             {
-                WSCLogger.logger.tracev("queueTask: creating worker") ;
+                WSCLogger.logger.tracef("queueTask: creating worker for task '%s'", task) ;
             }
             createWorker() ;
         }
         else if (debugEnabled)
         {
-            WSCLogger.logger.tracev("queueTask: queueing task for execution") ;
+            WSCLogger.logger.tracef("queueTask: queueing task '%s' for execution", task) ;
         }
         
         return true ;
@@ -429,14 +429,14 @@ public class TaskManager
                     }
                     if (debugEnabled)
                     {
-                        WSCLogger.logger.tracev("getTask: returning task") ;
+                        WSCLogger.logger.tracev("getTask: returning task {0}", task) ;
                     }
                     return task ;
                 }
                 waitingCount++ ;
                 if (debugEnabled)
                 {
-                    WSCLogger.logger.tracev("getTask: waiting for task") ;
+                    WSCLogger.logger.tracev("getTask: waiting for task for {0} number of times", waitingCount) ;
                 }
                 try
                 {

--- a/XTS/WS-T/dev/src/com/arjuna/webservices/logging/wstI18NLogger.java
+++ b/XTS/WS-T/dev/src/com/arjuna/webservices/logging/wstI18NLogger.java
@@ -857,7 +857,7 @@ public interface wstI18NLogger {
 
 	@Message(id = 43219, value = "Could not save recovery state for non-serializable durable WS-AT participant {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
-	public void warn_recovery_participant_at_ATParticipantRecoveryRecord_saveState_1(String arg0);
+	public void warn_recovery_participant_at_ATParticipantRecoveryRecord_saveState_1(String arg0, @Cause() Throwable cause);
 
 	@Message(id = 43220, value = "XML stream exception saving recovery state for participant {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)

--- a/XTS/WS-T/dev/src/com/arjuna/wst11/messaging/CompletionCoordinatorProcessorImpl.java
+++ b/XTS/WS-T/dev/src/com/arjuna/wst11/messaging/CompletionCoordinatorProcessorImpl.java
@@ -88,6 +88,11 @@ public class CompletionCoordinatorProcessorImpl extends CompletionCoordinatorPro
                     final MAP responseAddressingContext =
                         AddressingHelper.createResponseContext(map, messageId) ;
                     CompletionInitiatorClient.getClient().sendAborted(participant.getParticipant(), responseAddressingContext, instanceIdentifier) ;
+                    if (WSTLogger.logger.isTraceEnabled())
+                    {
+                        WSTLogger.logger.tracev(trbe, "Participant {0} commit failed to be aborted on instance {1}",
+                                participant.getParticipant(), instanceIdentifier) ;
+                    }
                     return ;
                 }
                 catch (final UnknownTransactionException ute)
@@ -96,6 +101,11 @@ public class CompletionCoordinatorProcessorImpl extends CompletionCoordinatorPro
                     final SoapFault soapFault = new SoapFault11(SoapFaultType.FAULT_SENDER, ArjunaTXConstants.UNKNOWNTRANSACTION_ERROR_CODE_QNAME,
                             WSTLogger.i18NLogger.get_wst11_messaging_CompletionCoordinatorProcessorImpl_1()) ;
                     CompletionInitiatorClient.getClient().sendSoapFault(participant.getParticipant(), faultAddressingContext, soapFault, instanceIdentifier) ;
+                    if (WSTLogger.logger.isTraceEnabled())
+                    {
+                        WSTLogger.logger.tracev(ute, "Participant {0} commit unknown failure on instance {1}: {2}",
+                                participant.getParticipant(), instanceIdentifier, WSTLogger.i18NLogger.get_wst11_messaging_CompletionCoordinatorProcessorImpl_1(), ute) ;
+                    }
                     return ;
                 }
                 catch (final SystemException se)
@@ -105,13 +115,19 @@ public class CompletionCoordinatorProcessorImpl extends CompletionCoordinatorPro
                     final String message = MessageFormat.format(pattern, new Object[] {se}) ;
                     final SoapFault soapFault = new SoapFault11(SoapFaultType.FAULT_SENDER, ArjunaTXConstants.UNKNOWNERROR_ERROR_CODE_QNAME, message) ;
                     CompletionInitiatorClient.getClient().sendSoapFault(participant.getParticipant(), faultAddressingContext, soapFault, instanceIdentifier) ;
+                    if (WSTLogger.logger.isTraceEnabled())
+                    {
+                        WSTLogger.logger.tracev(se, "Participant {0} commit system failure on instance {1}: {2}",
+                                participant.getParticipant(), instanceIdentifier, WSTLogger.i18NLogger.get_wst11_messaging_CompletionCoordinatorProcessorImpl_1()) ;
+                    }
                     return ;
                 }
                 catch (final Throwable th)
                 {
                     if (WSTLogger.logger.isTraceEnabled())
                     {
-                        WSTLogger.logger.tracev("Unexpected exception thrown from commit:", th) ;
+                        WSTLogger.logger.tracev(th, "Unexpected exception thrown from commit for participant {0} on instance {1}",
+                                participant.getParticipant(), instanceIdentifier) ;
                     }
                     final MAP faultAddressingContext = AddressingHelper.createFaultContext(map, MessageId.getMessageId()) ;
                     final SoapFault soapFault = new SoapFault11(th) ;

--- a/XTS/WS-T/dev/src/org/jboss/jbossts/xts/recovery/participant/at/ATParticipantRecoveryRecord.java
+++ b/XTS/WS-T/dev/src/org/jboss/jbossts/xts/recovery/participant/at/ATParticipantRecoveryRecord.java
@@ -46,7 +46,7 @@ public abstract class ATParticipantRecoveryRecord implements PersistableParticip
             recoveryState = ATParticipantHelper.getRecoveryState(useSerialization, participant);
             recoveryStateValid = true;
         } catch (Exception exception) {
-            WSTLogger.i18NLogger.warn_recovery_participant_at_ATParticipantRecoveryRecord_saveState_1(id);
+            WSTLogger.i18NLogger.warn_recovery_participant_at_ATParticipantRecoveryRecord_saveState_1(id, exception);
             // if we continue here then we cannot recover this transaction if we crash during
             // commit processing. we should strictly fail here to play safe but . . .
 

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ParticipantRecord.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ParticipantRecord.java
@@ -410,6 +410,17 @@ public class ParticipantRecord extends
 	}
 
 	/**
+	 * The WSCF does not implement 1PC properly and it fails to run it safely
+	 * in data consistent manner. Returning false to disable 1PC optimization
+	 * for the WSCF records.
+	 * See JBTM-396 and JBTM-3138.
+	 */
+
+	public boolean isPermittedTopLevelOnePhaseCommit() {
+		return false;
+	}
+
+	/**
 	 * The record is being driven through top-level commit and is the only
 	 * resource.
 	 *

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ParticipantRecord.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ParticipantRecord.java
@@ -225,6 +225,11 @@ public class ParticipantRecord extends
 				{
 					return TwoPhaseOutcome.HEURISTIC_COMMIT;
 				}
+				catch(SystemCommunicationException ex)
+				{
+					// if the participant is dead it will retry anyway
+					return TwoPhaseOutcome.FINISH_ERROR;
+				}
 				catch (SystemException ex)
 				{
 					return TwoPhaseOutcome.HEURISTIC_HAZARD;
@@ -363,7 +368,7 @@ public class ParticipantRecord extends
                 {
                     // if prepare timed out then we return error so it goes back on the
                     // prepare list and is rolled back
-                    return TwoPhaseOutcome.FINISH_ERROR;
+                    return TwoPhaseOutcome.PREPARE_NOTOK;
                 }
 				catch (SystemException ex)
 				{

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst/at/participants/DurableTwoPhaseCommitParticipant.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst/at/participants/DurableTwoPhaseCommitParticipant.java
@@ -69,7 +69,7 @@ public class DurableTwoPhaseCommitParticipant implements Participant
     /**
      * tell the participant to prepare
      *
-     * @return the participant's vote or a cancel vote the aprticipant is null
+     * @return the participant's vote or a cancel vote the participant is null
      *
      */
     public Vote prepare () throws InvalidParticipantException,
@@ -103,7 +103,6 @@ public class DurableTwoPhaseCommitParticipant implements Participant
 			else
 				return new VoteCancel();
 		}
-		//	catch (com.arjuna.mw.wst.exceptions.WrongStateException ex)
 		catch (com.arjuna.wst.WrongStateException ex)
 		{
 			wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_prepare(_id, _resource, ex);
@@ -111,28 +110,18 @@ public class DurableTwoPhaseCommitParticipant implements Participant
 			wse.addSuppressed(ex);
 			throw wse;
 		}
-		/*
-		 * catch (com.arjuna.mw.wst.exceptions.HeuristicHazardException ex {
-		 * throw new HeuristicHazardException(ex.toString()); } catch
-		 * (com.arjuna.mw.wst.exceptions.HeuristicMixedException ex) { throw new
-		 * HeuristicMixedException(ex.toString()); }
-		 */
-		//	catch (com.arjuna.mw.wst.exceptions.SystemException ex)
+		catch (com.arjuna.wst.stub.SystemCommunicationException ex) {
+		    wstxLogger.i18NLogger.warn_mwlabs_wst_at_participants_DurableTwoPhaseCommitParticipant_prepare_1(_id, _resource);
+		    SystemCommunicationException sce = new SystemCommunicationException(ex.toString());
+		    sce.addSuppressed(ex);
+		    throw sce;
+		}
 		catch (com.arjuna.wst.SystemException ex)
 		{
-            if(ex instanceof com.arjuna.wst.stub.SystemCommunicationException) {
-                wstxLogger.i18NLogger.warn_mwlabs_wst_at_participants_DurableTwoPhaseCommitParticipant_prepare_1(_id, _resource);
-                SystemCommunicationException sce = new SystemCommunicationException(ex.toString());
-                sce.addSuppressed(ex);
-                throw sce;
-            }
-            else
-            {
-                wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_prepare(_id, _resource, ex);
-                SystemException se = new SystemException(ex.toString());
-                se.addSuppressed(ex);
-                throw se;
-            }
+		    wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_prepare(_id, _resource, ex);
+		    SystemException se = new SystemException(ex.toString());
+		    se.addSuppressed(ex);
+		    throw se;
         }
 	}
 
@@ -153,7 +142,6 @@ public class DurableTwoPhaseCommitParticipant implements Participant
 					_resource.commit();
 				}
 			}
-			//	    catch (com.arjuna.mw.wst.exceptions.WrongStateException ex)
 			catch (com.arjuna.wst.WrongStateException ex)
 			{
 				wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_confirm(_id, _resource, ex);
@@ -161,30 +149,19 @@ public class DurableTwoPhaseCommitParticipant implements Participant
 				wse.addSuppressed(wse);
 				throw wse;
 			}
-			/*
-			 * catch (com.arjuna.mw.wst.exceptions.HeuristicHazardException ex) {
-			 * throw new HeuristicHazardException(ex.toString()); } catch
-			 * (com.arjuna.mw.wst.exceptions.HeuristicMixedException ex) { throw
-			 * new HeuristicMixedException(ex.toString()); } catch
-			 * (com.arjuna.mw.wst.exceptions.HeuristicRollbackException ex) {
-			 * throw new HeuristicCancelException(ex.toString()); }
-			 */
-			//	    catch (com.arjuna.mw.wst.exceptions.SystemException ex)
+			catch (com.arjuna.wst.stub.SystemCommunicationException ex) {
+                // log an error here -- we will end up writing a heuristic transaction record too
+                wstxLogger.i18NLogger.warn_mwlabs_wst_at_participants_DurableTwoPhaseCommitParticipant_confirm_1(_id, _resource);
+                SystemCommunicationException sce = new SystemCommunicationException(ex.toString());
+                sce.addSuppressed(ex);
+                throw sce;
+			}
 			catch (com.arjuna.wst.SystemException ex)
 			{
-				if(ex instanceof com.arjuna.wst.stub.SystemCommunicationException)
-				{
-                    // log an error here -- we will end up writing a heuristic transaction record too
-                    wstxLogger.i18NLogger.warn_mwlabs_wst_at_participants_DurableTwoPhaseCommitParticipant_confirm_1(_id, _resource);
-                    SystemCommunicationException sce = new SystemCommunicationException(ex.toString());
-                    sce.addSuppressed(ex);
-                    throw sce;
-                } else {
-                    wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_confirm(_id, _resource, ex);
-                    SystemException se = new SystemException(ex.toString());
-                    se.addSuppressed(ex);
-                    throw se;
-                }
+			    wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_confirm(_id, _resource, ex);
+			    SystemException se = new SystemException(ex.toString());
+			    se.addSuppressed(ex);
+			    throw se;
             }
 		}
 		else
@@ -209,36 +186,24 @@ public class DurableTwoPhaseCommitParticipant implements Participant
 				if (!_rolledback)
 					_resource.rollback();
 			}
-			//	    catch (com.arjuna.mw.wst.exceptions.WrongStateException ex)
 			catch (com.arjuna.wst.WrongStateException ex)
 			{
 				WrongStateException wse = new WrongStateException(ex.toString());
 				wse.addSuppressed(ex);
 				throw wse;
 			}
-			/*
-			 * catch (com.arjuna.mw.wst.exceptions.HeuristicHazardException ex) {
-			 * throw new HeuristicHazardException(ex.toString()); } catch
-			 * (com.arjuna.mw.wst.exceptions.HeuristicMixedException ex) { throw
-			 * new HeuristicMixedException(ex.toString()); } catch
-			 * (com.arjuna.mw.wst.exceptions.HeuristicCommitException ex) {
-			 * throw new HeuristicConfirmException(ex.toString()); }
-			 */
-			//	    catch (com.arjuna.mw.wst.exceptions.SystemException ex)
+			catch (com.arjuna.wst.stub.SystemCommunicationException ex) {
+			    // log an error here -- if the participant is dead it will retry anyway
+			    wstxLogger.i18NLogger.error_mwlabs_wst_at_participants_DurableTwoPhaseCommitParticipant_cancel_1(_id);
+			    SystemCommunicationException sce = new SystemCommunicationException(ex.toString());
+			    sce.addSuppressed(ex);
+			    throw sce;
+			}
 			catch (com.arjuna.wst.SystemException ex)
 			{
-                if(ex instanceof com.arjuna.wst.stub.SystemCommunicationException)
-                {
-                    // log an error here -- if the participant is dead it will retry anyway
-                    wstxLogger.i18NLogger.error_mwlabs_wst_at_participants_DurableTwoPhaseCommitParticipant_cancel_1(_id);
-                    SystemCommunicationException sce = new SystemCommunicationException(ex.toString());
-                    sce.addSuppressed(ex);
-                    throw sce;
-                } else {
-                    SystemException se = new SystemException(ex.toString());
-                    se.addSuppressed(ex);
-                    throw se;
-                }
+			    SystemException se = new SystemException(ex.toString());
+			    se.addSuppressed(ex);
+			    throw se;
 			}
 		}
 		else
@@ -299,17 +264,7 @@ public class DurableTwoPhaseCommitParticipant implements Participant
 					{
 						confirm();
 					}
-					catch (HeuristicHazardException ex)
-					{
-						wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_one_phase_failed(_id, _resource, ex);
-						throw ex;
-					}
-					catch (HeuristicMixedException ex)
-					{
-						wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_one_phase_failed(_id, _resource, ex);
-						throw ex;
-					}
-					catch (HeuristicCancelException ex)
+					catch (HeuristicHazardException | HeuristicMixedException |  HeuristicCancelException ex)
 					{
 						wstxLogger.i18NLogger.error_wst_at_participants_Durable2PC_one_phase_failed(_id, _resource, ex);
 						throw ex;

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/participants/CompletionCoordinatorImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/participants/CompletionCoordinatorImple.java
@@ -40,48 +40,34 @@ public class CompletionCoordinatorImple implements CompletionCoordinatorParticip
 
 	    _cm.confirm();
 	}
-	catch (com.arjuna.mw.wsas.exceptions.InvalidActivityException ex)
+	catch (com.arjuna.mw.wsas.exceptions.InvalidActivityException |
+	       com.arjuna.mw.wscf.exceptions.NoCoordinatorException ex)
 	{
-	    throw new UnknownTransactionException();
-	}
-	catch (com.arjuna.mw.wsas.exceptions.WrongStateException ex)
-	{
-	    throw new SystemException(ex.toString());
-	}
-	catch (com.arjuna.mw.wsas.exceptions.ProtocolViolationException ex)
-	{
-	    //	    throw new HeuristicHazardException();
-
-	    throw new SystemException(ex.toString());
-	}
-	catch (com.arjuna.mw.wscf.exceptions.NoCoordinatorException ex)
-	{
-	    throw new UnknownTransactionException();
+	    UnknownTransactionException ute = new UnknownTransactionException();
+	    ute.addSuppressed(ex);
+	    throw ute;
 	}
 	catch (com.arjuna.mw.wscf.model.twophase.exceptions.CoordinatorCancelledException ex)
 	{
-	    throw new TransactionRolledBackException();
+	    TransactionRolledBackException tre = new TransactionRolledBackException();
+	    tre.addSuppressed(ex);
+	    throw tre;
 	}
-	catch (com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicMixedException ex)
+	catch (com.arjuna.mw.wsas.exceptions.WrongStateException |
+	       com.arjuna.mw.wsas.exceptions.ProtocolViolationException |
+	       com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicMixedException |
+	       com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicHazardException |
+	       com.arjuna.mw.wsas.exceptions.NoPermissionException ex)
 	{
-	    //	    throw new HeuristicMixedException();
-
-	    throw new SystemException(ex.toString());
-	}
-	catch (com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicHazardException ex)
-	{
-	    //	    throw new HeuristicHazardException();
-
-	    throw new SystemException(ex.toString());
-
-	}
-	catch (com.arjuna.mw.wsas.exceptions.NoPermissionException ex)
-	{
-	    throw new SystemException(ex.toString());
+	    SystemException se = new SystemException(ex.toString());
+	    se.addSuppressed(ex);
+	    throw se;
 	}
 	catch (com.arjuna.mw.wsas.exceptions.SystemException ex)
 	{
-	    throw new SystemException(ex.toString());
+	    SystemException se = new SystemException(ex.toString());
+	    se.addSuppressed(ex);
+	    throw se;
 	}
 	finally
 	{
@@ -99,41 +85,29 @@ public class CompletionCoordinatorImple implements CompletionCoordinatorParticip
 
 	    _cm.cancel();
 	}
-	catch (com.arjuna.mw.wsas.exceptions.InvalidActivityException ex)
+	catch (com.arjuna.mw.wsas.exceptions.InvalidActivityException |
+	        com.arjuna.mw.wscf.exceptions.NoCoordinatorException ex)
 	{
-	    throw new UnknownTransactionException();
+	    UnknownTransactionException ute = new UnknownTransactionException();
+	    ute.addSuppressed(ex);
+	    throw ute;
 	}
-	catch (com.arjuna.mw.wsas.exceptions.WrongStateException ex)
+	catch (com.arjuna.mw.wsas.exceptions.WrongStateException |
+	       com.arjuna.mw.wsas.exceptions.ProtocolViolationException |
+	       com.arjuna.mw.wscf.model.twophase.exceptions.CoordinatorConfirmedException |
+	       com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicMixedException |
+	       com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicHazardException |
+	       com.arjuna.mw.wsas.exceptions.NoPermissionException ex)
 	{
-	    throw new SystemException(ex.toString());
-	}
-	catch (com.arjuna.mw.wsas.exceptions.ProtocolViolationException ex)
-	{
-	    throw new SystemException();
-	}
-	catch (com.arjuna.mw.wscf.exceptions.NoCoordinatorException ex)
-	{
-	    throw new UnknownTransactionException();
-	}
-	catch (com.arjuna.mw.wscf.model.twophase.exceptions.CoordinatorConfirmedException ex)
-	{
-	    throw new SystemException();
-	}
-	catch (com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicMixedException ex)
-	{
-	    throw new SystemException(ex.toString());
-	}
-	catch (com.arjuna.mw.wscf.model.twophase.exceptions.HeuristicHazardException ex)
-	{
-	    throw new SystemException(ex.toString());
-	}
-	catch (com.arjuna.mw.wsas.exceptions.NoPermissionException ex)
-	{
-	    throw new SystemException(ex.toString());
+	    SystemException se = new SystemException(ex.toString());
+	    se.addSuppressed(ex);
+	    throw se;
 	}
 	catch (com.arjuna.mw.wsas.exceptions.SystemException ex)
 	{
-	    throw new SystemException(ex.toString());
+	    SystemException se = new SystemException(ex.toString());
+	    se.addSuppressed(ex);
+	    throw se;
 	}
 	finally
 	{

--- a/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/interop/ATTestCase.java
+++ b/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/interop/ATTestCase.java
@@ -20,8 +20,6 @@
  */
 package com.jboss.transaction.txinterop.interop;
 
-import javax.inject.Named;
-
 import com.arjuna.webservices11.wsat.AtomicTransactionConstants;
 import com.arjuna.webservices11.wscoor.CoordinationConstants;
 import com.arjuna.webservices11.ServiceRegistry;

--- a/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/webservices/atinterop/client/SyncParticipantClient.java
+++ b/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/webservices/atinterop/client/SyncParticipantClient.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import com.arjuna.webservices.*;
 import org.jboss.ws.api.addressing.MAP;
 import org.oasis_open.docs.ws_tx.wscoor._2006._06.CoordinationContextType;
-import com.jboss.transaction.txinterop.webservices.atinterop.ATInteropConstants;
 
 /**
  * The participant client.

--- a/XTS/localjunit/crash-recovery-tests/src/test/java/com/arjuna/qa/junit/TestATCrashDuringSingleParticipantCommit.java
+++ b/XTS/localjunit/crash-recovery-tests/src/test/java/com/arjuna/qa/junit/TestATCrashDuringSingleParticipantCommit.java
@@ -5,9 +5,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class TestATCrashDuringOnePhaseCommit extends BaseCrashTest {
-	public TestATCrashDuringOnePhaseCommit() {
-		scriptName ="ATCrashDuringOnePhaseCommit";
+public class TestATCrashDuringSingleParticipantCommit extends BaseCrashTest {
+    /**
+     * One phase commit is not permitted for XTS. The single participant
+     * runs the two phase commit as well.
+     */
+	public TestATCrashDuringSingleParticipantCommit() {
+		scriptName ="ATCrashDuringCommit";
 	}
 
 	@Test

--- a/XTS/localjunit/xtstest/src/org/jboss/jbossts/xts/servicetests/test/at/SingleParticipantPrepareAndCommitTest.java
+++ b/XTS/localjunit/xtstest/src/org/jboss/jbossts/xts/servicetests/test/at/SingleParticipantPrepareAndCommitTest.java
@@ -21,10 +21,6 @@
 
 package org.jboss.jbossts.xts.servicetests.test.at;
 
-import org.jboss.jbossts.xts.servicetests.service.XTSServiceTestServiceManager;
-import org.jboss.jbossts.xts.servicetests.client.XTSServiceTestClient;
-import org.jboss.jbossts.xts.servicetests.generated.CommandsType;
-import org.jboss.jbossts.xts.servicetests.generated.ResultsType;
 import org.jboss.jbossts.xts.servicetests.test.XTSServiceTestBase;
 import org.jboss.jbossts.xts.servicetests.test.XTSServiceTest;
 import com.arjuna.mw.wst11.UserTransactionFactory;

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/XTSATRecoveryManagerImple.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/XTSATRecoveryManagerImple.java
@@ -221,7 +221,7 @@ public class XTSATRecoveryManagerImple extends XTSATRecoveryManager {
                             participantIterator.remove();
                         }
                     } catch (Exception e) {
-                        // we foudn a helper but it failed to convert the participant record -- log a warning
+                        // we found a helper but it failed to convert the participant record -- log a warning
                         // but leave the participant in the table for next time in case the helper has merely
                         // suffered a transient failure
                         found = true;

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/XTSATSubordinateRecoveryModule.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/XTSATSubordinateRecoveryModule.java
@@ -7,12 +7,21 @@ import com.arjuna.ats.arjuna.state.InputObjectState;
 
 import java.io.ObjectInputStream;
 
+import org.jboss.jbossts.xts.recovery.logging.RecoveryLogger;
+
 /**
  * A recovery module which recovers durable participants registered by subordinate coordinators
  */
 
 public class XTSATSubordinateRecoveryModule implements XTSATRecoveryModule
 {
+    public XTSATSubordinateRecoveryModule()
+    {
+        if (RecoveryLogger.logger.isDebugEnabled()) {
+            RecoveryLogger.logger.debug("XTSATSubordinateRecoveryModule created");
+        }
+    }
+
     public Durable2PCParticipant deserialize(String id, ObjectInputStream stream) throws Exception {
         if (id.startsWith(SubordinateATCoordinator.PARTICIPANT_PREFIX)) {
             // throw an exception because we don't expect these participants to use serialization

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/junit/InboundCrashRecoveryTests.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/junit/InboundCrashRecoveryTests.java
@@ -146,6 +146,58 @@ public class InboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
         instrumentedTestXAResource.assertMethodNotCalled("commit");
     }
 
+    /**
+     * <ul>
+     *   <li>A test client is deployed on the WFLY</li>
+     *   <li>Test case calls HTTP call to the client</li>
+     *   <li>The client starts JTA transaction</li>
+     *   <li>The client invokes WebService call to the WFLY. The WS is the single participant of the original transaction.</li>
+     *   <li>The WebService did some work - in this case it enlists
+     *       2 mock <code>TestXAResource</code>s in the business method</li>
+     *   <li>The call comes back to client which commits the transaction</li>
+     *   <li>The 1PC is about to start but 1PC is disabled (JBTM-3138) for the WCSF participant.
+     *       The prepare and commit calls hits the WS participant.</li>
+     *   <li>The WS participant process the 2PC on subordinate resources:<br/>
+     *       - <code>BridgeDurableParticipant</code><br/>
+     *       - <code>BridgeVolatileParticipant</code><br/>
+     *       - Two <code>TestXAResource</code></br></li>
+     *   <li>The commit phase starts. The first <code>TestXAResource</code>s is committed,
+     *       before the second <code>TestXAResource</code> could be committed the JVM crashes</li>
+     *   <li>The recovery is expected to commit the second <code>TestXAResource</code> later on</li>
+     * </ul>
+     */
+    @Test
+    @OperateOnDeployment(INBOUND_CLIENT_DEPLOYMENT_NAME)
+    public void testCrashCommitOnePhase(@ArquillianResource URL baseURL) throws Exception {
+
+        instrumentor.injectOnCall(TestServiceImpl.class, "doNothing", "$0.enlistXAResource(2)");
+        instrumentor.injectOnCall(TestClient.class, "terminateTransaction", "$2 = true"); // shouldCommit=true
+        instrumentor.installRule(RuleConstructor.createRule("crashOnSecondTestResource")
+            .onClass(TestXAResource.class)
+            .inMethod("commit")
+            .atEntry()
+            .ifCondition("NOT flag(\"testxaresourcecrash\")")
+            .doAction("debug(\"killing TestXAResource\"); killJVM()"));
+
+        execute(baseURL + TestClient.URL_PATTERN, false);
+
+        instrumentedTestXAResource.assertSumMethodCallCount("prepare", 2);
+        instrumentedTestXAResource.assertMethodNotCalled("rollback");
+        // commit called twice, first TestXAResource commits,
+        // the second enters the commit and immediately kills JVM
+        instrumentedTestXAResource.assertMethodCalled("commit");
+
+        rebootServer(controller);
+
+        doRecovery();
+        doRecovery();
+
+        instrumentedTestXAResource.assertMethodNotCalled("prepare");
+        instrumentedTestXAResource.assertMethodCalled("recover");
+        instrumentedTestXAResource.assertMethodNotCalled("rollback");
+        instrumentedTestXAResource.assertSumMethodCallCount("commit", 2);
+    }
+
     @Test
     @OperateOnDeployment(INBOUND_CLIENT_DEPLOYMENT_NAME)
     public void testCrashTwoLogs(@ArquillianResource URL baseURL) throws Exception {

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/utility/TestXAResource.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/utility/TestXAResource.java
@@ -20,8 +20,6 @@
  */
 package org.jboss.jbossts.txbridge.tests.inbound.utility;
 
-import org.jboss.logging.Logger;
-
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import javax.transaction.xa.XAException;
@@ -32,7 +30,6 @@ import javax.transaction.xa.XAException;
  * @author Jonathan Halliday (jonathan.halliday@redhat.com) 2010-01
  */
 public class TestXAResource extends TestXAResourceCommon implements XAResource {
-    private static Logger log = Logger.getLogger(TestXAResource.class);
 
     @Override
     public void commit(Xid xid, boolean b) throws XAException {


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3138
https://issues.jboss.org/browse/JBTM-3147

A follow-up to https://issues.jboss.org/browse/JBTM-3079 where active xids were considered to not be processed by recovery manager.

Here adding a testcase which crashes after prepare phase is finished and I would expect the commit should be processed. Discussion on this topic is at the forum https://developer.jboss.org/thread/279243

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !LRA !PERF
!MAIN XTS