### PR TITLE
JBTM-3195 Don't assert before all the threads return

### DIFF
--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/objectstore/CachedTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/objectstore/CachedTest.java
@@ -114,16 +114,20 @@ public class CachedTest
             t[i].start();
         }
 
+        boolean passed = true;
         for (int j = 0; j < threads; j++) {
             System.err.println("j: "+j);
             t[j].join();
-            assertTrue(((ThreadWriter) t[j]).passed);
+            passed = passed && ((ThreadWriter) t[j]).passed;
         }
 
         long ftime = Calendar.getInstance().getTime().getTime();
         long timeTaken = ftime - stime;
 
         store.sync();
+        
+        
+        assertTrue(passed);
 
         System.err.println("time for " + threads + " users is " + timeTaken);
     }


### PR DESCRIPTION
A test correction for https://issues.jboss.org/browse/JBTM-3195 but the underlying issue still needs investigation

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS !LRA