### PR TITLE
JBTM-3287 Add LRA API dependency to ThornTail LRA coordinator

### DIFF
--- a/rts/lra/lra-coordinator-thorntail/pom.xml
+++ b/rts/lra/lra-coordinator-thorntail/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>lra-coordinator-jar</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+          <groupId>org.eclipse.microprofile.lra</groupId>
+          <artifactId>microprofile-lra-api</artifactId>
+          <version>${version.microprofile.lra.api}</version>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3287

!MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

Only changing the LRA module which is currently failing on test issue tracked in different JBTM thus skipping testing. lra-coordinator-thorntail doesn't contain any tests.
