### PR TITLE
CI SCRIPTS: stabilize AS_TESTS axis, see more at WFLY-13385

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -420,6 +420,10 @@ function init_jboss_home {
   echo "JBOSS_HOME=$JBOSS_HOME"
   cp ${JBOSS_HOME}/docs/examples/configs/standalone-xts.xml ${JBOSS_HOME}/standalone/configuration
   cp ${JBOSS_HOME}/docs/examples/configs/standalone-rts.xml ${JBOSS_HOME}/standalone/configuration
+  # configuring bigger connection timeout for jboss cli (WFLY-13385)
+  CONF="${JBOSS_HOME}/bin/jboss-cli.xml"
+  sed -e 's#^\(.*</jboss-cli>\)#<connection-timeout>30</connection-timeout>\n\1#' "$CONF" > "$CONF.tmp" && mv "$CONF.tmp" "$CONF"
+  grep 'connection-timeout' "${CONF}"
 }
 
 function osgi_tests {


### PR DESCRIPTION
Solution for our CI environment on the unstable AS_TESTS axis.
See more at https://issues.redhat.com/browse/WFLY-13385

AS_TESTS
!MAIN !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA
