### PR TITLE
JBTM-3189 Cancel LRAs as soon as their timeLimit is reached

### DIFF
--- a/narayana-full/src/main/assembly/bin.xml
+++ b/narayana-full/src/main/assembly/bin.xml
@@ -212,6 +212,11 @@
 			<fileMode>0644</fileMode>
 			<outputDirectory>rts/lra/</outputDirectory>
 		</file>
+		<file>
+			<source>../rts/lra/lra-coordinator-thorntail/target/lra-coordinator-thorntail.jar</source>
+			<fileMode>0644</fileMode>
+			<outputDirectory>rts/lra/</outputDirectory>
+		</file>
 	</files>
 	<fileSets>
 		<fileSet>

--- a/rts/lra/lra-annotation-checker/pom.xml
+++ b/rts/lra/lra-annotation-checker/pom.xml
@@ -71,8 +71,8 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>${version.jaxrs.api}</version>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>${version.jaxrs-api}</version>
         </dependency>
 
         <!-- Tests -->

--- a/rts/lra/lra-client/pom.xml
+++ b/rts/lra/lra-client/pom.xml
@@ -57,13 +57,6 @@
             <version>2.5</version>
             <scope>provided</scope>
         </dependency>
-        <!-- JAXRS 2 Client API -->
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>${version.jaxrs.api}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/rts/lra/lra-coordinator-jar/pom.xml
+++ b/rts/lra/lra-coordinator-jar/pom.xml
@@ -62,18 +62,6 @@
                  </exclusion>
              </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-rest-client</artifactId>
-            <version>1.2.2</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>resteasy-jaxrs</artifactId>
-                    <groupId>org.jboss.resteasy</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/rts/lra/lra-coordinator-thorntail/pom.xml
+++ b/rts/lra/lra-coordinator-thorntail/pom.xml
@@ -9,10 +9,44 @@
 
     <artifactId>lra-coordinator-thorntail</artifactId>
     <name>Thorntail LRA Coordinator</name>
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
+
+    <properties>
+        <thorntail.http.port>8080</thorntail.http.port>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <build>
         <finalName>lra-coordinator</finalName>
+        <plugins>
+            <plugin>
+                <groupId>io.thorntail</groupId>
+                <artifactId>thorntail-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <environment>
+                        <thorntail.http.port>${thorntail.http.port}</thorntail.http.port>
+                    </environment>
+                    <properties>
+                        <lra.http.port>${thorntail.http.port}</lra.http.port>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>

--- a/rts/lra/lra-proxy/api/pom.xml
+++ b/rts/lra/lra-proxy/api/pom.xml
@@ -41,13 +41,6 @@
             <version>2.5</version>
             <scope>provided</scope>
         </dependency>
-        <!-- JAXRS 2 Client API -->
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>${version.jaxrs.api}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- jandex -->
         <dependency>
             <groupId>org.jboss</groupId>

--- a/rts/lra/lra-proxy/test/pom.xml
+++ b/rts/lra/lra-proxy/test/pom.xml
@@ -80,8 +80,8 @@
         <!-- JAXRS 2 Client API -->
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>${version.jaxrs.api}</version>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>${version.jaxrs-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rts/lra/lra-service-base/pom.xml
+++ b/rts/lra/lra-service-base/pom.xml
@@ -18,7 +18,13 @@
       <artifactId>microprofile-lra-api</artifactId>
       <version>${version.microprofile.lra.api}</version>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${version.apache.httpclient}</version>
+    </dependency>
+
     <!-- jboss logging -->
     <dependency>
       <groupId>org.jboss.logging</groupId>

--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/LRAHttpClient.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/LRAHttpClient.java
@@ -1,0 +1,66 @@
+package io.narayana.lra;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.FutureRequestExecutionService;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpRequestFutureTask;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class LRAHttpClient {
+    public static final long PARTICIPANT_TIMEOUT = 1; // number of seconds to wait for requests
+
+    private static LRAHttpClient client = new LRAHttpClient();
+
+    private FutureRequestExecutionService futureRequestExecutionService;
+
+    private LRAHttpClient() {
+        HttpClient httpClient = HttpClientBuilder.create().setMaxConnPerRoute(5).build();
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+
+        futureRequestExecutionService = new FutureRequestExecutionService(httpClient, executorService);
+    }
+
+    public static LRAHttpClient getClient() {
+        return client;
+    }
+
+    ResponseHolder request(HttpRequestBase httpMethod, long timelimit, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        HttpRequestFutureTask<ResponseHolder> futureTask = submitFutureTask(httpMethod);
+
+        // if any user wants this method to be async return the future.
+        // For now the current users are okay to block (but not indefinitely).
+        return futureTask.get(timelimit, unit);
+    }
+
+    public ResponseHolder request(HttpRequestBase httpMethod) throws IOException {
+        return submitTask(httpMethod);
+    }
+
+    private ResponseHolder submitTask(HttpRequestBase httpMethod) throws IOException {
+        CloseableHttpClient client = HttpClients.createDefault();
+
+        CloseableHttpResponse httpResponse = client.execute(httpMethod);
+
+        return new ResponseHolder(httpMethod, httpResponse);
+    }
+
+    private HttpRequestFutureTask<ResponseHolder> submitFutureTask(HttpRequestBase httpMethod) {//throws InterruptedException, ExecutionException {
+        ResponseHandler<ResponseHolder> responseHandler = httpResponse -> new ResponseHolder(httpMethod, httpResponse);
+
+        return futureRequestExecutionService.execute(
+                httpMethod, HttpClientContext.create(),
+                responseHandler);
+    }
+}

--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/RequestBuilder.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/RequestBuilder.java
@@ -1,0 +1,168 @@
+package io.narayana.lra;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.protocol.HTTP;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class RequestBuilder {
+    private HttpRequestBase httpRequest;
+    private ArrayList<String> paths;
+
+    private URIBuilder builder;
+    private boolean async;
+    private long timeout;
+    private TimeUnit timeUnit;
+
+    public RequestBuilder(URI baseURI) {
+        builder = new URIBuilder(baseURI);
+        paths = new ArrayList<>();
+
+        Collections.addAll(paths, strip(baseURI.getPath()).split("/"));
+    }
+
+    private String strip(String path) {
+        return path.replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+
+    public RequestBuilder path(String path) {
+        Collections.addAll(paths, strip(path).split("/"));
+
+        return this;
+    }
+
+    public RequestBuilder queryParam(String name, long value) {
+        builder.setParameter(name, Long.toString(value));
+        return this;
+    }
+
+    public RequestBuilder queryParam(String name, String value) {
+        builder.setParameter(name, value);
+        return this;
+    }
+
+    public RequestBuilder queryParam(String name, boolean value) {
+        builder.setParameter(name, Boolean.toString(value));
+        return this;
+    }
+
+    /**
+     * create a request. This method must be called before adding
+     * request headers
+     * @return the builder
+     */
+    public RequestBuilder request() {
+        builder.setPathSegments(paths);
+
+        httpRequest = new HttpGet();
+        return this;
+    }
+
+    /**
+     * add a request header. Must be called after calling {@link RequestBuilder#request()}
+     * @param name the name of the header
+     * @param value the header value
+     * @return the builder
+     */
+    public RequestBuilder header(String name, String value) {
+        httpRequest.addHeader(name, value);
+        return this;
+    }
+
+    /**
+     * add a request header. Must be called after calling {@link RequestBuilder#request()}
+     * @param name the name of the header
+     * @param value the header value
+     * @return the builder
+     */
+    public RequestBuilder header(String name, URI value) {
+        httpRequest.addHeader(name, value == null ? null : value.toASCIIString());
+        return this;
+    }
+
+    public RequestBuilder async(long timeout, TimeUnit timeUnit) {
+        this.async = true;
+        this.timeout = timeout;
+        this.timeUnit = timeUnit;
+        return this;
+    }
+
+    private HttpRequestBase setContent(HttpEntityEnclosingRequestBase req, String content, String mediaType) {
+        if (content != null) {
+            if (!mediaType.equals(MediaType.TEXT_PLAIN)) {
+                throw new IllegalArgumentException("RequestBuilder: the only supported content type is " + mediaType);
+            }
+            req.setEntity(new StringEntity(content, HTTP.DEF_CONTENT_CHARSET));
+        }
+
+        return req;
+    }
+
+    private URI build() {
+        try {
+            return builder.build();
+        } catch (URISyntaxException e) {
+            throw new WebApplicationException(e);
+        }
+    }
+
+    public ResponseHolder put() throws WebApplicationException {
+        return send(setContent(new HttpPut(build()), "", ContentType.TEXT_PLAIN.getMimeType()));
+    }
+
+    public ResponseHolder put(String content, String mediaType) throws WebApplicationException {
+        return send(setContent(new HttpPut(build()), content, mediaType));
+    }
+
+    public ResponseHolder post() throws WebApplicationException {
+        return send(setContent(new HttpPost(build()), "", ContentType.TEXT_PLAIN.getMimeType()));
+    }
+
+    public ResponseHolder get() throws WebApplicationException {
+        try {
+            return send(new HttpGet(builder.build()));
+        } catch (URISyntaxException e) {
+            throw new WebApplicationException(e);
+        }
+    }
+
+    public ResponseHolder delete() throws WebApplicationException {
+        try {
+            return send(new HttpDelete(builder.build()));
+        } catch (URISyntaxException e) {
+            throw new WebApplicationException(e);
+        }
+    }
+
+    private ResponseHolder send(HttpRequestBase req) throws WebApplicationException {
+        for (Header header : httpRequest.getAllHeaders()) {
+            req.addHeader(header);
+        }
+
+        LRAHttpClient httpClient = LRAHttpClient.getClient();
+
+        try {
+            return async ? httpClient.request(req, timeout, timeUnit) : httpClient.request(req);
+        } catch (InterruptedException | ExecutionException | TimeoutException | IOException e) {
+            throw new WebApplicationException(e);
+        }
+    }
+}

--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/ResponseHolder.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/ResponseHolder.java
@@ -1,0 +1,72 @@
+package io.narayana.lra;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.util.EntityUtils;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ResponseHolder {
+    private HttpRequestBase httpRequest;
+    private HttpResponse httpResponse;
+    private int status;
+    private String locationHeader;
+    private String responseString;
+
+    public ResponseHolder(HttpRequestBase httpRequest, HttpResponse httpResponse) {
+        this.httpRequest = httpRequest;
+        this.httpResponse = httpResponse;
+        status = httpResponse.getStatusLine().getStatusCode();
+        Header h = httpResponse.getFirstHeader(HttpHeaders.LOCATION);
+        locationHeader = h == null ? null : h.getValue();
+        HttpEntity entity = httpResponse.getEntity();
+        try {
+            responseString = entity != null ? EntityUtils.toString(entity, "UTF-8") : null;
+        } catch (IOException e) {
+            responseString = null;
+        }
+    }
+
+    public URI getRequestURI() {
+        return httpRequest.getURI();
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getLocationHeader() {
+        return locationHeader;
+    }
+
+    public String getResponseString() {
+        return responseString;
+    }
+
+    public URI getLocationHeaderAsURI() throws URISyntaxException {
+        return locationHeader != null ? new URI(locationHeader) : null;
+    }
+
+    public boolean hasEntity() {
+        return responseString != null;
+    }
+
+    public String getLastHeader(String headerName) {
+        return httpResponse.getLastHeader(headerName).getValue();
+    }
+
+    public String readEntity() {
+        return responseString;
+    }
+
+    public String getHeader(String name) {
+        Header header = httpResponse.getLastHeader(name);
+
+        return header == null ? null : header.getValue();
+    }
+}

--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -32,7 +32,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import javax.json.JsonObject;
-import javax.ws.rs.core.Response;
 
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -57,15 +56,15 @@ public interface lraI18NLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 25002, value = "LRA created with an unexpected status code: %d, coordinator response '%s'")
-    void error_lraCreationUnexpectedStatus(int status, Response response);
+    void error_lraCreationUnexpectedStatus(int status, String response);
 
     @LogMessage(level = ERROR)
     @Message(id = 25003, value = "LRA is null on creation, coordinator response '%s'")
-    void error_nullLraOnCreation(Response response);
+    void error_nullLraOnCreation(String response);
 
     @LogMessage(level = ERROR)
     @Message(id = 25004, value = "Cannot create URL from coordinator response '%s'")
-    void error_cannotCreateUrlFromLCoordinatorResponse(Response response, @Cause Throwable t);
+    void error_cannotCreateUrlFromLCoordinatorResponse(String response, @Cause Throwable t);
 
     @LogMessage(level = ERROR)
     @Message(id = 25005, value = "Error on contacting the LRA coordinator '%s'")
@@ -73,11 +72,11 @@ public interface lraI18NLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 25006, value = "LRA renewal ends with an unexpected status code: %d, coordinator response '%s'")
-    void error_lraRenewalUnexpectedStatus(int status, Response response);
+    void error_lraRenewalUnexpectedStatus(int status, String response);
 
     @LogMessage(level = ERROR)
     @Message(id = 25007, value = "Leaving LRA ends with an unexpected status code: %d, coordinator response '%s'")
-    void error_lraLeaveUnexpectedStatus(int status, Response response);
+    void error_lraLeaveUnexpectedStatus(int status, String response);
 
     @LogMessage(level = WARN)
     @Message(id = 25008, value = "JAX-RS @Suspended annotation is untested")
@@ -89,7 +88,7 @@ public interface lraI18NLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 25010, value = "LRA finished with an unexpected status code: %d, coordinator response '%s'")
-    void error_lraTerminationUnexpectedStatus(int status, Response response);
+    void error_lraTerminationUnexpectedStatus(int status, String response);
 
     @LogMessage(level = ERROR)
     @Message(id = 25011, value = "Cannot access coordinator '%s' when getting status for LRA '%s'")
@@ -109,7 +108,7 @@ public interface lraI18NLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 25015, value = "Too late to join with the LRA '%s', coordinator response: '%s'")
-    void error_tooLateToJoin(URL lra, Response response);
+    void error_tooLateToJoin(URL lra, String response);
 
     @LogMessage(level = ERROR)
     @Message(id = 25016, value = "Failed enlisting to LRA '%s', coordinator '%s' responded with status '%s'")

--- a/rts/lra/lra-test/lra-test-arquillian-extension/pom.xml
+++ b/rts/lra/lra-test/lra-test-arquillian-extension/pom.xml
@@ -37,11 +37,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.thorntail</groupId>
-      <artifactId>arquillian</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
     </dependency>

--- a/rts/lra/lra-test/lra-test-arquillian-extension/src/main/java/io/narayana/lra/arquillian/ConfigAuxiliaryArchiveAppender.java
+++ b/rts/lra/lra-test/lra-test-arquillian-extension/src/main/java/io/narayana/lra/arquillian/ConfigAuxiliaryArchiveAppender.java
@@ -44,6 +44,7 @@ public class ConfigAuxiliaryArchiveAppender implements AuxiliaryArchiveAppender 
         // adding Narayana LRA implementation under the Thorntail deployment
         archive.addPackages(true, io.narayana.lra.client.NarayanaLRAClient.class.getPackage())
                 .addPackages(true, io.narayana.lra.Current.class.getPackage())
+                .addPackages(true, org.apache.http.HttpEntity.class.getPackage())
                 .addPackage(LRACDIExtension.class.getPackage())
                 .addAsResource("META-INF/services/javax.enterprise.inject.spi.Extension")
                 .addClass(org.jboss.weld.exceptions.DefinitionException.class)

--- a/rts/lra/lra-test/lra-test-basic/pom.xml
+++ b/rts/lra/lra-test/lra-test-basic/pom.xml
@@ -33,7 +33,13 @@
       <version>${version.thorntail}</version>
       <scope>test</scope>
     </dependency>
-    
+ 
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${version.apache.httpclient}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.jboss.narayana.rts</groupId>
       <artifactId>lra-test-arquillian-extension</artifactId>

--- a/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/NonRootLRAParticipantIT.java
+++ b/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/NonRootLRAParticipantIT.java
@@ -59,11 +59,11 @@ public class NonRootLRAParticipantIT {
     public void testNonRootLRAParticipantEnlist() {
         Client client = ClientBuilder.newClient();
 
-        Response response = client.target(baseURL.toExternalForm() + "/root/participant/lra").request().get();
+        Response response = client.target(baseURL.toExternalForm() + "root/participant/lra").request().get();
 
         Assert.assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), response.getStatus());
 
-        response = client.target(baseURL.toExternalForm() + "/root/participant/counter").request().get();
+        response = client.target(baseURL.toExternalForm() + "root/participant/counter").request().get();
         Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         int counterValue = response.readEntity(Integer.class);
         Assert.assertEquals("Non root JAX-RS participant should have been enlisted and invoked",

--- a/rts/lra/lra-test/lra-test-basic/src/test/resources/arquillian-thorntail.xml
+++ b/rts/lra/lra-test/lra-test-basic/src/test/resources/arquillian-thorntail.xml
@@ -7,7 +7,7 @@
         <configuration>
             <property name="host">localhost</property>
             <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
-            <property name="javaVmArguments">-Dthorntail.http.host=${application.host} -Dthorntail.http.port=${application.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port}</property>
+            <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n -Dthorntail.http.host=${application.host} -Dthorntail.http.port=${application.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port}</property>
         </configuration>
     </container>
 </arquillian>

--- a/rts/lra/lra-test/lra-test-tck/pom.xml
+++ b/rts/lra/lra-test/lra-test-tck/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>lra-test-arquillian-extension</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${version.apache.httpclient}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/rts/lra/narayana-lra/pom.xml
+++ b/rts/lra/narayana-lra/pom.xml
@@ -21,6 +21,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+           <groupId>org.apache.httpcomponents</groupId>
+           <artifactId>httpclient</artifactId>
+           <version>${version.apache.httpclient}</version>
+         </dependency>
+
+        <dependency>
           <groupId>org.jboss.narayana.rts</groupId>
           <artifactId>lra-proxy-api</artifactId>
           <version>${project.version}</version>
@@ -35,12 +41,6 @@
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <version>${version.cdi-api}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>${version.jaxrs.api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -21,7 +21,8 @@
         <version.jackson>2.8.11.2</version.jackson>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
-        <version.jaxrs-api>2.1</version.jaxrs-api>
+        <version.jaxrs-api>1.0.3.Final</version.jaxrs-api>
+        <version.apache.httpclient>4.5.10</version.apache.httpclient>
         <version.cdi-api>2.0</version.cdi-api>
         <version.junit>4.12</version.junit>
 
@@ -74,6 +75,12 @@
             <version>1.0.3.Final</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <version>1.0.3.Final</version>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3189
https://issues.jboss.org/browse/JBTM-3211

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS !MAIN

The ultimate fix could be to wait for Java 11 HttpClient but this PR uses something similar (it replaces RestEasy client with Apache HttpClient). NB the coordinator uses an http client to contact participants and the server JAX-RS filter uses it to contact a coordinator.