### PR TITLE
[JBTM-3148] returning correct error code on one phase commit failure

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/TransactionImple.java
@@ -262,9 +262,11 @@ public class TransactionImple extends
 			{
 			case ActionStatus.COMMITTED:
 			case ActionStatus.COMMITTING:
-			case ActionStatus.H_COMMIT:
 				TransactionImple.removeTransaction(this);
 				break;
+			case ActionStatus.H_COMMIT:
+				TransactionImple.removeTransaction(this);
+				throw new javax.transaction.HeuristicMixedException(jtaLogger.i18NLogger.get_onephase_heuristic_commit_failure(super._theTransaction));
 			case ActionStatus.ABORTED:
 	                 case ActionStatus.ABORTING:
 	                 case ActionStatus.H_ROLLBACK:

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -580,12 +580,16 @@ public interface jtaI18NLogger {
     @Message(id = 16142, value = "Not actived transaction ''{0}'' for xid: {1}", format = MESSAGE_FORMAT)
     String get_not_activated_transaction(Transaction txn, Xid xid);
 
-    @Message(id = 16143, value = "Problem during waiting for lock '{0}' whilst in state {1}", format = MESSAGE_FORMAT)
+    @Message(id = 16143, value = "Problem during waiting for lock ''{0}'' whilst in state {1}", format = MESSAGE_FORMAT)
     @LogMessage(level = WARN)
     public void warn_intteruptedExceptionOnWaitingXARecoveryModuleLock(XARecoveryModule recModule, String state, @Cause() InterruptedException arg0);
 
     @Message(id = 16144, value = "No subordinate transaction to drive {0}, xid: {1}", format = MESSAGE_FORMAT)
     String get_no_subordinate_txn_for(String actionToDrive, Xid xid);
+
+    @Message(id = 16145, value = "One phase commit for transaction ''{0}'' does not store data in the object store. "
+            + "Recovery is won''t able to decide about outcome. Transaction is marked as heuristic to be decided by administrator.", format = MESSAGE_FORMAT)
+    String get_onephase_heuristic_commit_failure(StateManager action);
 
     /*
         Allocate new messages directly above this notice.


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3148

1PC for subordinate XAResource to return heuristics if failure on commit happens.



!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !RTS  !TOMCAT !JACOCO !LRA !PERF !XTS !AS_TESTS
MAIN 