### PR TITLE
Cannot build 4.17 branch with JDK 1.7 anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.8</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                    <goal>jar</goal>
+                </goals>
+                <configuration>
+                    <additionalparam>${javadoc.opts}</additionalparam>
+                </configuration>
+              </execution>
+            </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -473,6 +484,15 @@
         <module>ArjunaCore/txoj</module>
         <module>STM</module>
       </modules>
+    </profile>
+    <profile>
+      <id>java8-doclint-disabled</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
     </profile>
     <profile>
         <id>release</id>

--- a/rest-tx/tx/pom.xml
+++ b/rest-tx/tx/pom.xml
@@ -221,6 +221,7 @@
           </execution>
         </executions>
         <configuration>
+          <additionalparam>${javadoc.opts}</additionalparam>
           <detectOfflineLinks>false</detectOfflineLinks>
         </configuration>
       </plugin>

--- a/rest-tx/util/pom.xml
+++ b/rest-tx/util/pom.xml
@@ -154,6 +154,7 @@
           </execution>
         </executions>
         <configuration>
+          <additionalparam>${javadoc.opts}</additionalparam>
           <detectOfflineLinks>false</detectOfflineLinks>
         </configuration>
       </plugin>


### PR DESCRIPTION
We have a problem building the 4.17 branch for EAP 6 because sonatype has been changed to only allow HTTPS access ([this change took effect this year](https://central.sonatype.org/articles/2018/May/04/discontinued-support-for-tlsv11-and-below)) and the workaround is to either add `-Dhttps.protocols=TLSv1.2` to the runtime or upgrade Java.

The first option got me most of the way there but the JBoss AS build fails on the `JBoss Application Server Test Suite: Aggregator` module with the HTTP error `Return code is: 501, ReasonPhrase:HTTPS Required`.

Since the jbosstm and JBoss AS poms target compiler version 1.6 for the source and target this PR proposes that we build EAP6 using JDK 1.8 (currently it needs to build on 1.7).

!MAIN TOMCAT AS_TESTS RTS JACOCO XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB QA_JTS_OPENJDKORB BLACKTIE !PERF LRA NO_WIN DB_TESTS mysql db2 postgres oracle