### PR TITLE
JBTM-3271 Fix for the javadoc plugin not working on later releases of JDK 11 (see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233)

### DIFF
--- a/ArjunaCore/arjunacore/pom.xml
+++ b/ArjunaCore/arjunacore/pom.xml
@@ -187,6 +187,7 @@
               </execution>
             </executions>
             <configuration>
+              <source>8</source>
               <detectOfflineLinks>false</detectOfflineLinks>
               <excludePackageNames>*.internal.*</excludePackageNames>
             </configuration>

--- a/ArjunaJTA/narayana-jta/pom.xml
+++ b/ArjunaJTA/narayana-jta/pom.xml
@@ -261,6 +261,7 @@
               </execution>
             </executions>
             <configuration>
+              <source>8</source>
               <detectOfflineLinks>false</detectOfflineLinks>
               <excludePackageNames>*.internal.*</excludePackageNames>
             </configuration>

--- a/STM/pom.xml
+++ b/STM/pom.xml
@@ -89,6 +89,7 @@
                   </execution>
                 </executions>
                 <configuration>
+              <source>8</source>
               <detectOfflineLinks>false</detectOfflineLinks>
               <excludePackageNames>*.internal.*</excludePackageNames>
             </configuration>

--- a/XTS/jbossxts/pom.xml
+++ b/XTS/jbossxts/pom.xml
@@ -258,6 +258,7 @@
               </execution>
             </executions>
             <configuration>
+              <source>8</source>
               <detectOfflineLinks>false</detectOfflineLinks>
               <excludePackageNames>org.*:com.arjuna.services.*:com.arjuna.webservices*:com.arjuna.mwlabs.*:com.arjuna.webservices11*:com.arjuna.schemas:com.arjuna.mw.wstx</excludePackageNames>
             </configuration>
@@ -276,6 +277,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
+              <source>8</source>
               <additionalJOptions>
                 <additionalJOption>--add-modules</additionalJOption>
                 <additionalJOption>java.xml.bind</additionalJOption>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -339,6 +339,7 @@
                   <goal>javadoc</goal>
                 </goals>
                 <configuration>
+                  <source>8</source>
                   <includeDependencySources>true</includeDependencySources>
                   <docfilessubdirs>true</docfilessubdirs>
                   <subpackages>com.arjuna.ats:com.arjuna.common:com.arjuna.orbportability:org.jboss.narayana:org.jboss.jbossts:com.arjuna.mw:com.arjuna.wsc:com.arjuna.wsc11:com.arjuna.wst:com.arjuna.wst11:org.jboss.stm</subpackages>
@@ -441,6 +442,8 @@
              <jdk>[9,)</jdk>
           </activation>
           <properties>
+             <!-- skip javadoc generation since it has already been ran by the release profile -->
+             <maven.javadoc.skip>true</maven.javadoc.skip>
              <jvm.args.modular>--add-modules=java.se</jvm.args.modular>
 	     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
 	     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>

--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -353,6 +353,7 @@
               </execution>
             </executions>
             <configuration>
+              <source>8</source>
               <detectOfflineLinks>false</detectOfflineLinks>
             </configuration>
           </plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3271

MAIN !RTS !AS_TESTS !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !TOMCAT !JACOCO !LRA

The recent upgrades and fixes to CI changed the version of JDK 11 and no version of the javadoc plugin works with later JDK11 (and 12) versions. The best description of the issue is 
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8212233

