### PR TITLE
JBTM-3210 recovery listener to not being stuck

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -502,7 +502,7 @@ public class BasicAction extends StateManager
         }
         catch (ObjectStoreException e)
         {
-            tsLogger.logger.warn(e);
+            tsLogger.i18NLogger.warn_could_not_activate_type_at_object_store(type(), aaStore, e);
 
             return false;
         }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -27,12 +27,16 @@ import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT;
 
+import java.net.ServerSocket;
+import java.net.Socket;
+
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.objectstore.ParticipantStore;
 
 /**
  * i18n log messages for the arjuna module.
@@ -1576,6 +1580,17 @@ public interface arjunaI18NLogger {
 	@LogMessage(level = WARN)
     public void warn_not_asyncIO();
 
+    @Message(id = 12394, value = "Could not close transaction listener server socket ''{0}''", format = MESSAGE_FORMAT)
+    @LogMessage(level = WARN)
+    public void warn_could_not_close_transaction_listener_socket(ServerSocket ss, @Cause Throwable exception);
+
+    @Message(id = 12395, value = "Could not close transaction listener socket connection ''{0}''", format = MESSAGE_FORMAT)
+    @LogMessage(level = WARN)
+    public void warn_could_not_close_transaction_listener_connection(Socket ss, @Cause Throwable exception);
+
+    @Message(id = 12396, value = "Cannot activate type ''{0}'' at object store ''{1}''", format = MESSAGE_FORMAT)
+    @LogMessage(level = WARN)
+    public void warn_could_not_activate_type_at_object_store(String type, ParticipantStore store, @Cause Throwable exception);
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/SubordinateAtomicActionRecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/SubordinateAtomicActionRecoveryModule.java
@@ -79,7 +79,7 @@ public class SubordinateAtomicActionRecoveryModule implements RecoveryModule {
                 }
             }
             recoveryScanCompletedWithoutError = true;
-        } catch (ObjectStoreException | XAException | IOException e) {
+        } catch (Exception e) {
             jtaLogger.i18NLogger.warn_could_not_recover_subordinate(uid, e);
             recoveryScanCompletedWithoutError = false;
         }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/TransactionImporterImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/TransactionImporterImple.java
@@ -95,8 +95,9 @@ public class TransactionImporterImple implements TransactionImporter
 	public TransactionImportResult importRemoteTransaction(Xid xid, int timeout)
 			throws XAException
 	{
-		if (xid == null)
-			throw new IllegalArgumentException();
+		if (xid == null) {
+			throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_imported_transaction_uid_is_null());
+		}
 
 		/*
 		 * the imported transaction map is keyed by xid and the xid used is the one created inside
@@ -118,13 +119,15 @@ public class TransactionImporterImple implements TransactionImporter
 	public TransactionImple recoverTransaction(Uid actId)
 			throws XAException
 	{
-		if (actId == null)
-			throw new IllegalArgumentException();
+		if (actId == null) {
+			throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_imported_transaction_uid_is_null());
+		}
 
 		TransactionImple recovered = new TransactionImple(actId);
 
-		if (recovered.baseXid() == null)
-		    throw new IllegalArgumentException();
+		if (recovered.baseXid() == null) {
+		    throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_imported_transaction_base_id_is_null(actId, recovered));
+		}
 		
 		/*
 		 * Is the transaction already in the map? This may be the case because
@@ -156,8 +159,9 @@ public class TransactionImporterImple implements TransactionImporter
 	public SubordinateTransaction getImportedTransaction(Xid xid)
 			throws XAException
 	{
-		if (xid == null)
-			throw new IllegalArgumentException();
+		if (xid == null) {
+			throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_xid_is_null());
+		}
 
 		AtomicReference<TransactionImple> holder = _transactions.get(new SubordinateXidImple(xid));
 		TransactionImple tx = holder == null ? null : holder.get();
@@ -204,8 +208,9 @@ public class TransactionImporterImple implements TransactionImporter
 
 	public void removeImportedTransaction(Xid xid) throws XAException
 	{
-		if (xid == null)
-			throw new IllegalArgumentException();
+		if (xid == null) {
+			throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_xid_is_null());
+		}
 
         AtomicReference<TransactionImple> remove = _transactions.remove(new SubordinateXidImple(xid));
         if (remove != null) {

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/TransactionImporterImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/TransactionImporterImple.java
@@ -96,7 +96,7 @@ public class TransactionImporterImple implements TransactionImporter
 			throws XAException
 	{
 		if (xid == null) {
-			throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_imported_transaction_uid_is_null());
+			throw new IllegalArgumentException(jtaLogger.i18NLogger.get_error_xid_is_null());
 		}
 
 		/*

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/jca/SubordinateAtomicAction.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/jca/SubordinateAtomicAction.java
@@ -41,6 +41,7 @@ import com.arjuna.ats.arjuna.state.OutputObjectState;
 import com.arjuna.ats.arjuna.utils.Utility;
 import com.arjuna.ats.internal.arjuna.Header;
 import com.arjuna.ats.internal.jta.xa.XID;
+import com.arjuna.ats.jta.logging.jtaLogger;
 import com.arjuna.ats.jta.xa.XATxConverter;
 import com.arjuna.ats.jta.xa.XidImple;
 
@@ -206,6 +207,9 @@ public class SubordinateAtomicAction extends
 		}
 		catch (IOException ex)
 		{
+		    if (jtaLogger.logger.isDebugEnabled()) {
+		        jtaLogger.logger.debugf(ex, "Cannot restrote state for type %s and action %s", getType(), this.toString());
+		    }
 			return false;
 		}
 		

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -591,6 +591,15 @@ public interface jtaI18NLogger {
             + "Recovery is won''t able to decide about outcome. Transaction is marked as heuristic to be decided by administrator.", format = MESSAGE_FORMAT)
     String get_onephase_heuristic_commit_failure(StateManager action);
 
+    @Message(id = 16146, value = "Cannot work with the imported transaction as UID is null.", format = MESSAGE_FORMAT)
+    String get_error_imported_transaction_uid_is_null();
+
+    @Message(id = 16147, value = "Cannot recover imported transaction of UID ''{0}'' of transaction ''{1}'' as transaction base Xid is null.", format = MESSAGE_FORMAT)
+    String get_error_imported_transaction_base_id_is_null(Uid uid, javax.transaction.Transaction txn);
+
+    @Message(id = 16148, value = "Cannot work further as the argument Xid is null.", format = MESSAGE_FORMAT)
+    String get_error_xid_is_null();
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in sequence. Don't reuse ids.


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3210
Backport of master PR: https://github.com/jbosstm/narayana/pull/1514

Not being stuck with IllegalArgument exception during recovery and closing recovery listener connection when there is no plan of processing it.

MAIN XTS AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA