### PR TITLE
[JBTM-3163] AfterLRA notifications are delivered twice

### DIFF
--- a/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/rts/lra/lra-client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -33,6 +33,7 @@ import static io.narayana.lra.LRAConstants.STATUS;
 import static io.narayana.lra.LRAConstants.TIMELIMIT_PARAM_NAME;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 
@@ -677,7 +678,7 @@ public class NarayanaLRAClient implements Closeable {
 
             if (response.getStatus() == Response.Status.PRECONDITION_FAILED.getStatusCode()) {
                 LRALogger.i18NLogger.error_tooLateToJoin(lraId, response);
-                throw new WebApplicationException(lraId + ": Too late to join with this LRA ", BAD_REQUEST);
+                throw new WebApplicationException(lraId + ": Too late to join with this LRA ", NOT_FOUND);
             } else if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
                 LRALogger.logger.infof("Failed enlisting to LRA '%s', coordinator '%s' responded with status '%s'",
                         lraId, base, Response.Status.NOT_FOUND.getStatusCode());

--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -247,8 +247,6 @@ public class LRAService {
             }
         }
 
-        finished(transaction, fromHierarchy);
-
         if (transaction.isTopLevel()) {
             // forget any nested LRAs
             transaction.forgetAllParticipants(); // instruct compensators to clean up

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -43,6 +43,8 @@
                         <exclude>**/TckInvalidParticipantSignaturesTests.java</exclude>
                         <exclude>**/TckParticipantTests.java</exclude>
                         <exclude>**/TckInvalidSignaturesTests.java</exclude>
+                        <!-- https://github.com/eclipse/microprofile-lra/pull/192 -->
+                        <exclude>**/TckTests.java</exclude>
                     </excludes>
                     <systemPropertyVariables combine.children="append">
                         <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3163

No need to test. There is a TCK test in non-JAX-RS cases which is asserting that the afterLRA is called only once.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

