### PR TITLE
JBTM-3082 Wrong LRA status reported when it is Closing

### DIFF
--- a/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -477,7 +477,7 @@ public class Transaction extends AtomicAction {
         }
 
         if (getSize(heuristicList) != 0 || getSize(failedList) != 0) {
-            status = LRAStatus.Cancelling;
+            status = compensate ? LRAStatus.Cancelling : LRAStatus.Closing;
         } else if (getSize(pendingList) != 0 || getSize(preparedList) != 0) {
             status = LRAStatus.Closing;
         } else {

--- a/rts/lra/lra-test/basic/src/test/java/io/narayana/lra/arquillian/resource/TestLRAParticipant.java
+++ b/rts/lra/lra-test/basic/src/test/java/io/narayana/lra/arquillian/resource/TestLRAParticipant.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+@Path("/participant")
+public class TestLRAParticipant {
+    @PUT
+    @Path("/compensate")
+    @Compensate
+    public Response compensate(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.status(Response.Status.ACCEPTED).build();
+    }
+
+    @PUT
+    @Path("/complete")
+    @Complete
+    public Response complete(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.status(Response.Status.ACCEPTED).build();
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3116

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS

If an LRA is closing (due to a participant report 202 Accepted when asked to complete) then the current implementation returns the wrong status (Cancelling instead of Closing). This PR reports the status correctly.