### PR TITLE
[SCRIPT ONLY] after fixing JBTM-3067 there is no need to rebase jdk11

### DIFF
--- a/scripts/hudson/narayana-rebase.sh
+++ b/scripts/hudson/narayana-rebase.sh
@@ -34,9 +34,6 @@ function rebase_narayana {
   rm -rf .git/rebase-apply
   git clean -f -d -x
   
-  if [ "$jdk" = "jdk11.latest" ]; then
-    BRANCHPOINT=jdk-11
-  else
   # Work out the branch point
   git branch -D 4.17
   git branch 4.17 origin/4.17
@@ -58,7 +55,6 @@ function rebase_narayana {
     export BRANCHPOINT=master
   else
     export BRANCHPOINT=4.17
-  fi
   fi
 
   # Update the pull to head  


### PR DESCRIPTION
… against a special branch. Especially when there is no such branch as `jdk-11` :)

MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO JDK11