### PR TITLE
JBTM-3135 Temporarily disable the BlackTie JNI tests on Windows

### DIFF
--- a/blacktie/integration-tests/pom.xml
+++ b/blacktie/integration-tests/pom.xml
@@ -283,6 +283,27 @@
 	</properties>
 
         <profiles>
+          <!-- Temporarily disable the tests on Windows https://issues.jboss.org/browse/JBTM-3135 -->
+          <profile>
+            <id>jdk11</id>
+            <activation>
+              <os>
+                <family>Windows</family>
+              </os>
+              <jdk>[11,)</jdk>
+            </activation>
+            <build>
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                    <skipTests>true</skipTests>
+                  </configuration>
+                </plugin>
+              </plugins>
+            </build>
+          </profile>
           <profile>
             <id>j9</id>
             <activation>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3135

This is to temporarily remove the JNI tests on Windows JDK11 as instructions are currently for a 32-bit JDK and a 32-bit JVM and JDK11 is only available as 32-bit

!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB BLACKTIE !XTS !PERF !RTS !AS_TESTS !TOMCAT !JACOCO !LRA !DB_TESTS JDK11