### PR TITLE
JBTM-3171 Set recovery header on AfterLRA notifications.

### DIFF
--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -71,6 +71,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.narayana.lra.coordinator.domain.model.LRARecord.PARTICIPANT_TIMEOUT;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
 
 public class Transaction extends AtomicAction {
     private static final String LRA_TYPE = "/StateManager/BasicAction/TwoPhaseCoordinator/LRA";
@@ -79,7 +80,7 @@ public class Transaction extends AtomicAction {
     private URI parentId;
     private String clientId;
     private List<LRARecord> pending;
-    private List<URI> afterLRAListeners;
+    private List<AfterLRAListener> afterLRAListeners;
     private LRAStatus status;
     private String responseData;
     private LocalDateTime startTime;
@@ -152,8 +153,9 @@ public class Transaction extends AtomicAction {
                 os.packInt(0);
             } else {
                 os.packInt(afterLRAListeners.size());
-                for (URI uri : afterLRAListeners) {
-                    os.packString(uri.toASCIIString());
+                for (AfterLRAListener participant : afterLRAListeners) {
+                    os.packString(participant.notificationURI.toASCIIString());
+                    os.packString(participant.recoveryId.toASCIIString());
                 }
             }
         } catch (IOException e) {
@@ -259,7 +261,7 @@ public class Transaction extends AtomicAction {
             } else {
                 afterLRAListeners = new ArrayList<>();
                 for (int i = 0; i < cnt; i++) {
-                    afterLRAListeners.add(new URI(os.unpackString()));
+                    afterLRAListeners.add(new AfterLRAListener(new URI(os.unpackString()), new URI(os.unpackString())));
                 }
             }
 
@@ -389,9 +391,10 @@ public class Transaction extends AtomicAction {
         while ((r = i.iterate()) != null) {
             if (r instanceof LRARecord) {
                 URI endNotification = ((LRARecord) r).getEndNotificationUri();
+                URI recoveryCoordinatorURI = ((LRARecord) r).getRecoveryCoordinatorURI();
 
-                if (endNotification != null) {
-                    afterLRAListeners.add(endNotification);
+                if (endNotification != null && recoveryCoordinatorURI != null) {
+                    afterLRAListeners.add(new AfterLRAListener(endNotification, recoveryCoordinatorURI));
                 }
             }
         }
@@ -828,16 +831,17 @@ public class Transaction extends AtomicAction {
             Client client = ClientBuilder.newClient();
 
             try {
-                Iterator<URI> listeners = afterLRAListeners.iterator();
+                Iterator<AfterLRAListener> listeners = afterLRAListeners.iterator();
 
                 while (listeners.hasNext()) {
-                    URI uri = listeners.next();
+                    AfterLRAListener participant = listeners.next();
                     Response response = null;
 
                     try {
-                        Future<Response> asyncResponse = client.target(uri)
+                        Future<Response> asyncResponse = client.target(participant.notificationURI)
                                 .request()
                                 .header(LRA.LRA_HTTP_ENDED_CONTEXT_HEADER, id)
+                                .header(LRA_HTTP_RECOVERY_HEADER, participant.recoveryId.toASCIIString())
                                 .async()
                                 .put(Entity.text(status.name()));
 
@@ -854,7 +858,7 @@ public class Transaction extends AtomicAction {
                         notifiedAll = false;
 
                         if (LRALogger.logger.isInfoEnabled()) {
-                            LRALogger.logger.infof("Could not notify AfterLRA listener at %s (%s)", uri, e.getMessage());
+                            LRALogger.logger.infof("Could not notify AfterLRA listener at %s (%s)", participant.notificationURI, e.getMessage());
                         }
                     } finally {
                         if (response != null) {
@@ -868,5 +872,15 @@ public class Transaction extends AtomicAction {
         }
 
         return notifiedAll;
+    }
+
+    static class AfterLRAListener {
+        public AfterLRAListener(URI notificationURI, URI recoveryId) {
+            this.notificationURI = notificationURI;
+            this.recoveryId = recoveryId;
+        }
+
+        final URI notificationURI;
+        final URI recoveryId;
     }
 }

--- a/rts/lra/lra-test/tck/pom.xml
+++ b/rts/lra/lra-test/tck/pom.xml
@@ -21,7 +21,8 @@
         <lra.tck.suite.thorntail.trace.params></lra.tck.suite.thorntail.trace.params>
         <lra.tck.suite.debug.params></lra.tck.suite.debug.params> <!-- has content when -Ddebug.tck is specified -->
         <lra.tck.suite.debug.port>8788</lra.tck.suite.debug.port>
-        <lra.tck.consistency.delay>20000</lra.tck.consistency.delay>
+        <lra.tck.consistency.shortDelay>0</lra.tck.consistency.shortDelay>
+        <lra.tck.consistency.longDelay>20000</lra.tck.consistency.longDelay>
 
         <version.org.jboss.weld.se>3.0.3.Final</version.org.jboss.weld.se>
 
@@ -47,7 +48,8 @@
                         <lra.tck.suite.thorntail.trace.params>${lra.tck.suite.thorntail.trace.params}</lra.tck.suite.thorntail.trace.params>
                         <lra.coordinator.port>${lra.coordinator.port}</lra.coordinator.port>
                         <lra.tck.suite.debug.params>${lra.tck.suite.debug.params}</lra.tck.suite.debug.params>
-                        <lra.tck.consistency.delay>${lra.tck.consistency.delay}</lra.tck.consistency.delay>
+                        <lra.tck.consistency.longDelay>${lra.tck.consistency.longDelay}</lra.tck.consistency.longDelay>
+                        <lra.tck.consistency.shortDelay>${lra.tck.consistency.shortDelay}</lra.tck.consistency.shortDelay>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/rts/lra/lra-test/tck/src/test/resources/arquillian-thorntail.xml
+++ b/rts/lra/lra-test/tck/src/test/resources/arquillian-thorntail.xml
@@ -7,7 +7,7 @@
         <configuration>
             <property name="host">localhost</property>
             <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
-            <property name="javaVmArguments">${lra.tck.suite.thorntail.trace.params} ${lra.tck.suite.debug.params} -Dthorntail.http.host=${lra.tck.suite.host} -Dthorntail.http.port=${lra.tck.suite.port} -Dlra.tck.coordinator.hostname=localhost -Dlra.tck.coordinator.port=${lra.coordinator.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port} -Dlra.tck.consistency.delay=${lra.tck.consistency.delay}</property>
+            <property name="javaVmArguments">${lra.tck.suite.thorntail.trace.params} ${lra.tck.suite.debug.params} -Dthorntail.http.host=${lra.tck.suite.host} -Dthorntail.http.port=${lra.tck.suite.port} -Dlra.tck.coordinator.hostname=localhost -Dlra.tck.coordinator.port=${lra.coordinator.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port} -Dlra.tck.consistency.shortDelay=${lra.tck.consistency.shortDelay} -Dlra.tck.consistency.longDelay=${lra.tck.consistency.longDelay}</property>
         </configuration>
     </container>
 </arquillian>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20190812.092710-499</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190812.092711-499</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-RC1</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-RC1</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -138,13 +138,13 @@
     </build>
 
     <modules>
+        <module>lra-service-base</module>
         <module>lra-client</module>
         <module>lra-coordinator</module>
         <module>lra-filters</module>
         <module>lra-proxy</module>
         <module>lra-annotation-checker</module>
         <module>lra-test</module>
-        <module>lra-service-base</module>
     </modules>
 
     <profiles>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20190811.061210-496</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20190811.061212-496</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20190812.092710-499</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20190812.092711-499</version.microprofile.lra.tck>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3171

MAIN !TOMCAT !WIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !AS_TESTS !JACOCO

LRA includes the capability to receive JAX-RS notifications when an LRA is finished but the implementation does not set the "recovery header". This requirement was added in MP-LRA issue eclipse/microprofile-lra#209 with new tests to verify that the recovery header is set correctly.

The PR also updates the implementation to use the new name for MP-LRA config properties (that replace lra.tck.consistency.delay)
