### PR TITLE
Jbtm 3169

### DIFF
--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
@@ -122,6 +122,10 @@ public class LRARecoveryModule implements RecoveryModule {
 
                 if (!inFlight && lra.isRecovering()) {
                     lra.replayPhase2();
+
+                    if (!lra.isRecovering() && lraService != null) {
+                        lraService.finished(lra, false);
+                    }
                 }
 
             } catch (Exception ex) {

--- a/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/lra-filters/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -223,7 +223,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                         // if there is an LRA present nest a new LRA under it
                         suspendedLRA = incommingLRA;
                         lraTrace(containerRequestContext, suspendedLRA, "ServerLRAFilter before: REQUIRED start new LRA");
-                        newLRA = lraId = startLRA(incommingLRA, method, getTimeOut(method));
+                        newLRA = lraId = startLRA(incommingLRA, method, getTimeOut(transactional));
                     } else {
                         lraId = incommingLRA;
                         resumeTransaction(incommingLRA);
@@ -232,7 +232,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 
                 } else {
                     lraTrace(containerRequestContext, null, "ServerLRAFilter before: REQUIRED start new LRA");
-                    newLRA = lraId = startLRA(null, method, getTimeOut(method));
+                    newLRA = lraId = startLRA(null, method, getTimeOut(transactional));
                 }
 
                 break;
@@ -240,7 +240,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
 //                    previous = AtomicAction.suspend();
                 suspendedLRA = incommingLRA;
                 lraTrace(containerRequestContext, suspendedLRA, "ServerLRAFilter before: REQUIRES_NEW start new LRA");
-                newLRA = lraId = startLRA(null, method, getTimeOut(method));
+                newLRA = lraId = startLRA(null, method, getTimeOut(transactional));
 
                 break;
             case SUPPORTS:
@@ -459,9 +459,9 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
         return false;
     }
 
-    private long getTimeOut(Method method) {
-        long timeLimit = method.getAnnotation(LRA.class).timeLimit();
-        ChronoUnit timeUnit = method.getAnnotation(LRA.class).timeUnit();
+    private long getTimeOut(LRA transactional) {
+        long timeLimit = transactional.timeLimit();
+        ChronoUnit timeUnit = transactional.timeUnit();
 
         return Duration.of(timeLimit, timeUnit).toMillis();
     }

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -116,6 +116,8 @@
                                         <argument>${lra.coordinator.trace.params}</argument>
                                         <argument>-jar</argument>
                                         <argument>${lra.coordinator.jar.path}</argument>
+                                        <argument>-DRecoveryEnvironmentBean.periodicRecoveryPeriod=10</argument>
+                                        <argument>-DRecoveryEnvironmentBean.recoveryBackoffPeriod=5</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -21,7 +21,7 @@
         <lra.tck.suite.thorntail.trace.params></lra.tck.suite.thorntail.trace.params>
         <lra.tck.suite.debug.params></lra.tck.suite.debug.params> <!-- has content when -Ddebug.tck is specified -->
         <lra.tck.suite.debug.port>8788</lra.tck.suite.debug.port>
-        <lra.tck.consistency.delay>0</lra.tck.consistency.delay>
+        <lra.tck.consistency.delay>20000</lra.tck.consistency.delay>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20190801.113716-482</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190801.113717-482</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190807.170228-492</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190807.170229-492</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

https://issues.jboss.org/browse/JBTM-3169

MP-LRA issue 195 (see https://github.com/eclipse/microprofile-lra/issues) introduced some changes to response codes that relate to how unknown LRA id's are handled by implementations. The associated tests for the issue also uncovered a bug in how recovery handles in progress LRA's. The new TCK tests are in pull request 205.

The PR also adds a none zero value for the MP-LRA TCK config property `lra.tck.consistency.delay` since the new tests require two passes of the recovery thread.