### PR TITLE
JBTM-3228: Nested LRA participants should have Forget methods called …

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -149,7 +149,7 @@ public class LRAService {
             // the LRA is top level or it's a nested LRA that was closed by a
             // parent LRA (ie when fromHierarchy is true) then it's okay to forget about the LRA
 
-            if (transaction.afterLRANotification()) {
+            if (transaction.endLRANotification()) {
                 remove(ActionStatus.stringForm(transaction.status()), transaction.getId());
             }
         }
@@ -310,12 +310,12 @@ public class LRAService {
             return Response.Status.PRECONDITION_FAILED.getStatusCode();
         }
 
-        if (participant == null || participant.getRecoveryCoordinatorURI() == null) {
+        if (participant == null || participant.getRecoveryURI() == null) {
             // probably already closing or cancelling
             return Response.Status.PRECONDITION_FAILED.getStatusCode();
         }
 
-        String recoveryURI = participant.getRecoveryCoordinatorURI().toASCIIString();
+        String recoveryURI = participant.getRecoveryURI().toASCIIString();
 
         updateRecoveryURI(lra, participant.getParticipantURI(), recoveryURI, false);
 

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20191205.071254-612</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20191205.071305-612</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-20200102.071313-640</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-20200102.071324-640</version.microprofile.lra.tck>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>


### PR DESCRIPTION
…when the parent LRA is closed

https://issues.redhat.com/browse/JBTM-3228

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !AS_TESTS !TOMCAT !JACOCO !mysql !postgres !db2 !oracle !RTS !MAIN LRA