### PR TITLE
Jbtm 3087 mp lra issue149

### DIFF
--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -757,4 +757,8 @@ public class Transaction extends AtomicAction {
             }
         }  // else another thread finishing this LRA so it is too late to cancel
     }
+
+    URI getParentId() {
+        return parentId;
+    }
 }

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -168,6 +168,8 @@
                                         <argument>-Djava.net.preferIPv4Stack=true</argument>
                                         <argument>${lra.coordinator.debug.params}</argument>
                                         <argument>${lra.coordinator.trace.params}</argument>
+                                        <argument>-DRecoveryEnvironmentBean.periodicRecoveryPeriod=10</argument>
+                                        <argument>-DRecoveryEnvironmentBean.recoveryBackoffPeriod=3</argument>
                                         <argument>-jar</argument>
                                         <argument>${project.basedir}/../../lra-coordinator/target/lra-coordinator-swarm.jar</argument>
                                     </arguments>

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -80,11 +80,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-          <groupId>org.wildfly.swarm</groupId>
-          <artifactId>arquillian</artifactId>
-          <scope>test</scope>
+            <groupId>io.thorntail</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -24,13 +24,14 @@
         <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
         <version.json.api>1.1</version.json.api>
-        <version.jaxrs.api>1.0.0.Final</version.jaxrs.api>
         <version.jackson>2.8.11.2</version.jackson>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
-        <version.jaxrs-api>2.0</version.jaxrs-api>
+        <version.jaxrs-api>2.1</version.jaxrs-api>
         <version.cdi-api>1.2</version.cdi-api>
         <version.junit>4.12</version.junit>
+
+        <version.thorntail>2.4.0.Final</version.thorntail>
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
 
         <version.microprofile.lra.api>1.0-20190430.132220-362</version.microprofile.lra.api>
@@ -73,6 +74,13 @@
                 <version>${version.arquillian}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.thorntail</groupId>
+                <artifactId>bom</artifactId>
+                <version>${version.thorntail}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -33,8 +33,8 @@
         <version.junit>4.12</version.junit>
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
 
-        <version.microprofile.lra.api>1.0-20190418.101203-346</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190418.101205-346</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190430.132220-362</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190430.132221-362</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3087

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

1. This PR updates LRA to use JAX-RS 2.1 (which adds reactive features to JAX-RS and is a version supported by Thorntail)
2. The PR also includes the commit to accommodate MP-LRA issue 117 which replaced the @NestedLRA annotation with an LRA.Type.Nested element (and exposes the parent context in a JAX-RS header when a nested LRA is active)
