### PR TITLE
[JBTM-3181] updating pom.xml for the lra-proxy-api to be released on nexus

### DIFF
--- a/rts/lra/lra-annotation-checker/pom.xml
+++ b/rts/lra/lra-annotation-checker/pom.xml
@@ -34,12 +34,6 @@
                     </mojoDependencies>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <inherited>false</inherited>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 
@@ -95,6 +89,11 @@
             <id>release</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <inherited>false</inherited>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-install-plugin</artifactId>

--- a/rts/lra/lra-client/pom.xml
+++ b/rts/lra/lra-client/pom.xml
@@ -21,13 +21,6 @@
 
     <build>
       <finalName>lra-client</finalName>
-      <plugins>
-        <plugin>
-          <inherited>false</inherited>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-        </plugin>
-      </plugins>
     </build>
 
     <dependencies>
@@ -78,6 +71,11 @@
           <id>release</id>
           <build>
               <plugins>
+                <plugin>
+                  <inherited>false</inherited>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                </plugin>
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-install-plugin</artifactId>

--- a/rts/lra/lra-coordinator/pom.xml
+++ b/rts/lra/lra-coordinator/pom.xml
@@ -22,11 +22,6 @@
     <build>
         <finalName>lra-coordinator</finalName>
         <plugins>
-          <plugin>
-            <inherited>false</inherited>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-          </plugin>
             <plugin>
                 <groupId>io.thorntail</groupId>
                 <artifactId>thorntail-maven-plugin</artifactId>
@@ -87,6 +82,11 @@
           <id>release</id>
           <build>
               <plugins>
+                <plugin>
+                  <inherited>false</inherited>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                </plugin>
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-install-plugin</artifactId>

--- a/rts/lra/lra-proxy/api/pom.xml
+++ b/rts/lra/lra-proxy/api/pom.xml
@@ -100,6 +100,11 @@
           <build>
               <plugins>
                 <plugin>
+                  <inherited>false</inherited>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-install-plugin</artifactId>
                   <executions>

--- a/rts/lra/lra-proxy/pom.xml
+++ b/rts/lra/lra-proxy/pom.xml
@@ -30,6 +30,11 @@
           <build>
               <plugins>
                 <plugin>
+                  <inherited>false</inherited>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                </plugin>
+                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-install-plugin</artifactId>
                   <executions>

--- a/rts/lra/lra-service-base/pom.xml
+++ b/rts/lra/lra-service-base/pom.xml
@@ -34,13 +34,6 @@
   
   <build>
     <finalName>${project.artifactId}</finalName>
-    <plugins>
-      <plugin>
-        <inherited>false</inherited>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
   
   <profiles>
@@ -48,6 +41,11 @@
         <id>release</id>
         <build>
             <plugins>
+              <plugin>
+                <inherited>false</inherited>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+              </plugin>
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>

--- a/rts/lra/narayana-lra/pom.xml
+++ b/rts/lra/narayana-lra/pom.xml
@@ -14,16 +14,6 @@
     <name>Narayana LRA</name>
     <packaging>jar</packaging>
 
-    <build>
-      <plugins>
-        <plugin>
-          <inherited>false</inherited>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-        </plugin>
-      </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
@@ -66,6 +56,11 @@
           <id>release</id>
           <build>
               <plugins>
+                <plugin>
+                  <inherited>false</inherited>
+                  <groupId>org.sonatype.plugins</groupId>
+                  <artifactId>nexus-staging-maven-plugin</artifactId>
+                </plugin>
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3181

as the `nexus-staging-maven-plugin` was not forgotten for the release profiles few times already I moved them to the profile in all lra pom.xml. For being obvious they are essential part for the `release` profile.

MAIN LRA
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
