### PR TITLE
JBTM-3227: LRA branch upgrade LRA snapshot build dependency

### DIFF
--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-      <version.microprofile.lra.api>1.0-20191129.071308-603</version.microprofile.lra.api>
-      <version.microprofile.lra.tck>1.0-20191129.071320-603</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20191204.071313-609</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20191204.071327-609</version.microprofile.lra.tck>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTM-3227

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS !MAIN LRA

This PR fixes the failing CI test (testForget)