### PR TITLE
[JBTM-3170] fix for wrong parsing jdbc connection property name

### DIFF
--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/recovery/BasicXARecovery.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/recovery/BasicXARecovery.java
@@ -120,7 +120,7 @@ public class BasicXARecovery implements XAResourceRecovery
 
 		if (breakPosition != -1)
 		{
-			fileName = parameter.substring(0, breakPosition - 1);
+			fileName = parameter.substring(0, breakPosition);
 
 			try
 			{

--- a/ArjunaJTA/jdbc/src/test/resources/h2recovery-multiple-properties.xml
+++ b/ArjunaJTA/jdbc/src/test/resources/h2recovery-multiple-properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+    <entry key="DB_1_DatabaseUser">sa</entry>
+    <entry key="DB_1_DatabasePassword">sa</entry>
+    <entry key="DB_1_DatabaseDynamicClass"></entry>
+    <entry key="DB_1_DatabaseURL">h2DataSource</entry>
+    <entry key="DB_2_DatabaseUser">sa</entry>
+    <entry key="DB_2_DatabasePassword">sa</entry>
+    <entry key="DB_2_DatabaseDynamicClass"></entry>
+    <entry key="DB_2_DatabaseURL">h2DataSource</entry>
+</properties>

--- a/ArjunaJTA/jdbc/tests/classes/com/arjuna/ats/internal/jdbc/recovery/BasicXARecoveryTest.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/arjuna/ats/internal/jdbc/recovery/BasicXARecoveryTest.java
@@ -35,6 +35,7 @@ import java.sql.SQLException;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class BasicXARecoveryTest {
@@ -68,6 +69,17 @@ public class BasicXARecoveryTest {
         assertTrue(bxar.hasMoreResources());
         XAResource xar2 = bxar.getXAResource();
         assertEquals(xar1, xar2);
+    }
 
+    @Test
+    public void testWithNumberOfConnections () throws SQLException, NamingException {
+        BasicXARecovery bxar = new BasicXARecovery();
+        bxar.initialise("h2recovery-multiple-properties.xml;2");
+        assertTrue(bxar.hasMoreResources());
+        XAResource xar1 = bxar.getXAResource();
+        assertTrue(bxar.hasMoreResources());
+        assertTrue(bxar.hasMoreResources());
+        XAResource xar2 = bxar.getXAResource();
+        assertNotEquals(xar1, xar2);
     }
 }


### PR DESCRIPTION
when multiple connections are configured

https://issues.jboss.org/browse/JBTM-3170

MAIN TOMCAT WIN
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !AS_TESTS !JACOCO !LRA
