### PR TITLE
JBTM-3091 Use the correct MP LRA TCK snapshot

### DIFF
--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -34,8 +34,7 @@
         <version.arquillian>1.1.12.Final</version.arquillian>
 
         <version.microprofile.lra.api>1.0-20190122.071206-242</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-SNAPSHOT</version.microprofile.lra.tck>
-        <!--<version.microprofile.lra.tck>1.0-20190122.071207-242</version.microprofile.lra.tck>-->
+        <version.microprofile.lra.tck>1.0-20190122.071207-242</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3091

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !XTS

This PR corrects a dependency on the wrong LRA MP TCK snapshot build