### PR TITLE
JBTM-3087 Upgrade the version of the MP-LRA dependency

### DIFF
--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -28,8 +28,8 @@
         <version.thorntail>2.4.0.Final</version.thorntail>
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
 
-        <version.microprofile.lra.api>1.0-20190430.132220-362</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190430.132221-362</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190515.061205-378</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190515.061206-378</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3087

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

This is an interim upgrade of our LRA dependencies while we wait for pr 1450 (which is in progress). We need it as soon as possible since all of our builds are currently failing.

Note that we need an immediate fix because MP-LRA builds are expunged after 30 days