### PR TITLE
JBTM-3144 Intermittent LRA TCK test failures

### DIFF
--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -35,4 +35,5 @@ public abstract class LRAConstants {
     public static final String CLIENT_ID_PARAM_NAME = "ClientID";
     public static final String TIMELIMIT_PARAM_NAME = "TimeLimit";
     public static final String PARENT_LRA_PARAM_NAME = "ParentLRA";
+    public static final String RECOVERY_PARAM = "recoveryCount";
 }

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -167,8 +167,6 @@
                                         <argument>-Djava.net.preferIPv4Stack=true</argument>
                                         <argument>${lra.coordinator.debug.params}</argument>
                                         <argument>${lra.coordinator.trace.params}</argument>
-                                        <argument>-DRecoveryEnvironmentBean.periodicRecoveryPeriod=10</argument>
-                                        <argument>-DRecoveryEnvironmentBean.recoveryBackoffPeriod=3</argument>
                                         <argument>-jar</argument>
                                         <argument>${project.basedir}/../../lra-coordinator/target/lra-coordinator-swarm.jar</argument>
                                     </arguments>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3144

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !R

Some MP-LRA TCK tests need to wait for a recovery cycle to validate eventual consistency and one of the tests periodically fails on CI hardware due to timing issues (but I have not seen it on my laptop).

This PR adds a synchronous recovery scan and also has the benefit of significantly speeding up the TCK run (since it avoids multiple long waits for the next scheduled scan).