### PR TITLE
[WFLY-11849] txbridge import transaction to use default timeout not null

### DIFF
--- a/XTS/WSTX/classes/com/arjuna/mw/wst11/UserTransaction.java
+++ b/XTS/WSTX/classes/com/arjuna/mw/wst11/UserTransaction.java
@@ -129,4 +129,10 @@ public abstract class UserTransaction
         throws UnknownTransactionException, SecurityException, SystemException, WrongStateException;
 
     public abstract String transactionIdentifier ();
+
+    /**
+     * Returning timeout of the transaction
+     * as it was defined when it begun.
+     */
+    public abstract int getTimeout();
 }

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserSubordinateTransactionImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserSubordinateTransactionImple.java
@@ -59,4 +59,8 @@ public class UserSubordinateTransactionImple extends UserTransaction
     public String transactionIdentifier() {
         return UserTransactionImple.getUserTransaction().transactionIdentifier();
     }
+
+    public int getTimeout() {
+        return UserTransactionImple.getUserTransaction().getTimeout();
+    }
 }

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserTransactionImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserTransactionImple.java
@@ -201,6 +201,11 @@ public class UserTransactionImple extends UserTransaction
         }
     }
 
+    @Override
+    public int getTimeout() {
+        return timeout;
+    }
+
 	/*
 	 * Not sure if this is right as it doesn't map to registering a participant
 	 * with the coordinator.
@@ -284,6 +289,7 @@ public class UserTransactionImple extends UserTransaction
 
 
             final Long expires = (timeout > 0 ? new Long(timeout) : null) ;
+            this.timeout = timeout;
             final String messageId = MessageId.getMessageId() ;
             final CoordinationContext currentContext = (current != null ? getContext(current) : null);
             final CoordinationContextType coordinationContext = ActivationCoordinator.createCoordinationContext(
@@ -494,4 +500,5 @@ public class UserTransactionImple extends UserTransaction
 	protected String _activationCoordinatorService;
 	private Hashtable _completionCoordinators = new Hashtable();
     private UserSubordinateTransactionImple _userSubordinateTransaction;
+    private int timeout = -1;
 }

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserTransactionStandaloneImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserTransactionStandaloneImple.java
@@ -163,9 +163,9 @@ public class UserTransactionStandaloneImple extends UserTransaction
 	}
 
     /**
-     * method provided for the benefit of UserSubordinateTransactionImple to allow it
+     * method provided for the benefit of {@link UserSubordinateTransactionImple} to allow it
      * to begin a subordinate transaction which requires an existing context to be
-     * installed on the thread before it will start and instal la new transaction
+     * installed on the thread before it will start and install a new transaction
      *
      * @param timeout
      * @throws com.arjuna.wst.WrongStateException
@@ -176,8 +176,13 @@ public class UserTransactionStandaloneImple extends UserTransaction
         throw new SystemException("UserTransactionStandaloneImple does not support subordinate transactions");
     }
 
+    @Override
+    public int getTimeout() {
+        return timeout;
+    }
+
 	/*
-	 * enlist the client for the completiopn protocol so it can commit or ro0ll back the transaction
+	 * enlist the client for the completion protocol so it can commit or roll back the transaction
 	 */
 
 	private final void enlistCompletionParticipants ()
@@ -257,6 +262,7 @@ public class UserTransactionStandaloneImple extends UserTransaction
 
 
             final Long expires = (timeout > 0 ? new Long(timeout) : null) ;
+            this.timeout = timeout;
             final String messageId = MessageId.getMessageId() ;
             final CoordinationContext currentContext = (current != null ? getContext(current) : null);
             final CoordinationContextType coordinationContext = ActivationCoordinator.createCoordinationContext(
@@ -447,4 +453,5 @@ public class UserTransactionStandaloneImple extends UserTransaction
 	protected String _activationCoordinatorService;
 	private Hashtable _completionCoordinators = new Hashtable();
     private UserSubordinateTransactionImple _userSubordinateTransaction;
+    private int timeout = -1;
 }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wstx/tests/arq/WarDeployment.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wstx/tests/arq/WarDeployment.java
@@ -16,7 +16,7 @@ public class WarDeployment {
 		archive.delete(ArchivePaths.create("META-INF/MANIFEST.MF"));
 
 		final String ManifestMF = "Manifest-Version: 1.0\n"
-			+ "Dependencies: org.jboss.modules,org.jboss.msc,org.jboss.jts,org.jboss.xts\n";
+			+ "Dependencies: org.jboss.xts\n";
 		archive.setManifest(new StringAsset(ManifestMF));
 
 		return archive;

--- a/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridge.java
+++ b/rts/at/bridge/src/main/java/org/jboss/narayana/rest/bridge/inbound/InboundBridge.java
@@ -35,6 +35,7 @@ import javax.transaction.xa.Xid;
 import com.arjuna.ats.jta.recovery.SerializableXAResourceDeserializer;
 import org.jboss.logging.Logger;
 
+import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.arjuna.ats.internal.arjuna.FormatConstants;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManager;
 import com.arjuna.ats.jta.TransactionManager;
@@ -217,7 +218,8 @@ public final class InboundBridge implements XAResource, SerializableXAResourceDe
         final Transaction transaction;
 
         try {
-            transaction = SubordinationManager.getTransactionImporter().importTransaction(xid);
+            transaction = SubordinationManager.getTransactionImporter()
+                    .importTransaction(xid, TxControl.getDefaultTimeout());
         } catch (XAException e) {
             LOG.warn(e.getMessage(), e);
             throw new InboundBridgeException("Failed to import transaction.", e);

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/AbstractTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/AbstractTestCase.java
@@ -232,4 +232,29 @@ public abstract class AbstractTestCase {
         return baseAddress + ":" + basePort;
     }
 
+    /**
+     * Checking if the parameter <code>recordToAssert</code>
+     * is placed exactly once in the {@link JSONArray}.
+     */
+    protected void assertJsonArray(JSONArray invocationsJSONArray, String recordToAssert, int expectedRecordFoundCount) throws JSONException {
+        if(recordToAssert == null) throw new NullPointerException("recordToAssert");
+        boolean containsJsonArrayExpectedCount = containsJsonArray(invocationsJSONArray, recordToAssert, expectedRecordFoundCount);
+        if (!containsJsonArrayExpectedCount) {
+            String formattedTimesString = expectedRecordFoundCount + " times";
+            if(expectedRecordFoundCount == 1) formattedTimesString = "once";
+            if(expectedRecordFoundCount == 2) formattedTimesString = "twice";
+            Assert.fail("Invocation result returned as a JSON array '" + invocationsJSONArray + "' "
+                    + "expected to contain the record '" + recordToAssert + "' " + formattedTimesString);
+        }
+    }
+
+    protected boolean containsJsonArray(JSONArray invocationsJSONArray, String recordToAssert, int expectedRecordFoundCount) throws JSONException {
+        int recordFoundCount = 0;
+        for(int i = 0; i < invocationsJSONArray.length(); i++) {
+            if(recordToAssert.equals(invocationsJSONArray.get(i))) {
+                recordFoundCount++;
+            }
+        }
+        return recordFoundCount == expectedRecordFoundCount;
+    }
 }

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeTestCase.java
@@ -72,11 +72,11 @@ public class InboundBridgeTestCase extends AbstractTestCase {
 
         JSONArray jsonArray = getResourceInvocations(ADVANCED_INBOUND_BRIDGE_RESOURCE_URL);
 
-        Assert.assertEquals(4, jsonArray.length());
-        Assert.assertEquals("LoggingXAResource.start", jsonArray.get(0));
-        Assert.assertEquals("LoggingXAResource.end", jsonArray.get(1));
-        Assert.assertEquals("LoggingXAResource.prepare", jsonArray.get(2));
-        Assert.assertEquals("LoggingXAResource.commit", jsonArray.get(3));
+        assertJsonArray(jsonArray, "LoggingXAResource.start", 1);
+        assertJsonArray(jsonArray, "LoggingXAResource.end", 1);
+        assertJsonArray(jsonArray, "LoggingXAResource.prepare", 1);
+        assertJsonArray(jsonArray, "LoggingXAResource.commit", 1);
+        assertJsonArray(jsonArray, "LoggingXAResource.rollback", 0);
     }
 
     @Test
@@ -87,10 +87,11 @@ public class InboundBridgeTestCase extends AbstractTestCase {
 
         JSONArray jsonArray = getResourceInvocations(ADVANCED_INBOUND_BRIDGE_RESOURCE_URL);
 
-        Assert.assertEquals(3, jsonArray.length());
-        Assert.assertEquals("LoggingXAResource.start", jsonArray.get(0));
-        Assert.assertEquals("LoggingXAResource.end", jsonArray.get(1));
-        Assert.assertEquals("LoggingXAResource.rollback", jsonArray.get(2));
+        assertJsonArray(jsonArray, "LoggingXAResource.start", 1);
+        assertJsonArray(jsonArray, "LoggingXAResource.end", 1);
+        assertJsonArray(jsonArray, "LoggingXAResource.prepare", 0);
+        assertJsonArray(jsonArray, "LoggingXAResource.commit", 0);
+        assertJsonArray(jsonArray, "LoggingXAResource.rollback", 1);
     }
 
     @Test
@@ -109,12 +110,11 @@ public class InboundBridgeTestCase extends AbstractTestCase {
         Assert.assertEquals("LoggingRestATResource.terminateParticipant(" + TxStatusMediaType.TX_COMMITTED + ")",
                 loggingRestATResourceInvocations.get(1));
 
-        Assert.assertEquals(4, loggingXAResourceInvocations.length());
-        Assert.assertEquals("LoggingXAResource.start", loggingXAResourceInvocations.get(0));
-        Assert.assertEquals("LoggingXAResource.end", loggingXAResourceInvocations.get(1));
-        Assert.assertEquals("LoggingXAResource.prepare", loggingXAResourceInvocations.get(2));
-        Assert.assertEquals("LoggingXAResource.commit", loggingXAResourceInvocations.get(3));
-
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.start", 1);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.end", 1);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.prepare", 1);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.commit", 1);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.rollback", 0);
     }
 
     @Test
@@ -131,10 +131,10 @@ public class InboundBridgeTestCase extends AbstractTestCase {
         Assert.assertEquals("LoggingRestATResource.terminateParticipant(" + TxStatusMediaType.TX_ROLLEDBACK + ")",
                 loggingRestATResourceInvocations.get(0));
 
-        Assert.assertEquals(3, loggingXAResourceInvocations.length());
-        Assert.assertEquals("LoggingXAResource.start", loggingXAResourceInvocations.get(0));
-        Assert.assertEquals("LoggingXAResource.end", loggingXAResourceInvocations.get(1));
-        Assert.assertEquals("LoggingXAResource.rollback", loggingXAResourceInvocations.get(2));
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.start", 1);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.end", 1);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.prepare", 0);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.commit", 0);
+        assertJsonArray(loggingXAResourceInvocations, "LoggingXAResource.rollback", 1);
     }
-
 }

--- a/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeWithMultipleDeploymentsTestCase.java
+++ b/rts/at/bridge/src/test/java/org/jboss/narayana/rest/bridge/inbound/test/integration/InboundBridgeWithMultipleDeploymentsTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.narayana.rest.bridge.inbound.test.integration;
 
+import static org.junit.Assert.assertTrue;
+
 import org.codehaus.jettison.json.JSONArray;
 import org.jboss.arquillian.container.test.api.Config;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -97,29 +99,22 @@ public class InboundBridgeWithMultipleDeploymentsTestCase extends AbstractTestCa
         JSONArray firstLoggingXAResourceInvocations = getResourceInvocations(FIRST_RESOURCE_URL);
         JSONArray secondLoggingXAResourceInvocations = getResourceInvocations(SECOND_RESOURCE_URL);
 
-        if (firstLoggingXAResourceInvocations.length() == 5) {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", firstLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.prepare", firstLoggingXAResourceInvocations.get(3));
-            Assert.assertEquals("LoggingXAResource.commit", firstLoggingXAResourceInvocations.get(4));
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.start", 1);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.end", 1);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.prepare", 1);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.commit", 1);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.rollback", 0);
 
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.prepare", secondLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.commit", secondLoggingXAResourceInvocations.get(3));
-        } else {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.prepare", firstLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.commit", firstLoggingXAResourceInvocations.get(3));
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.start", 1);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.end", 1);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.prepare", 1);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.commit", 1);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.rollback", 0);
 
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.prepare", secondLoggingXAResourceInvocations.get(3));
-            Assert.assertEquals("LoggingXAResource.commit", secondLoggingXAResourceInvocations.get(4));
-        }
+        boolean isSameRMCalled = containsJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.isSameRM", 1);
+        isSameRMCalled = containsJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.isSameRM", 1) || isSameRMCalled;
+        assertTrue("One of the XAResources had to be invoked with call XAResource.isSameRM "
+                + "but no one was called with that", isSameRMCalled);
     }
 
 
@@ -133,25 +128,22 @@ public class InboundBridgeWithMultipleDeploymentsTestCase extends AbstractTestCa
         JSONArray firstLoggingXAResourceInvocations = getResourceInvocations(FIRST_RESOURCE_URL);
         JSONArray secondLoggingXAResourceInvocations = getResourceInvocations(SECOND_RESOURCE_URL);
 
-        if (firstLoggingXAResourceInvocations.length() == 4) {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", firstLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.rollback", firstLoggingXAResourceInvocations.get(3));
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.start", 1);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.end", 1);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.prepare", 0);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.commit", 0);
+        assertJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.rollback", 1);
 
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.rollback", secondLoggingXAResourceInvocations.get(2));
-        } else {
-            Assert.assertEquals("LoggingXAResource.start", firstLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.end", firstLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.rollback", firstLoggingXAResourceInvocations.get(2));
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.start", 1);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.end", 1);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.prepare", 0);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.commit", 0);
+        assertJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.rollback", 1);
 
-            Assert.assertEquals("LoggingXAResource.start", secondLoggingXAResourceInvocations.get(0));
-            Assert.assertEquals("LoggingXAResource.isSameRM", secondLoggingXAResourceInvocations.get(1));
-            Assert.assertEquals("LoggingXAResource.end", secondLoggingXAResourceInvocations.get(2));
-            Assert.assertEquals("LoggingXAResource.rollback", secondLoggingXAResourceInvocations.get(3));
-        }
+        boolean isSameRMCalled = containsJsonArray(firstLoggingXAResourceInvocations, "LoggingXAResource.isSameRM", 1);
+        isSameRMCalled = containsJsonArray(secondLoggingXAResourceInvocations, "LoggingXAResource.isSameRM", 1) || isSameRMCalled;
+        assertTrue("One of the XAResources had to be invoked with call XAResource.isSameRM "
+                + "but no one was called with that", isSameRMCalled);
     }
 
     @Override

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/service/TestServiceImpl.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/service/TestServiceImpl.java
@@ -20,20 +20,18 @@
  */
 package org.jboss.jbossts.txbridge.tests.inbound.service;
 
-import org.jboss.logging.Logger;
-import org.jboss.jbossts.txbridge.tests.inbound.utility.TestSynchronization;
-import org.jboss.jbossts.txbridge.tests.inbound.utility.TestXAResource;
-
-import javax.ejb.Remote;
+import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.jws.HandlerChain;
 import javax.jws.WebMethod;
 import javax.jws.WebService;
 import javax.jws.soap.SOAPBinding;
 import javax.transaction.TransactionManager;
-import javax.transaction.xa.XAException;
+
+import org.jboss.jbossts.txbridge.tests.inbound.utility.TestSynchronization;
+import org.jboss.jbossts.txbridge.tests.inbound.utility.TestXAResource;
+import org.jboss.logging.Logger;
 
 
 /**
@@ -48,6 +46,9 @@ import javax.transaction.xa.XAException;
 public class TestServiceImpl {
     private static Logger log = Logger.getLogger(TestServiceImpl.class);
 
+    @Resource(lookup = "java:/TransactionManager")
+    private TransactionManager tm;
+
     @WebMethod
     public void doNothing() {
         log.trace("doNothing()");
@@ -55,7 +56,6 @@ public class TestServiceImpl {
 
     @WebMethod(exclude = true)
     public void enlistSynchronization(int count) {
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
         try {
             for (int i = 0; i < count; i++) {
                 TestSynchronization testSynchronization = new TestSynchronization();
@@ -68,7 +68,6 @@ public class TestServiceImpl {
 
     @WebMethod(exclude = true)
     public void enlistXAResource(int count) {
-        TransactionManager tm = com.arjuna.ats.jta.TransactionManager.transactionManager();
         try {
             for (int i = 0; i < count; i++) {
                 TestXAResource testXAResource = new TestXAResource();


### PR DESCRIPTION
The integration with WFLY with change of the WFTC-54 causes
that timeout set to 0 means the timeout elapsed and participant
is not permitted to be enlisted to transaction.
Let's use default timeout instead.

https://issues.jboss.org/browse/WFLY-11849

requires: https://github.com/jbosstm/jboss-as/pull/81
(adding the integration tests for txbridge to wfly)

Documentation is over here: https://github.com/jbosstm/documentation/pull/49

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF !TOMCAT !JACOCO !LRA 