### PR TITLE
JBTM-3115 disable LRA tck tests by default

### DIFF
--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <skipTests>true</skipTests>
+        <no.lra.coordinator>true</no.lra.coordinator>
         <lra.coordinator.exec.plugin.phase>pre-integration-test</lra.coordinator.exec.plugin.phase>
         <lra.coordinator.port>8080</lra.coordinator.port>
         <lra.coordinator.trace.params></lra.coordinator.trace.params>
@@ -138,7 +139,8 @@
             <id>start.lra.coodinator.before.it.tests</id>
             <activation>
                 <property>
-                    <name>!no.lra.coordinator</name>
+                    <name>no.lra.coordinator</name>
+                    <value>false</value>
                 </property>
             </activation>
             <build>


### PR DESCRIPTION
Signed-off-by: Michael Musgrove <mmusgrov@redhat.com>

This is an update to the fix for JBTM-3115 which does not start a coordinator by default.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS