### PR TITLE
RELEASE SCRIPT ONLY: correct place for jboss-dockerfiles repo

### DIFF
--- a/narayana-release-process.sh
+++ b/narayana-release-process.sh
@@ -152,7 +152,7 @@ fi
 docker login docker.io
 [ $? -ne 0 ] && echo "Login to docker.io was not succesful" && exit
 git clone git@github.com:jbosstm/jboss-dockerfiles.git
-cd jboss-dockerfiles/lra/dockerfile
+cd jboss-dockerfiles/lra/lra-coordinator
 docker build -t lra-coordinator --build-arg NARAYANA_VERSION=${CURRENT} .
 docker tag lra-coordinator:latest docker.io/jbosstm/lra-coordinator:${CURRENT}
 docker tag lra-coordinator:latest docker.io/jbosstm/lra-coordinator:latest

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -52,9 +52,9 @@ do
 
     if [[ "$(uname)" == "Darwin" ]] # MacOS
     then
-      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile -o -iname \Dockerfile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "" "s/$CURRENT_SNAPSHOT_VERSION/$CURRENT/g" || fatal
+      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "" "s/$CURRENT_SNAPSHOT_VERSION/$CURRENT/g" || fatal
     else
-      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile -o -iname \Dockerfile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "s/$CURRENT_SNAPSHOT_VERSION/$CURRENT/g" || fatal
+      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "s/$CURRENT_SNAPSHOT_VERSION/$CURRENT/g" || fatal
     fi
     set +e
     git status | grep "new\|deleted"
@@ -69,9 +69,9 @@ do
 
     if [[ "$(uname)" == "Darwin" ]] # MacOS
     then
-      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile -o -iname \Dockerfile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "" "s/$CURRENT/$NEXT/g" || fatal
+      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "" "s/$CURRENT/$NEXT/g" || fatal
     else
-      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile -o -iname \Dockerfile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "s/$CURRENT/$NEXT/g" || fatal
+      find . -name \*.java -o -name \*.xml -o -name \*.template -o -name \*.properties -o -name \*.ent -o -name \INSTALL -o -name \README -o -name pre-release-vars.sh -o -name \*.sh -o -name \*.bat -o -name \*.cxx -o -name \*.c -o -name \*.cpp -o -iname \makefile | grep -v ".svn" | grep -v ".git" | grep -v target | grep -v .idea | xargs sed -i "s/$CURRENT/$NEXT/g" || fatal
     fi
     set +e
     git status | grep "new\|deleted"


### PR DESCRIPTION
and the lra-coordinator could be pushed to dockerhub

on top of it - making changes in Dockerfile is I think not intended. The changes adds SNAPSHOT which does not work well and Dockerfile can be created in different manner than go with the SNAPSHOT - as it's the current case of the jboss-dockerfiles repository.

The release script is already written in way to release correct version of the docker image to the dockerhub.