### PR TITLE
[JBTM-3109][lra#94] renaming LRA status complete/compensate to close/cancel

### DIFF
--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -105,7 +105,7 @@ public class NarayanaLRAClient implements LRAClient, Closeable {
     private static final String startLRAUrl = "/start";///?ClientId=abc&timeout=300000";
     private static final String recoveryQueryUrl = "/recovery";
     private static final String getAllLRAsUrl = "/";
-    private static final String getRecoveringLRAsUrl = "?status=Compensating";
+    private static final String getRecoveringLRAsUrl = "?status=Cancelling";
     private static final String getActiveLRAsUrl = "?status=";
 
     private static final String confirmFormat = "/%s/close";
@@ -670,8 +670,8 @@ public class NarayanaLRAClient implements LRAClient, Closeable {
                     jo.getString("lraId"),
                     jo.getString("clientId"),
                     jo.getString(STATUS),
-                    jo.getBoolean("complete"),
-                    jo.getBoolean("compensated"),
+                    jo.getBoolean("closed"),
+                    jo.getBoolean("cancelled"),
                     jo.getBoolean("recovering"),
                     jo.getBoolean("active"),
                     jo.getBoolean("topLevel"),

--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAInfo.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAInfo.java
@@ -28,8 +28,8 @@ public class NarayanaLRAInfo {
     private String lraId;
     private String clientId;
     private String status;
-    private boolean isComplete;
-    private boolean isCompensated;
+    private boolean isClosed;
+    private boolean isCancelled;
     private boolean isRecovering;
     private boolean isActive;
     private boolean isTopLevel;
@@ -37,14 +37,14 @@ public class NarayanaLRAInfo {
     private long finishTime;
 
     public NarayanaLRAInfo(String lraId, String clientId, String status,
-                boolean isComplete, boolean isCompensated, boolean isRecovering,
+                boolean isClosed, boolean isCancelled, boolean isRecovering,
                 boolean isActive, boolean isTopLevel,
                 long startTime, long finishTime) {
         this.lraId = lraId;
         this.clientId = clientId;
         this.status = status;
-        this.isComplete = isComplete;
-        this.isCompensated = isCompensated;
+        this.isClosed = isClosed;
+        this.isCancelled = isCancelled;
         this.isRecovering = isRecovering;
         this.isActive = isActive;
         this.isTopLevel = isTopLevel;
@@ -64,12 +64,12 @@ public class NarayanaLRAInfo {
         return this.status;
     }
 
-    public boolean isComplete() {
-        return this.isComplete;
+    public boolean isClosed() {
+        return this.isClosed;
     }
 
-    public boolean isCompensated() {
-        return this.isCompensated;
+    public boolean isCancelled() {
+        return this.isCancelled;
     }
 
     public boolean isRecovering() {
@@ -122,8 +122,8 @@ public class NarayanaLRAInfo {
                 "lraId='" + lraId + '\'' +
                 ", clientId='" + clientId + '\'' +
                 ", status='" + status + '\'' +
-                ", isComplete=" + isComplete +
-                ", isCompensated=" + isCompensated +
+                ", isClosed=" + isClosed +
+                ", isCancelled=" + isCancelled +
                 ", isRecovering=" + isRecovering +
                 ", isActive=" + isActive +
                 ", isTopLevel=" + isTopLevel +

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -117,7 +117,7 @@ public class Coordinator {
     private static NarayanaLRAInfo convert(LRAStatusHolder lra) {
         return new NarayanaLRAInfo(lra.getLraId(), lra.getClientId(),
                 lra.getStatus().name(),
-                lra.isComplete(), lra.isCompensated(), lra.isRecovering(), lra.isActive(), lra.isTopLevel(),
+                lra.isClosed(), lra.isCancelled(), lra.isRecovering(), lra.isActive(), lra.isTopLevel(),
                 lra.getStartTime(), lra.getFinishTime());
     }
 

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAStatusHolder.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAStatusHolder.java
@@ -36,10 +36,6 @@ public class LRAStatusHolder {
     private String lraId;
     //    @ApiModelProperty( value = "The client id associated with this LRA", required = false )
     private String clientId;
-    //    @ApiModelProperty( value = "Indicates whether or not this LRA has completed", required = false )
-    private boolean isClose;
-    //    @ApiModelProperty( value = "Indicates whether or not this LRA has compensated", required = false )
-    private boolean isCanceled;
     //    @ApiModelProperty( value = "Indicates whether or not this LRA is recovering", required = false )
     private boolean isRecovering;
     //    @ApiModelProperty( value = "Indicates whether or not this LRA has been asked to complete or compensate yet", required = false )
@@ -59,8 +55,6 @@ public class LRAStatusHolder {
 
         this.lraId = info.getLraId();
         this.clientId = info.getClientId();
-        this.isClose = info.isComplete();
-        this.isCanceled = info.isCompensated();
         this.isRecovering = info.isRecovering();
         this.isActive = info.isActive();
         this.isTopLevel = info.isTopLevel();
@@ -85,27 +79,27 @@ public class LRAStatusHolder {
         return lraStatus != null && lraStatus == state;
     }
 
-    public boolean isCompensating() {
+    public boolean isCancelling() {
         return isInState(LRAStatus.Cancelling);
     }
 
-    public boolean isCompensated() {
+    public boolean isCancelled() {
         return isInState(LRAStatus.Cancelled);
     }
 
-    public boolean isCompleting() {
+    public boolean isClosing() {
         return isInState(LRAStatus.Closing);
     }
 
-    public boolean isCompleted() {
+    public boolean isClosed() {
         return isInState(LRAStatus.Closed);
     }
 
-    public boolean isFailedToComplete() {
+    public boolean isFailedToClose() {
         return isInState(LRAStatus.FailedToClose);
     }
 
-    public boolean isFailedToCompensate() {
+    public boolean isFailedToCancel() {
         return isInState(LRAStatus.FailedToCancel);
     }
 
@@ -131,10 +125,6 @@ public class LRAStatusHolder {
 
     public String getEncodedResponseData() throws IOException {
         return responseData;
-    }
-
-    public boolean isComplete() {
-        return isClose;
     }
 
     public long getStartTime() {

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -105,7 +105,7 @@ public class Transaction extends AtomicAction {
 
     public NarayanaLRAInfo getLRAInfo() {
         return new NarayanaLRAInfo(id.toExternalForm(), clientId, status == null ? "" : status.name(),
-                isComplete(), isCompensated(), isRecovering(),
+                isClosed(), isCancelled(), isRecovering(),
                 isActive(), isTopLevel(),
                 startTime.toInstant(ZoneOffset.UTC).toEpochMilli(),
                 finishTime == null ? 0L : finishTime.toInstant(ZoneOffset.UTC).toEpochMilli());
@@ -296,11 +296,11 @@ public class Transaction extends AtomicAction {
         status = toLRAStatus(actionStatus);
     }
 
-    boolean isComplete() {
+    boolean isClosed() {
         return status != null && status.equals(LRAStatus.Closed);
     }
 
-    boolean isCompensated() {
+    boolean isCancelled() {
         return status != null && status.equals(LRAStatus.Cancelled);
     }
 

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -113,17 +113,17 @@ public class LRAService {
         }
 
         if (LRAStatus.Cancelling.name().equals(state)) {
-            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isCompensating).collect(toList());
+            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isCancelling).collect(toList());
         } else if (LRAStatus.Cancelled.name().equals(state)) {
-            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isCompensated).collect(toList());
+            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isCancelled).collect(toList());
         } else if (LRAStatus.FailedToCancel.name().equals(state)) {
-            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isFailedToCompensate).collect(toList());
+            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isFailedToCancel).collect(toList());
         } else if (LRAStatus.Closing.name().equals(state)) {
-            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isCompensating).collect(toList());
+            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isClosing).collect(toList());
         } else if (LRAStatus.Closed.name().equals(state)) {
-            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isCompleted).collect(toList());
+            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isClosed).collect(toList());
         } else if (LRAStatus.FailedToClose.name().equals(state)) {
-            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isFailedToComplete).collect(toList());
+            return recoveringLRAs.values().stream().map(LRAStatusHolder::new).filter(LRAStatusHolder::isFailedToClose).collect(toList());
         }
 
         return null;

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -60,6 +60,12 @@
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-tck</artifactId>
             <version>${version.microprofile.lra.tck}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${version.resteasy-client}</version>
             <scope>test</scope>
         </dependency>
 
@@ -187,6 +193,7 @@
             <activation>
                 <property>
                     <name>skipTests</name>
+                    <value>true</value>
                 </property>
             </activation>
             <properties>
@@ -198,6 +205,7 @@
             <activation>
                 <property>
                     <name>maven.test.skip</name>
+                    <value>true</value>
                 </property>
             </activation>
             <properties>

--- a/rts/lra/lra-test/tck/src/test/java/io/narayana/lra/tck/LRATckInfo.java
+++ b/rts/lra/lra-test/tck/src/test/java/io/narayana/lra/tck/LRATckInfo.java
@@ -66,13 +66,13 @@ public class LRATckInfo implements LRAInfo {
     }
 
     @Override
-    public boolean isComplete() {
-        return narayanaLraInfoInstance.isComplete();
+    public boolean isClosed() {
+        return narayanaLraInfoInstance.isClosed();
     }
 
     @Override
-    public boolean isCompensated() {
-        return narayanaLraInfoInstance.isCompensated();
+    public boolean isCancelled() {
+        return narayanaLraInfoInstance.isCancelled();
     }
 
     @Override

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -33,8 +33,8 @@
         <version.junit>4.12</version.junit>
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
 
-        <version.microprofile.lra.api>1.0-20190222.071200-278</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190222.071201-278</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190303.071139-290</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190303.071140-290</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3109

Based on the changes in LRA TCK the LRA status methods were renamed to
close and cancel.

https://github.com/eclipse/microprofile-lra/issues/94
https://github.com/eclipse/microprofile-lra/pull/98

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO