### PR TITLE
[JBTM-3185] updating use of jandex version for narayana-jta cdi

### DIFF
--- a/ArjunaJTA/cdi/pom.xml
+++ b/ArjunaJTA/cdi/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
         <executions>
           <execution>
             <id>make-index</id>

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
     <version.com.github.spotbugs.spotbugs-maven-plugin>3.1.10</version.com.github.spotbugs.spotbugs-maven-plugin>
     <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
     <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
-    <version.org.jboss.jandex>1.1.0.Final</version.org.jboss.jandex>
+    <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
     <version.rhino.js>1.7R2</version.rhino.js>
     <version.org.jboss.logmanager>1.5.1.Final</version.org.jboss.logmanager>
     <version.org.jboss.logging.jboss-logging>3.2.1.Final</version.org.jboss.logging.jboss-logging>

--- a/rts/lra/lra-proxy/api/pom.xml
+++ b/rts/lra/lra-proxy/api/pom.xml
@@ -22,7 +22,6 @@
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <narayana.nodename.property>CoreEnvironmentBean.nodeIdentifier</narayana.nodename.property>
-        <version.jandex>2.1.1.Final</version.jandex>
     </properties>
 
     <build>
@@ -53,7 +52,7 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
-            <version>${version.jandex}</version>
+            <version>${version.org.jboss.jandex}</version>
         </dependency>
         <!-- jboss logging -->
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3185

Update for jandex index version used at ARjunaJTA/cdi.

MAIN WIN LRA AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !TOMCAT !JACOCO
