### PR TITLE
[JBTM-3295] LRA CDI when fails on non providing @Compensate/@AfterLRA…

### DIFF
--- a/rts/lra/lra-proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRACDIExtension.java
+++ b/rts/lra/lra-proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRACDIExtension.java
@@ -127,7 +127,7 @@ public class LRACDIExtension implements Extension {
             return false;
         } else if (!annotations.containsKey(DotNames.COMPENSATE) && !annotations.containsKey(DotNames.AFTER_LRA)) {
             throw new IllegalStateException(String.format("%s: %s",
-                classInfo.simpleName(), "The class contains an LRA method and no Compensate or AfterLRA method was found."));
+                classInfo.name(), "The class contains an LRA method and no Compensate or AfterLRA method was found."));
         } else {
             return true;
         }


### PR DESCRIPTION
… method has to show the problematic classname

https://issues.redhat.com/browse/JBTM-3295

LRA
!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
