### PR TITLE
JBTM-3146 Make the parsing of XML and Java archives more flexible

### DIFF
--- a/ArjunaJTS/narayana-jts-ibmorb/pom.xml
+++ b/ArjunaJTS/narayana-jts-ibmorb/pom.xml
@@ -130,6 +130,49 @@
           <revisionOnScmFailure>${project.version}-noscm</revisionOnScmFailure>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jboss.maven.plugins</groupId>
+        <artifactId>maven-injection-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>bytecode</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bytecodeInjections>
+            <bytecodeInjection>
+              <expression>${buildNumber}</expression>
+              <targetMembers>
+                <methodBodyReturn>
+                  <className>com.arjuna.common.util.ConfigurationInfo</className>
+                  <methodName>getSourceId</methodName>
+                </methodBodyReturn>
+              </targetMembers>
+            </bytecodeInjection>
+            <bytecodeInjection>
+              <expression>jbossts-ibmorb-properties.xml</expression>
+              <targetMembers>
+                <methodBodyReturn>
+                  <className>com.arjuna.common.util.ConfigurationInfo</className>
+                  <methodName>getPropertiesFile</methodName>
+                </methodBodyReturn>
+              </targetMembers>
+            </bytecodeInjection>
+            <bytecodeInjection>
+              <expression>JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}</expression>
+              <targetMembers>
+                <methodBodyReturn>
+                  <className>com.arjuna.common.util.ConfigurationInfo</className>
+                  <methodName>getBuildId</methodName>
+                </methodBodyReturn>
+              </targetMembers>
+            </bytecodeInjection>
+          </bytecodeInjections>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/common/classes/com/arjuna/common/util/propertyservice/PropertiesFactory.java
+++ b/common/classes/com/arjuna/common/util/propertyservice/PropertiesFactory.java
@@ -32,6 +32,17 @@ public final class PropertiesFactory {
 
     private static AbstractPropertiesFactory delegatePropertiesFactory;
 
+    /**
+     * Allow the properties factory delegate to be supplied externally. This
+     * is useful for containers like Quarkus that need to statically initialise
+     * properties during a deployment phase.
+     *
+     * @param propertiesFactory a factory for providing default values for properties
+     */
+    public static void setDelegatePropertiesFactory(AbstractPropertiesFactory propertiesFactory) {
+        delegatePropertiesFactory = propertiesFactory;
+    }
+
     public static Properties getDefaultProperties() {
         initPropertiesFactory();
         return delegatePropertiesFactory.getDefaultProperties();

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -54,6 +54,50 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jboss.maven.plugins</groupId>
+        <artifactId>maven-injection-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>bytecode</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- inject build information into the ConfigurationInfo class -->
+          <bytecodeInjections>
+            <bytecodeInjection>
+              <expression>${buildNumber}</expression>
+              <targetMembers>
+                <methodBodyReturn>
+                  <className>com.arjuna.common.util.ConfigurationInfo</className>
+                  <methodName>getSourceId</methodName>
+                </methodBodyReturn>
+              </targetMembers>
+            </bytecodeInjection>
+            <bytecodeInjection>
+              <expression>jbossts-properties.xml</expression>
+              <targetMembers>
+                <methodBodyReturn>
+                  <className>com.arjuna.common.util.ConfigurationInfo</className>
+                  <methodName>getPropertiesFile</methodName>
+                </methodBodyReturn>
+              </targetMembers>
+            </bytecodeInjection>
+            <bytecodeInjection>
+              <expression>JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}</expression>
+              <targetMembers>
+                <methodBodyReturn>
+                  <className>com.arjuna.common.util.ConfigurationInfo</className>
+                  <methodName>getBuildId</methodName>
+                </methodBodyReturn>
+              </targetMembers>
+            </bytecodeInjection>
+          </bytecodeInjections>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -587,8 +587,6 @@
           </plugins>
         </build>
         <properties>
-          <maven.compiler.source>1.9</maven.compiler.source>
-          <maven.compiler.target>1.9</maven.compiler.target>
           <version.org.jacorb.jacorb>3.7</version.org.jacorb.jacorb>
           <version.org.jacorb.jacorb-idl-compiler>3.7</version.org.jacorb.jacorb-idl-compiler>
           <server.jvm.args>${jvm.args.other} ${jvm.args.byteman} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3146

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

This is a second attempt at fixing JBTM-3146.

Note that the latest fix sets the JDK compiler for JDK8 compatibility during the build (which is the default since our parent is jboss-parent). This change is valid since JBoss projects are not currently using JDK 11 features yet.