### PR TITLE
[JBTM-3246] adapting async handling for CDI interceptors

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/RunnableWithException.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/RunnableWithException.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.jta.cdi;
+
+/**
+ * Functional interface for 'run' method
+ * that throws a checked exception.
+ */
+@FunctionalInterface
+public interface RunnableWithException {
+    void run() throws Exception;
+}

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionHandler.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionHandler.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.jta.cdi;
+
+import com.arjuna.ats.jta.logging.jtaLogger;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+
+public final class TransactionHandler {
+
+    /**
+     * For cases that the transaction should be marked for rollback
+     * ie. when {@link RuntimeException} is thrown or when the exception si marked in {@link Transactional#rollbackOn()}
+     * then {@link Transaction#setRollbackOnly()} is invoked.
+     */
+    public static void handleExceptionNoThrow(Transactional transactional, Throwable e, Transaction tx)
+            throws IllegalStateException, SystemException {
+
+        for (Class<?> dontRollbackOnClass : transactional.dontRollbackOn()) {
+            if (dontRollbackOnClass.isAssignableFrom(e.getClass())) {
+                return;
+            }
+        }
+
+        for (Class<?> rollbackOnClass : transactional.rollbackOn()) {
+            if (rollbackOnClass.isAssignableFrom(e.getClass())) {
+                tx.setRollbackOnly();
+                return;
+            }
+        }
+
+        if (e instanceof RuntimeException) {
+            tx.setRollbackOnly();
+            return;
+        }
+    }
+
+    /**
+     * <p>
+     * It finished the transaction.
+     * </p>
+     * <p>
+     * Call {@link TransactionManager#rollback()} when the transaction si marked for {@link Status#STATUS_MARKED_ROLLBACK}.
+     * otherwise the transaction is committed.
+     * Either way there is executed the {@link Runnable} 'afterEndTransaction' after the transaction is finished.
+     * </p>
+     */
+    public static void endTransaction(TransactionManager tm, Transaction tx, RunnableWithException afterEndTransaction) throws Exception {
+        try {
+            if (tx != tm.getTransaction()) {
+                throw new RuntimeException(jtaLogger.i18NLogger.get_wrong_tx_on_thread());
+            }
+
+            if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK) {
+                tm.rollback();
+            } else {
+                tm.commit();
+            }
+        } finally {
+            afterEndTransaction.run();
+        }
+    }
+}

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/async/ContextPropagationAsyncHandler.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/async/ContextPropagationAsyncHandler.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2020, Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arjuna.ats.jta.cdi.async;
+
+import com.arjuna.ats.jta.cdi.RunnableWithException;
+import com.arjuna.ats.jta.cdi.TransactionHandler;
+import io.smallrye.reactive.converters.ReactiveTypeConverter;
+import io.smallrye.reactive.converters.Registry;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.jboss.logging.Logger;
+import org.reactivestreams.Publisher;
+
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Handling asynchronous context propagation calls.
+ * It extends transactions until the intercepted method's async return type is completed.
+ */
+public final class ContextPropagationAsyncHandler {
+    private static final Logger log = Logger.getLogger(ContextPropagationAsyncHandler.class);
+
+    // check if classes of reactive streams from smallrye for transaction asynchronous handling are available on classpath
+    private static final boolean areSmallRyeReactiveClassesAvailable = areSmallRyeReactiveClassesAvailable();
+
+    /**
+     * <p>
+     * Tries to handle asynchronously the returned type from the @{@link Transactional} call.
+     * This CDI interceptor method checks the return type intercepted method.
+     * If it's a asynchronous "type" (<code>objectToHandle</code> is <codde>instanceof</code> e.g. {@link CompletionStage})
+     * then the transaction completion (committing/roll-backing) will be suspended
+     * until the asynchronous code finishes.
+     * </p>
+     * <p>
+     * If the interceptor returns nothing or just some "normal" return type then synchronous handling is processed.
+     * Synchronous means that the transaction is completed just here when the method annotated with @{@link Transactional}
+     * ends.
+     * </p>
+     *
+     * @param tm  transaction manager
+     * @param tx  the original transaction
+     * @param transactional  link to method which is annotated with @{@link Transactional}
+     * @param objectToHandleRef  on interceptor proceed this is the returned type which differentiate the action;
+     *                        method changes the object when it was handled asynchronously
+     * @param returnType
+     * @param afterEndTransaction  a lamda invocation on transaction finalization
+     * @return @{code true} if async handling is possible and it was proceeded, @{code false} means async processing is not possible;
+     *   the method changes the value referenced by @{code objectToHandleRef}, when @{code true} is returned
+     * @throws Exception failure on async processing error happens
+     */
+    public static boolean tryHandleAsynchronously(
+            TransactionManager tm, Transaction tx, Transactional transactional, AtomicReference objectToHandleRef,
+            Class<?> returnType, RunnableWithException afterEndTransaction) throws Exception {
+
+        Object objectToHandle = objectToHandleRef.get();
+        if (objectToHandle == null) {
+            return false;
+        }
+        if (objectToHandle instanceof CompletionStage) {
+            // checking if the returned type is CompletionStage, it's certain to be s on classpath as it's under JDK java.util.concurrent package
+            objectToHandle = handleAsync(tm, tx, transactional, objectToHandle, afterEndTransaction);
+        } else if (objectToHandle instanceof CompletionStage == false && areSmallRyeReactiveClassesAvailable) {
+            // the smallrye reactive classes and converter utility class are available, trying to convert the returned object to the known async type
+            ReactiveTypeConverter<Object> converter = null;
+            if (objectToHandle instanceof Publisher == false || returnType != Publisher.class) {
+                @SuppressWarnings({ "rawtypes", "unchecked" })
+                Optional<ReactiveTypeConverter<Object>> lookup = Registry.lookup((Class) objectToHandle.getClass());
+                if (lookup.isPresent()) {
+                    converter = lookup.get();
+                    if (converter.emitAtMostOneItem()) {
+                        objectToHandle = converter.toCompletionStage(objectToHandle);
+                    } else {
+                        objectToHandle = converter.toRSPublisher(objectToHandle);
+                    }
+                }
+            }
+            if (objectToHandle instanceof CompletionStage) {
+                objectToHandle = handleAsync(tm, tx, transactional, objectToHandle, afterEndTransaction);
+                // convert back
+                if (converter != null)
+                    objectToHandle = converter.fromCompletionStage((CompletionStage<?>) objectToHandle);
+            } else if (objectToHandle instanceof Publisher) {
+                objectToHandle = handleAsync(tm, tx, transactional, objectToHandle, afterEndTransaction);
+                // convert back
+                if (converter != null)
+                    objectToHandle = converter.fromPublisher((Publisher<?>) objectToHandle);
+            } else {
+                // no way to handle the object as known asynchronous type
+                return false;
+            }
+        } else {
+            // we are not able to handle the returned type as asynchronous
+            return false;
+        }
+        // the returned type is the asynchronous type and the type was handled
+        objectToHandleRef.set(objectToHandle);
+        return true;
+    }
+
+    private static Object handleAsync(TransactionManager tm, Transaction tx, Transactional transactional, Object ret, RunnableWithException afterEndTransaction) throws Exception {
+        // Suspend the transaction to remove it from the main request thread
+        tm.suspend();
+        afterEndTransaction.run();
+        if (ret instanceof CompletionStage) {
+            return ((CompletionStage<?>) ret).handle((v, throwable) -> {
+                try {
+                    doInTransaction(tm, tx, () -> {
+                        if (throwable != null) {
+                            TransactionHandler.handleExceptionNoThrow(transactional, throwable, tx);
+                        }
+                        TransactionHandler.endTransaction(tm, tx, () -> {});
+                    });
+                } catch (RuntimeException e) {
+                    if (throwable != null)
+                        e.addSuppressed(throwable);
+                    throw e;
+                } catch (Exception e) {
+                    CompletionException x = new CompletionException(e);
+                    if (throwable != null)
+                        x.addSuppressed(throwable);
+                    throw x;
+                }
+                // pass-through the previous results
+                if (throwable instanceof RuntimeException)
+                    throw (RuntimeException) throwable;
+                if (throwable != null)
+                    throw new CompletionException(throwable);
+                return v;
+            });
+        } else if (ret instanceof Publisher) {
+            ret = ReactiveStreams.fromPublisher(((Publisher<?>) ret))
+                    .onError(throwable -> {
+                        try {
+                            doInTransaction(tm, tx, () -> TransactionHandler.handleExceptionNoThrow(transactional, throwable, tx));
+                        } catch (RuntimeException e) {
+                            e.addSuppressed(throwable);
+                            throw e;
+                        } catch (Exception e) {
+                            RuntimeException x = new RuntimeException(e);
+                            x.addSuppressed(throwable);
+                            throw x;
+                        }
+                        // pass-through the previous result
+                        if (throwable instanceof RuntimeException)
+                            throw (RuntimeException) throwable;
+                        throw new RuntimeException(throwable);
+                    }).onTerminate(() -> {
+                        try {
+                            doInTransaction(tm, tx, () -> TransactionHandler.endTransaction(tm, tx, () -> {
+                            }));
+                        } catch (RuntimeException e) {
+                            throw e;
+                        } catch (Exception e) {
+                            RuntimeException x = new RuntimeException(e);
+                            throw x;
+                        }
+                    })
+                    .buildRs();
+        }
+        return ret;
+    }
+
+    private static void doInTransaction(TransactionManager tm, Transaction tx, RunnableWithException f) throws Exception {
+        // Verify if this thread's transaction is the right one
+        Transaction currentTransaction = tm.getTransaction();
+        // If not, install the right transaction
+        if (currentTransaction != tx) {
+            if (currentTransaction != null)
+                tm.suspend();
+            tm.resume(tx);
+        }
+        f.run();
+        if (currentTransaction != tx) {
+            tm.suspend();
+            if (currentTransaction != null)
+                tm.resume(currentTransaction);
+        }
+    }
+
+    /**
+     * <p>
+     * Checks if classes from the following maven artifacts are available on classpath
+     * <ul>
+     *   <li>io.smallrye.reactive:smallrye-reactive-converter-api (WildFly module io.smallrye.reactive.streams-operators)</li>
+     *   <li>org.eclipse.microprofile.reactive-streams-operators.microprofile-reactive-streams-operators-api
+     *       (WildFly module org.eclipse.microprofile.reactive-streams-operators.api)</li>
+     *   <li>org.reactivestreams:reactive-streams (Wildfly module org.reactivestreams)</li>
+     * </ul>
+     * </p>
+     *
+     * @return true if the classes are available on classpath, false otherwise
+     */
+    private static boolean areSmallRyeReactiveClassesAvailable() {
+        return Arrays.asList(
+                "io.smallrye.reactive.converters.ReactiveTypeConverter",
+                "io.smallrye.reactive.converters.Registry",
+                "org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams",
+                "org.reactivestreams.Publisher")
+                .stream().allMatch(className -> {
+                    try {
+                        Class.forName(className);
+                    } catch (ClassNotFoundException cnfe) {
+                        log.debugf("Class %s is not available on classpath. Handling of asynchronous types in @Transactional " +
+                                "methods could not work properly. Consider to add java artifacts " +
+                                "'org.eclipse.microprofile.reactive-streams-operators.microprofile-reactive-streams-operators-api', " +
+                                "'org.reactivestreams:reactive-streams' and  'io.smallrye.reactive:smallrye-reactive-converter-api' " +
+                                "to your classpath", className);
+                        return false;
+                    }
+                    return true;
+                });
+    }
+}

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
@@ -23,32 +23,31 @@
 package com.arjuna.ats.jta.cdi.transactional;
 
 
-import static java.security.AccessController.doPrivileged;
-
+import com.arjuna.ats.jta.cdi.TransactionExtension;
+import com.arjuna.ats.jta.cdi.async.ContextPropagationAsyncHandler;
+import com.arjuna.ats.jta.cdi.RunnableWithException;
+import com.arjuna.ats.jta.cdi.TransactionHandler;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
 import com.arjuna.ats.jta.logging.jtaLogger;
+import org.jboss.tm.usertx.UserTransactionOperationsProvider;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.enterprise.context.ContextNotActiveException;
 import javax.enterprise.inject.Intercepted;
 import javax.enterprise.inject.spi.AnnotatedMethod;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.Bean;
 import javax.inject.Inject;
 import javax.interceptor.InvocationContext;
-import javax.transaction.Status;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.Transactional;
-
-import org.jboss.tm.usertx.UserTransactionOperationsProvider;
-
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.security.PrivilegedAction;
-import com.arjuna.ats.jta.cdi.TransactionExtension;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.security.AccessController.doPrivileged;
 
 /**
  * @author paul.robinson@redhat.com 02/05/2013
@@ -57,7 +56,6 @@ import com.arjuna.ats.jta.cdi.TransactionExtension;
  * target="_parent">Laird Nelson</a>
  */
 public abstract class TransactionalInterceptorBase implements Serializable {
-
     private static final long serialVersionUID = 1L;
 
     @Inject
@@ -114,8 +112,9 @@ public abstract class TransactionalInterceptorBase implements Serializable {
                     break;
                 }
             }
-    
+
             // check existence of the stereotype on method
+            assert currentAnnotatedMethod != null;
             Transactional transactionalMethod = getTransactionalAnnotationRecursive(currentAnnotatedMethod.getAnnotations());
             if(transactionalMethod != null) return transactionalMethod;
             // stereotype recursive search, covering ones added by an extension too
@@ -131,7 +130,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
             if (transactional != null) {
                 return transactional;
             }
-    
+
             Class<?> targetClass = ic.getTarget().getClass();
             transactional = targetClass.getAnnotation(Transactional.class);
             if (transactional != null) {
@@ -162,22 +161,40 @@ public abstract class TransactionalInterceptorBase implements Serializable {
 
     private Transactional getTransactionalAnnotationRecursive(Set<Annotation> annotationsOnMember) {
         return getTransactionalAnnotationRecursive(
-            annotationsOnMember.toArray(new Annotation[annotationsOnMember.size()]));
+            annotationsOnMember.toArray(new Annotation[0]));
     }
 
     protected Object invokeInOurTx(InvocationContext ic, TransactionManager tm) throws Exception {
+        return invokeInOurTx(ic, tm, () -> {});
+    }
+
+    protected Object invokeInOurTx(InvocationContext ic, TransactionManager tm, RunnableWithException afterEndTransaction) throws Exception {
 
         tm.begin();
         Transaction tx = tm.getTransaction();
 
+        boolean throwing = false;
+        Object ret = null;
+
         try {
-            return ic.proceed();
+            ret = ic.proceed();
         } catch (Exception e) {
+            throwing = true;
             handleException(ic, e, tx);
         } finally {
-            endTransaction(tm, tx);
+            AtomicReference<Object> retRef = new AtomicReference<>(ret);
+            boolean asyncReturnType =
+                    ContextPropagationAsyncHandler.tryHandleAsynchronously(
+                            tm, tx, getTransactional(ic), retRef, ic.getMethod().getReturnType(), afterEndTransaction);
+            if (throwing || ret == null || !asyncReturnType) {
+                // is throwing (OR) is null (OR) is not asynchronous type (OR) no async handler classes on classpath : handle synchronously
+                TransactionHandler.endTransaction(tm, tx, afterEndTransaction);
+            }
+            if (asyncReturnType) {
+                ret = retRef.get();
+            }
         }
-        throw new RuntimeException("UNREACHABLE");
+        return ret;
     }
 
     protected Object invokeInCallerTx(InvocationContext ic, Transaction tx) throws Exception {
@@ -195,42 +212,15 @@ public abstract class TransactionalInterceptorBase implements Serializable {
         return ic.proceed();
     }
 
+    /**
+     * The handleException considers the transaction to be marked for rollback only in case the thrown exception
+     * comes with this effect (see {@link TransactionHandler#handleExceptionNoThrow(Transactional, Throwable, Transaction)}
+     * and consider the {@link Transactional#dontRollbackOn()}.
+     * If so then this method rethrows the {@link Exception} passed as the parameter 'e'.
+     */
     protected void handleException(InvocationContext ic, Exception e, Transaction tx) throws Exception {
-
-        Transactional transactional = getTransactional(ic);
-
-        for (Class<?> dontRollbackOnClass : transactional.dontRollbackOn()) {
-            if (dontRollbackOnClass.isAssignableFrom(e.getClass())) {
-                throw e;
-            }
-        }
-
-        for (Class<?> rollbackOnClass : transactional.rollbackOn()) {
-            if (rollbackOnClass.isAssignableFrom(e.getClass())) {
-                tx.setRollbackOnly();
-                throw e;
-            }
-        }
-
-        if (e instanceof RuntimeException) {
-            tx.setRollbackOnly();
-            throw e;
-        }
-
+        TransactionHandler.handleExceptionNoThrow(getTransactional(ic), e, tx);
         throw e;
-    }
-
-    protected void endTransaction(TransactionManager tm, Transaction tx) throws Exception {
-
-        if (tx != tm.getTransaction()) {
-            throw new RuntimeException(jtaLogger.i18NLogger.get_wrong_tx_on_thread());
-        }
-
-        if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK) {
-            tm.rollback();
-        } else {
-            tm.commit();
-        }
     }
 
     protected boolean setUserTransactionAvailable(boolean available) {

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequiresNew.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorRequiresNew.java
@@ -51,11 +51,7 @@ public class TransactionalInterceptorRequiresNew extends TransactionalIntercepto
     protected Object doIntercept(TransactionManager tm, Transaction tx, InvocationContext ic) throws Exception {
         if (tx != null) {
             tm.suspend();
-            try {
-                return invokeInOurTx(ic, tm);
-            } finally {
-                tm.resume(tx);
-            }
+            return invokeInOurTx(ic, tm, () -> tm.resume(tx));
         } else {
             return invokeInOurTx(ic, tm);
         }

--- a/ArjunaJTA/cdi/pom.xml
+++ b/ArjunaJTA/cdi/pom.xml
@@ -146,7 +146,13 @@
         <version>${version.org.jboss.logging.jboss-logging-processor}</version>
         <scope>provided</scope>
       </dependency>
-  </dependencies>
+      <dependency>
+          <groupId>io.smallrye.reactive</groupId>
+          <artifactId>smallrye-reactive-converter-api</artifactId>
+          <version>${version.smallrye-converter-api}</version>
+          <scope>provided</scope>
+      </dependency>
+    </dependencies>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,7 @@
     <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
     <version.com.github.docker-java>3.0.14</version.com.github.docker-java>
     <version.org.eclipse.microprofile.openapi>1.1.2</version.org.eclipse.microprofile.openapi>
+    <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
 
     <!-- Maven plugin versions -->
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>


### PR DESCRIPTION
Thanks for submitting your Pull Request!

https://issues.redhat.com/browse/JBTM-3246

Adapting the code from Quarkus to handle asynchronous calls for context propagation MP spec.
The class 'ContextPropagationAsyncHandler' is deliberately published with the ASL v.2.

The result needs to be tested with WildFly and changes for MicroProfile. If the results passes the MP TCK will be checked with @kabir

MAIN AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA

