### PR TITLE
JBTM-3145 (MP-LRA issue146) allow LRA compensators to be called with …

### DIFF
--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -36,4 +36,5 @@ public abstract class LRAConstants {
     public static final String TIMELIMIT_PARAM_NAME = "TimeLimit";
     public static final String PARENT_LRA_PARAM_NAME = "ParentLRA";
     public static final String RECOVERY_PARAM = "recoveryCount";
+    public static final String HTTP_METHOD_NAME = "method"; // the name of the HTTP method used to invoke participants
 }

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -25,7 +25,7 @@
         <lra.tck.suite.thorntail.trace.params></lra.tck.suite.thorntail.trace.params>
         <lra.tck.suite.debug.params></lra.tck.suite.debug.params> <!-- has content when -Ddebug.tck is specified -->
         <lra.tck.suite.debug.port>8788</lra.tck.suite.debug.port>
-        <lra.tck.consistency.delay>2000</lra.tck.consistency.delay>
+        <lra.tck.consistency.delay>0</lra.tck.consistency.delay>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -46,9 +46,6 @@
                         <!-- exclude non JAX-RS tests pending PR 1450 -->
                         <exclude>**/TckInvalidParticipantSignaturesTests.java</exclude>
                         <exclude>**/TckParticipantTests.java</exclude>
-                        <!-- https://github.com/eclipse/microprofile-lra/issues/146 allows participant methods to be
-                             invoked with any http method. The implementation needs to catch up -->
-                        <exclude>**/TckContextTests.java</exclude>
                     </excludes>
                     <systemPropertyVariables combine.children="append">
                         <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,9 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-
-        <version.microprofile.lra.api>1.0-20190614.061200-417</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190614.061201-417</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190620.172218-426</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190620.172219-426</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
…any HTTP method

https://issues.jboss.org/browse/JBTM-3145

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

MP-LRA issue 146 allows compensator callback endpoints to be invoked with any HTTP method (DELETE, PUT, POST or GET)