### PR TITLE
RELEASE SCRIPTS ONLY: narayana-full is under community profile

### DIFF
--- a/narayana-release-process.sh
+++ b/narayana-release-process.sh
@@ -129,8 +129,8 @@ cd -
 cd ~/tmp/narayana/$CURRENT/sources/narayana/
 git checkout $CURRENT
 MAVEN_OPTS="-XX:MaxPermSize=512m" 
-mvn clean install -DskipTests -gs tools/maven/conf/settings.xml -Dorson.jar.location=./ext/
-mvn clean deploy -DskipTests -gs tools/maven/conf/settings.xml -Dorson.jar.location=./ext/ -Prelease
+mvn clean install -DskipTests -gs tools/maven/conf/settings.xml -Dorson.jar.location=$PWD/ext/ -Pcommunity
+mvn clean deploy -DskipTests -gs tools/maven/conf/settings.xml -Dorson.jar.location=$PWD/ext/ -Prelease,community
 mvn clean deploy -DskipTests -gs tools/maven/conf/settings.xml -Prelease -f blacktie/utils/cpp-plugin/pom.xml
 mvn clean deploy -DskipTests -gs tools/maven/conf/settings.xml -Prelease  -f blacktie/pom.xml -pl :blacktie-jatmibroker-nbf -am
 git archive -o ../../narayana-full-$CURRENT-src.zip $CURRENT

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -72,7 +72,11 @@ do
       exit
     fi
     set -e
-    git commit -am "Updated to $CURRENT" || fatal
+    # when there is nothing to commit then do not commit
+    toCommit=`git log origin/master..HEAD --oneline | wc -l`
+    if [ $toCommit -ge 1 ]; then
+      git commit -am "Updated to $CURRENT" || fatal
+    fi
     git tag $CURRENT || fatal
 
     if [[ "$(uname)" == "Darwin" ]] # MacOS
@@ -89,7 +93,10 @@ do
       exit
     fi
     set -e
-    git commit -am "Updated to $NEXT" || fatal
+    toCommit=`git log origin/master..HEAD --oneline | wc -l`
+    if [ $toCommit -ge 1 ]; then
+      git commit -am "Updated to $NEXT" || fatal
+    fi
     git push origin $BRANCH --tags || fatal
     cd ..
 done


### PR DESCRIPTION
...and dockerfiles can be without update

The `narayana-full` is under community profile the release script needs to be updated.
JBoss docker files could not be updated and commit is not necessary in such case. We don't want the script go to `fatal` in empty commit.