### PR TITLE
JBTM-3115 Do not run LRA TCK by default

### DIFF
--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -14,6 +14,7 @@
     <name>LRA tests: MicroProfile TCK</name>
 
     <properties>
+        <skipTests>true</skipTests>
         <lra.coordinator.exec.plugin.phase>pre-integration-test</lra.coordinator.exec.plugin.phase>
         <lra.coordinator.port>8080</lra.coordinator.port>
         <lra.coordinator.trace.params></lra.coordinator.trace.params>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3115
By default skip LRA TCK testing
Note that this change does not disable running a coordinator which is a more invasive change and I would prefer that @ochaloup does that.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS