### PR TITLE
JBTM-3226 Downgrade byteman version when using multi rule scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
     <version.com.sun.grizzly>1.9.59</version.com.sun.grizzly>
     <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
     <version.junit>4.11</version.junit>
-    <version.org.jboss.byteman>4.0.9</version.org.jboss.byteman>
+    <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
     <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
     <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR9</version.org.jboss.arquillian.container.weld>

--- a/rts/lra/lra-coordinator-jar/pom.xml
+++ b/rts/lra/lra-coordinator-jar/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
-            <version>${version.org.jboss.byteman}</version>
+            <version>${version.org.jboss.byteman.lra}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -31,6 +31,7 @@
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
+        <version.org.jboss.byteman.lra>4.0.9</version.org.jboss.byteman.lra>
       
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
https://github.com/jbosstm/narayana/pull/1530

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS MAIN !LRA

The latest byteman version fails rule check validation when there are multiple rules in a script