### PR TITLE
JBTM-3280 unignore time limit is not failing on ci + JBTM-3283 fixing -Dit.test used

### DIFF
--- a/rts/lra/lra-test/lra-test-tck/pom.xml
+++ b/rts/lra/lra-test/lra-test-tck/pom.xml
@@ -28,7 +28,6 @@
 
         <it.test>
             <!-- https://issues.redhat.com/browse/JBTM-3280 -->
-            !TckTests#timeLimit,
             !TckRecoveryTests#testCancelWhenParticipantIsRestarted
         </it.test>
     </properties>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -31,7 +31,7 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
   <url>http://www.jboss.org/jbosstm</url>
  
   <properties>
-    <version.thorntail>2.4.0.Final</version.thorntail>
+    <version.thorntail>2.6.0.Final</version.thorntail>
     <version.quarkus>0.22.0</version.quarkus>
     <version.resteasy-client>${version.org.jboss.resteasy}</version.resteasy-client>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3280
https://issues.redhat.com/browse/JBTM-3283

Un-ignoring `TckTests#timeLimit` as after testing it seems it was fixed meanwhile by some other fix.
Plus, fixing the -Dit.test when used with `TckRecoveryTests`.

Thanks to @xstefank to find the reason and the fix.

LRA JDK11
!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
