### PR TITLE
JBTM-3228 Nested LRA participants should have Forget methods called w…

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
@@ -138,7 +138,7 @@ class RecoveringLRA extends Transaction {
             if (r instanceof LRARecord) {
                 LRARecord rec = (LRARecord) r;
 
-                rec.setLraService(getLraService());
+                rec.setLRAService(getLraService());
             }
         }
     }

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20191204.071313-609</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20191204.071327-609</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20191205.071254-612</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20191205.071305-612</version.microprofile.lra.tck>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>


### PR DESCRIPTION
…hen the parent LRA is closed

https://issues.redhat.com/browse/JBTM-3228

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS !MAIN LRA

There will be one failing TCK test `TckContextTests.testAfterLRAEnlistmentDuringClosingPhase` for which fix will be coming in a separate JBTM. I also included a small code clean up of duplicated method setLraService in LRARecord.