### PR TITLE
JBTM-3170 Set LRA recovery header on AfterLRA notifications

### DIFF
--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
@@ -331,7 +331,7 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
                 Future<Response> asyncResponse = getAsyncResponse(target, PUT.class.getName(), asyncInvoker, compensatorData, MediaType.WILDCARD);
 
                 // the catch block below catches any Timeout exception
-                Response response = asyncResponse.get(PARTICIPANT_TIMEOUT, TimeUnit.SECONDS);
+                Response response = asyncResponse.get(1000, TimeUnit.SECONDS);
 
                 httpStatus = response.getStatus();
 
@@ -365,6 +365,10 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
             } catch (Exception e) {
                  LRALogger.logger.infof("LRARecord.doEnd put %s failed: %s",
                             target.getUri(), e.getMessage());
+                if (LRALogger.logger.isInfoEnabled()) {
+                    LRALogger.logger.infof("LRARecord.doEnd put %s failed: %s",
+                            target.getUri(), e);
+                }
             } finally {
                 client.close();
             }

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -21,7 +21,8 @@
         <lra.tck.suite.thorntail.trace.params></lra.tck.suite.thorntail.trace.params>
         <lra.tck.suite.debug.params></lra.tck.suite.debug.params> <!-- has content when -Ddebug.tck is specified -->
         <lra.tck.suite.debug.port>8788</lra.tck.suite.debug.port>
-        <lra.tck.consistency.delay>20000</lra.tck.consistency.delay>
+        <lra.tck.consistency.shortDelay>0</lra.tck.consistency.shortDelay>
+        <lra.tck.consistency.longDelay>20000</lra.tck.consistency.longDelay>
 
         <version.org.jboss.weld.se>3.0.3.Final</version.org.jboss.weld.se>
 
@@ -47,7 +48,8 @@
                         <lra.tck.suite.thorntail.trace.params>${lra.tck.suite.thorntail.trace.params}</lra.tck.suite.thorntail.trace.params>
                         <lra.coordinator.port>${lra.coordinator.port}</lra.coordinator.port>
                         <lra.tck.suite.debug.params>${lra.tck.suite.debug.params}</lra.tck.suite.debug.params>
-                        <lra.tck.consistency.delay>${lra.tck.consistency.delay}</lra.tck.consistency.delay>
+                        <lra.tck.consistency.longDelay>${lra.tck.consistency.longDelay}</lra.tck.consistency.longDelay>
+                        <lra.tck.consistency.shortDelay>${lra.tck.consistency.shortDelay}</lra.tck.consistency.shortDelay>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/rts/lra/lra-test/tck/src/test/resources/arquillian-thorntail.xml
+++ b/rts/lra/lra-test/tck/src/test/resources/arquillian-thorntail.xml
@@ -7,7 +7,7 @@
         <configuration>
             <property name="host">localhost</property>
             <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
-            <property name="javaVmArguments">${lra.tck.suite.thorntail.trace.params} ${lra.tck.suite.debug.params} -Dthorntail.http.host=${lra.tck.suite.host} -Dthorntail.http.port=${lra.tck.suite.port} -Dlra.tck.coordinator.hostname=localhost -Dlra.tck.coordinator.port=${lra.coordinator.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port} -Dlra.tck.consistency.delay=${lra.tck.consistency.delay}</property>
+            <property name="javaVmArguments">${lra.tck.suite.thorntail.trace.params} ${lra.tck.suite.debug.params} -Dthorntail.http.host=${lra.tck.suite.host} -Dthorntail.http.port=${lra.tck.suite.port} -Dlra.tck.coordinator.hostname=localhost -Dlra.tck.coordinator.port=${lra.coordinator.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port} -Dlra.tck.consistency.shortDelay=${lra.tck.consistency.shortDelay} -Dlra.tck.consistency.longDelay=${lra.tck.consistency.longDelay}</property>
         </configuration>
     </container>
 </arquillian>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20190811.061210-496</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190811.061212-496</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190812.092710-499</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190812.092711-499</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3170

MAIN !TOMCAT !WIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !AS_TESTS !JACOCO

LRA includes the capability to receive JAX-RS notifications when an LRA is finished but the implementation does not set the "recovery header". This requirement was added in MP-LRA issue https://github.com/eclipse/microprofile-lra/issues/209 with new tests to verify that the recovery header is set correctly.


