### PR TITLE
[JBTM-2858] activate restat inbound bridge, deactivated by mistake

### DIFF
--- a/rts/at/bridge/pom.xml
+++ b/rts/at/bridge/pom.xml
@@ -273,9 +273,6 @@
                                 <server.jvm.args>${server.jvm.args}</server.jvm.args>
                                 <node.address>127.0.0.1</node.address>
                             </systemPropertyVariables>
-                            <excludes>
-                              <exclude>AnnotationsTestCase.java</exclude>
-                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
…during jdk9 fixes

https://issues.redhat.com/browse/JBTM-2858

MAIN RTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !TOMCAT !JACOCO !LRA !AS_TESTS

