### PR TITLE
JBTM-3219 Upgrade resteasy dependency and harmonise versions between …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
     <version.org.jboss.integration>6.0.0.CR1</version.org.jboss.integration>
     <version.org.jboss.ironjacamar>1.1.1.Final</version.org.jboss.ironjacamar>
     <version.org.jboss.ws>1.0.2.Final</version.org.jboss.ws>
-    <version.org.jboss.resteasy>3.1.0.Beta1</version.org.jboss.resteasy>
+    <version.org.jboss.resteasy>3.9.1.Final</version.org.jboss.resteasy>
     <version.org.jboss.weld>2.3.5.Final</version.org.jboss.weld>
     <version.org.apache.activemq>2.9.0</version.org.apache.activemq>
     <version.org.hibernate.javax.persistence>1.0.1.Final</version.org.hibernate.javax.persistence>
@@ -475,7 +475,7 @@
     <version.asm>3.3.1</version.asm>
     <version.com.sun.jersey>1.9.1</version.com.sun.jersey>
     <version.com.sun.grizzly>1.9.59</version.com.sun.grizzly>
-    <version.org.codehaus.jettison>1.3.4</version.org.codehaus.jettison>
+    <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
     <version.junit>4.11</version.junit>
     <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
     <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
@@ -486,7 +486,7 @@
     <version.org.jboss.shrinkwrap.resolver>2.2.2</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
-    <version.javax.ws.rs-api>2.0.1</version.javax.ws.rs-api>
+    <version.javax.ws.rs-api>2.0.1.Final</version.javax.ws.rs-api>
     <version.org.mockito>2.5.3</version.org.mockito>
     <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
     <version.com.github.docker-java>3.0.14</version.com.github.docker-java>

--- a/rts/at/bridge/pom.xml
+++ b/rts/at/bridge/pom.xml
@@ -68,8 +68,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
             <version>${version.javax.ws.rs-api}</version>
             <scope>provided</scope>
         </dependency>

--- a/rts/at/integration/pom.xml
+++ b/rts/at/integration/pom.xml
@@ -57,8 +57,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
             <version>${version.javax.ws.rs-api}</version>
             <scope>provided</scope>
         </dependency>
@@ -104,6 +104,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${version.org.jboss.resteasy}</version>
+        </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>

--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -200,12 +200,6 @@
     </dependency>
     <dependency>
         <groupId>org.jboss.resteasy</groupId>
-        <artifactId>async-http-servlet-3.0</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-undertow</artifactId>
         <version>${version.org.jboss.resteasy}</version>
         <scope>test</scope>

--- a/rts/at/util/pom.xml
+++ b/rts/at/util/pom.xml
@@ -66,8 +66,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <version>${version.javax.ws.rs-api}</version>
       <scope>provided</scope>
     </dependency>

--- a/rts/lra/lra-annotation-checker/pom.xml
+++ b/rts/lra/lra-annotation-checker/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>${version.jaxrs-api}</version>
+            <version>${version.javax.ws.rs-api}</version>
         </dependency>
 
         <!-- Tests -->

--- a/rts/lra/lra-proxy/test/pom.xml
+++ b/rts/lra/lra-proxy/test/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>${version.jaxrs-api}</version>
+            <version>${version.javax.ws.rs-api}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rts/lra/lra-test/lra-test-tck/pom.xml
+++ b/rts/lra/lra-test/lra-test-tck/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy}</version>
+            <version>${version.org.jboss.resteasy}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>

--- a/rts/lra/lra-test/pom.xml
+++ b/rts/lra/lra-test/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy}</version>
+            <version>${version.org.jboss.resteasy}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -21,7 +21,6 @@
         <version.jackson>2.8.11.2</version.jackson>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
-        <version.jaxrs-api>1.0.3.Final</version.jaxrs-api>
         <version.apache.httpclient>4.5.10</version.apache.httpclient>
         <version.cdi-api>2.0</version.cdi-api>
         <version.junit>4.12</version.junit>
@@ -78,7 +77,7 @@
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>1.0.3.Final</version>
+            <version>${version.javax.ws.rs-api}</version>
         </dependency>
 
         <!-- for testing -->

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -33,15 +33,12 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
   <properties>
     <version.thorntail>2.4.0.Final</version.thorntail>
     <version.quarkus>0.22.0</version.quarkus>
-    <!-- Impportant: the resteasy client version must match the one used by wildfly.thorntail -->
-    <version.resteasy-client>3.6.2.Final</version.resteasy-client>
-    <version.resteasy>3.6.2.Final</version.resteasy>
+    <version.resteasy-client>${version.org.jboss.resteasy}</version.resteasy-client>
 
     <version.json.api>1.1</version.json.api>
     <version.jaxrs.api>1.0.0.Final</version.jaxrs.api>
 
     <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
-    <version.jaxrs-api>2.0</version.jaxrs-api>
     <version.cdi-api>1.0-SP1</version.cdi-api>
     <version.junit>4.12</version.junit>
 


### PR DESCRIPTION
…various rts modules
https://issues.jboss.org/browse/JBTM-3219

JACOCO PERF NO_WIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !AS_TESTS !TOMCAT !mysql !postgres !db2 !oracle !RTS !MAIN

1. We are currently on a beta from 2016.
2. The versions of RESTEasy used by our various modules is inconsistent.
3. The versions of jaxrs-api are also inconsistent.