### PR TITLE
JBTM-3093 Disable the site plugin for LRA

### DIFF
--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -154,6 +154,13 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3093

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !XTS !AS_TESTS !TOMCAT

PR 1401 reverted this change by mistake. This new PR adds it back in again.