### PR TITLE
JBTM-3229 Allow to enlist AfterLRA listeners after the LRA enters the ending phase

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
@@ -835,7 +835,7 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
     }
 
     public String getCompensator() {
-        return compensateURI.toASCIIString();
+        return compensateURI != null ? compensateURI.toASCIIString() : null;
     }
 
     void setLRAService(LRAService lraService) {

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -568,6 +568,12 @@ public class Transaction extends AtomicAction {
             }
 
             return p;
+        } else if (isRecovering() && p.getCompensator() == null && p.getEndNotificationUri() != null) {
+            // the participant is an AfterLRA listener
+            afterLRAListeners.add(new AfterLRAListener(p.getEndNotificationUri(), p.getRecoveryCoordinatorURI()));
+            updateState();
+
+            return p;
         }
 
         return null;

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -294,7 +294,9 @@ public class LRAService {
             timeLimit = 0;
         }
 
-        if (!transaction.isActive()) {
+        // the tx must be either Active (for participants with the @Compensate methods) or
+        // Closing/Canceling (for the AfterLRA listeners)
+        if (!transaction.isActive() && !transaction.isRecovering()) {
             return Response.Status.PRECONDITION_FAILED.getStatusCode();
         }
 

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20191204.071313-609</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20191204.071327-609</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20191205.071254-612</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20191205.071305-612</version.microprofile.lra.tck>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3229

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS !MAIN LRA

This PR builds on top of the https://github.com/jbosstm/narayana/pull/1535 so it can be updated separately but we can still verify that full TCK is passing with all changes. We can merge either one of them first and I will adjust the other if needed.