### PR TITLE
[JBTM-3265] afterLRA failure loading state before the finishing the LRA end method

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -461,7 +461,9 @@ public class Transaction extends AtomicAction {
             }
         }
 
-        updateState();
+        // note that we can either run the post actions now or wait for a recovery pass
+        // doing it here will provide more timely notifications
+        runPostLRAActions();
 
         if (pending != null && pending.size() != 0) {
             if (!nested) {
@@ -477,9 +479,6 @@ public class Transaction extends AtomicAction {
             status = toLRAStatus(res);
         }
 
-        // note that we can either run the post actions now or wait for a recovery pass
-        // doing it here will provide more timely notifications
-        runPostLRAActions();
 
         if (!isRecovering()) {
             if (lraService != null) {

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/internal/LRARecoveryModule.java
@@ -86,7 +86,7 @@ public class LRARecoveryModule implements RecoveryModule {
 
     public void periodicWorkSecondPass() {
         if (LRALogger.logger.isDebugEnabled()) {
-            LRALogger.logger.debug("AtomicActionRecoveryModule second pass");
+            LRALogger.logger.debug("LRARecoveryModule second pass");
         }
 
         processTransactionsStatus();

--- a/rts/lra/lra-test/lra-test-arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
+++ b/rts/lra/lra-test/lra-test-arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
@@ -44,14 +44,14 @@ public class NarayanaLRARecovery {
         do {
             LRALogger.logger.info("Recovery attempt #" + ++counter);
         } while (!waitForEndPhaseReplay(lraId));
-        LRALogger.logger.info("LRA " + lraId + "has finished the recovery " + counter);
+        LRALogger.logger.info("LRA " + lraId + " has finished the recovery " + counter);
     }
 
     public boolean waitForEndPhaseReplay(URI lraId) {
         String host = lraId.getHost();
         int port = lraId.getPort();
         if (!recoverLRAs(host, port, lraId)) {
-            // first recovery scan probably collided with periodic recovevery which started
+            // first recovery scan probably collided with periodic recovery which started
             // before the test execution so try once more
             return recoverLRAs(host, port, lraId);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3265

This is follow-up to the investigation on the PR: https://github.com/jbosstm/narayana/pull/1565
Direct link on the reasoning on this PR is here: https://github.com/jbosstm/narayana/pull/1565#pullrequestreview-374334136

MAIN LRA
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO

