### PR TITLE
JBTM-3247 Do not delete LRA records on the failed list

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -377,7 +377,7 @@ public class Coordinator {
     @PUT
     @Path("nested/{NestedLraId}/forget")
     public Response forgetNestedLRA(@PathParam("NestedLraId") String nestedLraId) {
-        lraService.remove(null, toURI(nestedLraId));
+        lraService.remove(toURI(nestedLraId));
 
         return Response.ok().build();
     }

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/LRAStatusHolder.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/LRAStatusHolder.java
@@ -45,6 +45,7 @@ public class LRAStatusHolder {
     long startTime;
     long finishTime;
     long timeNow;
+    String[] failedParticipants;
 
     private LRAStatus lraStatus;
 
@@ -60,6 +61,7 @@ public class LRAStatusHolder {
         this.httpStatus = lra.getHttpStatus();
         this.responseData = lra.getResponseData();
         this.lraStatus = lra.getLRAStatus();
+        this.failedParticipants = lra.getFailedParticipants().values().toArray(new String[0]);
     }
 
     public String getLraId() {
@@ -136,6 +138,10 @@ public class LRAStatusHolder {
 
     public long getTimeNow() {
         return timeNow;
+    }
+
+    public String[] getFailedParticipants() {
+        return failedParticipants;
     }
 
     @Override

--- a/rts/lra/lra-coordinator-jar/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery2TestCase.java
+++ b/rts/lra/lra-coordinator-jar/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery2TestCase.java
@@ -163,7 +163,8 @@ public class LRACoordinatorRecovery2TestCase extends TestBase {
         Assert.assertEquals("LRA with long timeout should still be active",
                 LRAStatus.Active.name(), longStatus.name());
         Assert.assertTrue("LRA with short timeout should not be active",
-                shortStatus == null || LRAStatus.Cancelled.equals(shortStatus));
+                shortStatus == null ||
+                        LRAStatus.Cancelled.equals(shortStatus) || LRAStatus.Cancelling.equals(shortStatus));
 
         // verify that it is still possible to join in with the LRA
         try (Response response = client.target(lraListenerURL).path(LRA_LISTENER_UNTIMED_ACTION)

--- a/rts/lra/lra-test/lra-test-basic/pom.xml
+++ b/rts/lra/lra-test/lra-test-basic/pom.xml
@@ -45,6 +45,20 @@
       <artifactId>lra-test-arquillian-extension</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.narayana.rts</groupId>
+      <artifactId>lra-coordinator-jar</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.jettison</groupId>
+      <artifactId>jettison</artifactId>
+      <version>${version.org.codehaus.jettison}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <build>

--- a/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/FailedLRAIT.java
+++ b/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/FailedLRAIT.java
@@ -1,0 +1,290 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.arquillian.resource.LRAParticipantWithStatusURI;
+import io.narayana.lra.arquillian.resource.LRAParticipantWithoutStatusURI;
+import io.narayana.lra.arquillian.spi.NarayanaLRARecovery;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONObject;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.tck.service.spi.LRARecoveryService;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.narayana.lra.arquillian.resource.SimpleLRAParticipant.RESET_ACCEPTED_PATH;
+import static io.narayana.lra.arquillian.resource.SimpleLRAParticipant.START_LRA_PATH;
+import static io.narayana.lra.arquillian.resource.SimpleLRAParticipant.SIMPLE_PARTICIPANT_RESOURCE_PATH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * There is a spec requirement to report failed LRAs but the spec only requires that a failure message is reported
+ * (not how it is reported). Failure records are vital pieces of data needed to aid failure tracking and analysis.
+ *
+ * The Narayana implementation allows failed LRAs to be directly queried. The following tests validate that the
+ * correct failure records are kept until explicitly removed.
+ */
+@RunWith(Arquillian.class)
+public class FailedLRAIT {
+
+    @ArquillianResource
+    private URL baseURL;
+
+    private Client client;
+
+    @Deployment
+    public static WebArchive deploy() {
+        return ShrinkWrap.create(WebArchive.class, FailedLRAIT.class.getSimpleName() + ".war")
+                .addPackages(true,
+                        org.codehaus.jettison.JSONSequenceTooLargeException.class.getPackage(),
+                        LRARecoveryService.class.getPackage());
+    }
+
+    @Before
+    public void before() {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    public void after() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    /**
+     * test that a failure record is created when a participant (with status reporting) fails to compensate
+     */
+    @Test
+    public void testWithStatusCompensateFailed() throws Exception {
+        URI lra = invokeInTransaction(LRAParticipantWithStatusURI.LRA_PARTICIPANT_PATH,
+                LRAParticipantWithStatusURI.TRANSACTIONAL_CANCEL_PATH, 500);
+
+        if (!validateStateAndRemove(lra, LRAStatus.FailedToCancel)) {
+            fail("lra not in failed list");
+        }
+    }
+
+    /**
+     * test that a failure record is created when a participant (with status reporting) fails to complete
+     */
+    @Test
+    public void testWithStatusCompleteFailed() throws Exception {
+        // invoke a method that should run with an LRA
+        URI lra = invokeInTransaction(LRAParticipantWithStatusURI.LRA_PARTICIPANT_PATH,
+                LRAParticipantWithStatusURI.TRANSACTIONAL_CLOSE_PATH, 200);
+
+        // when the invoked method returns validate that the narayana implementation created a failure record
+        if (!validateStateAndRemove(lra, LRAStatus.FailedToClose)) {
+            fail("lra not in failed list");
+        }
+    }
+
+    /**
+     * test that a failure record is created when a participant (without status reporting) fails to compensate
+     */
+    @Test
+    public void testCompensateFailed() throws Exception {
+        URI lra = invokeInTransaction(LRAParticipantWithoutStatusURI.LRA_PARTICIPANT_PATH,
+                LRAParticipantWithoutStatusURI.TRANSACTIONAL_CANCEL_PATH, 500);
+
+        if (!validateStateAndRemove(lra, LRAStatus.FailedToCancel)) {
+            fail("lra not in failed list");
+        }
+    }
+
+    /**
+     * test that a failure record is created when a participant (without status reporting) fails to complete
+     */
+    @Test
+    public void testCompleteFailed() throws Exception {
+        URI lra = invokeInTransaction(LRAParticipantWithoutStatusURI.LRA_PARTICIPANT_PATH,
+                LRAParticipantWithoutStatusURI.TRANSACTIONAL_CLOSE_PATH, 200);
+
+        if (!validateStateAndRemove(lra, LRAStatus.FailedToClose)) {
+            fail("lra not in failed list");
+        }
+    }
+
+    /**
+     * test that only failed LRAs can be deleted via the recovery coordinator
+     */
+    @Test
+    public void testCannotDeleteNonFailedLRAs() throws Exception {
+        // start an LRA which will return 202 when asked to compensate
+        URI lra = invokeInTransaction(SIMPLE_PARTICIPANT_RESOURCE_PATH,
+                START_LRA_PATH, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+
+        // the LRA should return 202 Accepted when asked to compensate
+
+        // verify that deleting the LRA log fails
+        int status1 = removeFailedLRA(lra); // lra is compensating so should fail
+        int status2 = removeFailedLRA(lra.getHost(), lra.getPort(), "Invalid URI Syntax");
+        int status3 = removeFailedLRA(lra.getHost(), lra.getPort(), "http://example.com");
+
+        assertEquals("deleting a compensating LRA", 412, status1);
+        assertEquals("deleting an invalid (wrong URI syntax) LRA", 412, status2);
+        assertEquals("deleting a non existent LRA", 404, status3);
+
+        // tell the participant compensate method to return an end state on the next compensate request
+        invokeInTransaction(SIMPLE_PARTICIPANT_RESOURCE_PATH, RESET_ACCEPTED_PATH, 200);
+
+        // wait for recovery to replay the compensation
+        new NarayanaLRARecovery().waitForRecovery(lra);
+
+        // the participant should now be in a failed state so the record can be deleted
+        int status4 = removeFailedLRA(lra);
+        assertEquals("deleting a failed LRA", 204, status4);
+    }
+
+    private URI invokeInTransaction(String resourcePrefix, String resourcePath, int expectedStatus) {
+        Response response = null;
+
+        try {
+            response = client.target(UriBuilder.fromUri(baseURL.toExternalForm())
+                    .path(resourcePrefix)
+                    .path(resourcePath).build())
+                    .request()
+                    .get();
+
+            assertEquals(expectedStatus, response.getStatus());
+            Assert.assertTrue(response.hasEntity());
+
+            return URI.create(response.readEntity(String.class));
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    /**
+     * Validate whether or not a given LRA is in a particular state.
+     * Also validate that the corresponding record is removed.
+     *
+     * @param lra the LRA whose state is to be validated
+     * @param state the state that the target LRA should be in
+     * @return true if the LRA is in the target state and that its log was successfully removed
+     * @throws Exception if the state cannot be determined
+     */
+    private boolean validateStateAndRemove(URI lra, LRAStatus state) throws Exception {
+        List<JSONObject> failedRecords = getFailedRecords(lra);
+        for (JSONObject failedLRA : failedRecords) {
+            String lraId = (String) failedLRA.get("lraId");
+            lraId = lraId.replaceAll("\\\\", "");
+            if (lraId.contains(lra.toASCIIString())) {
+                String status = (String) failedLRA.get("status");
+                if (status.equals(state.name())) {
+                    // remove the failed LRA
+                    Assert.assertEquals("Could not remove log",
+                            Response.Status.NO_CONTENT.getStatusCode(),
+                            removeFailedLRA(lra));
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    // look up LRAs that are in a failed state (ie FailedToCancel or FailedToClose)
+    private List<JSONObject> getFailedRecords(URI lra) throws Exception {
+        Response response = null;
+        String recoveryUrl = String.format("http://%s:%d/%s",
+                lra.getHost(), lra.getPort(), LRAConstants.RECOVERY_COORDINATOR_PATH_NAME);
+
+        try {
+            response = client.target(new URI(recoveryUrl)).path("failed").request().get();
+
+            Assert.assertTrue("Missing response body when querying for failed LRAs", response.hasEntity());
+            String failedLRAs = response.readEntity(String.class);
+
+            JSONArray jsonArray = new JSONArray(failedLRAs);
+            List<JSONObject> failedList = new ArrayList<>();
+
+            for (int i = 0; i < jsonArray.length(); i++) {
+                failedList.add(new JSONObject(jsonArray.getString(i)));
+            }
+
+            return failedList;
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+
+    // ask the recovery coordinator to delete its log for an LRA
+    private int removeFailedLRA(URI lra) throws URISyntaxException, UnsupportedEncodingException {
+        String recoveryUrl = String.format("http://%s:%d/%s",
+                lra.getHost(), lra.getPort(), LRAConstants.RECOVERY_COORDINATOR_PATH_NAME);
+        String txId = URLEncoder.encode(lra.toASCIIString(), "UTF-8");
+
+        return removeFailedLRA(recoveryUrl, txId);
+    }
+
+    // ask the recovery coordinator to delete its log for an LRA
+    private int removeFailedLRA(String host, int port, String lra) throws URISyntaxException, UnsupportedEncodingException {
+        String recoveryUrl = String.format("http://%s:%d/%s",
+                host, port, LRAConstants.RECOVERY_COORDINATOR_PATH_NAME);
+
+        return removeFailedLRA(recoveryUrl, lra);
+    }
+
+    // ask the recovery coordinator to delete its log for an LRA
+    private int removeFailedLRA(String recoveryUrl, String lra) throws URISyntaxException {
+        Response response = null;
+
+        try {
+            response = client.target(new URI(recoveryUrl)).path(lra).request().delete();
+
+            return response.getStatus();
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+    }
+}

--- a/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/resource/LRAParticipantWithStatusURI.java
+++ b/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/resource/LRAParticipantWithStatusURI.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.Forget;
+import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
+import org.eclipse.microprofile.lra.annotation.Status;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
+
+@ApplicationScoped
+@Path(LRAParticipantWithStatusURI.LRA_PARTICIPANT_PATH)
+public class LRAParticipantWithStatusURI {
+    public static final String LRA_PARTICIPANT_PATH = "participant-with-status-reporting";
+    public static final String TRANSACTIONAL_CLOSE_PATH = "close-work";
+    public static final String TRANSACTIONAL_CANCEL_PATH = "cancel-work";
+    public static final String FORGET_COUNT_PATH = "forget-count";
+
+    private static final AtomicInteger forgetCount = new AtomicInteger(0);
+    private static final AtomicInteger compensateCount = new AtomicInteger(0);
+    private static final AtomicInteger completeCount = new AtomicInteger(0);
+
+    @GET
+    @Path(TRANSACTIONAL_CLOSE_PATH)
+    @LRA
+    public Response closeLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.ok(lraId.toASCIIString()).build();
+    }
+
+    @GET
+    @Path(TRANSACTIONAL_CANCEL_PATH)
+    @LRA(cancelOn = Response.Status.INTERNAL_SERVER_ERROR)
+    public Response abortLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(lraId.toASCIIString()).build();
+    }
+
+    @GET
+    @Path(FORGET_COUNT_PATH)
+    public int getForgetCount() {
+        return forgetCount.get();
+    }
+
+    @PUT
+    @Path("compensate")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Compensate
+    public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId)
+            throws NotFoundException {
+        compensateCount.incrementAndGet();
+
+        return Response.status(500).entity(ParticipantStatus.FailedToCompensate.name()).build();
+    }
+
+    @PUT
+    @Path("complete")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Complete
+    public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId)
+            throws NotFoundException {
+        completeCount.incrementAndGet();
+
+        return Response.status(500).entity(ParticipantStatus.FailedToComplete.name()).build();
+    }
+
+    @DELETE
+    @Path("delete")
+    @Forget
+    public Response forget() {
+        forgetCount.incrementAndGet();
+
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Status
+    public Response status(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
+                           @HeaderParam(LRA_HTTP_RECOVERY_HEADER) URI recoveryId) {
+        if (completeCount.get() == 1) {
+            return Response.ok(ParticipantStatus.FailedToComplete.name()).build();
+        } else if (compensateCount.get() == 1) {
+            return Response.ok(ParticipantStatus.FailedToCompensate.name()).build();
+        } else {
+            return Response.ok(ParticipantStatus.Active.name()).build();
+        }
+    }
+}

--- a/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/resource/LRAParticipantWithoutStatusURI.java
+++ b/rts/lra/lra-test/lra-test-basic/src/test/java/io/narayana/lra/arquillian/resource/LRAParticipantWithoutStatusURI.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.Forget;
+import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+
+@ApplicationScoped
+@Path(LRAParticipantWithoutStatusURI.LRA_PARTICIPANT_PATH)
+public class LRAParticipantWithoutStatusURI {
+    public static final String LRA_PARTICIPANT_PATH = "participant-without-status-reporting";
+    public static final String TRANSACTIONAL_CLOSE_PATH = "close-work";
+    public static final String TRANSACTIONAL_CANCEL_PATH = "cancel-work";
+    public static final String FORGET_COUNT_PATH = "forget-count";
+
+    private static final AtomicInteger forgetCount = new AtomicInteger(0);
+
+    @GET
+    @Path(TRANSACTIONAL_CLOSE_PATH)
+    @LRA
+    public Response closeLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.ok(lraId.toASCIIString()).build();
+    }
+
+    @GET
+    @Path(TRANSACTIONAL_CANCEL_PATH)
+    @LRA(cancelOn = Response.Status.INTERNAL_SERVER_ERROR)
+    public Response abortLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(lraId.toASCIIString()).build();
+    }
+
+    @GET
+    @Path(FORGET_COUNT_PATH)
+    public int getForgetCount() {
+        return forgetCount.get();
+    }
+
+    @PUT
+    @Path("compensate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Compensate
+    public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId)
+            throws NotFoundException {
+        return Response.status(500).entity(ParticipantStatus.FailedToCompensate.name()).build();
+    }
+
+    @PUT
+    @Path("complete")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Complete
+    public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId)
+            throws NotFoundException {
+        return Response.status(500).entity(ParticipantStatus.FailedToComplete.name()).build();
+    }
+
+    @DELETE
+    @Path("delete")
+    @Forget
+    public Response foget() {
+        forgetCount.incrementAndGet();
+
+        return Response.ok().build();
+    }
+}

--- a/rts/lra/lra-test/lra-test-tck/pom.xml
+++ b/rts/lra/lra-test/lra-test-tck/pom.xml
@@ -25,7 +25,6 @@
         <lra.tck.consistency.longDelay>20000</lra.tck.consistency.longDelay>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     </properties>
 
     <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3291

LRA MAIN !AS_TESTS !QA_JTA !JACOCO !QA_JTS_JACORB !TOMCAT !RTS !XTS !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

This PR changes the LRA implementation such that we now retain failure records (previously we reported the failure and then deleted them).

The OpenAPI doc for reading the records justifies their retention by saying:

"Failure records are vital pieces of data needed to aid failure tracking and analysis and are retained for inspection."

And I raised [JBTM-3297](https://issues.redhat.com/browse/JBTM-3297) to move these records to another part of the store so that standard LRA recovery processing does not need to read them.



