### PR TITLE
JBTM-3307 Temporarily disable LRACoordinatorRecovery2TestCase

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery2TestCase.java
+++ b/rts/lra/lra-coordinator-jar/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery2TestCase.java
@@ -43,6 +43,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -129,6 +130,7 @@ public class LRACoordinatorRecovery2TestCase extends TestBase {
      * @throws URISyntaxException if the LRA or recovery URIs are invalid (should never happen)
      */
     @Test
+    @Ignore
     public void testRecovery2() throws URISyntaxException {
         startContainer(null);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3307

This test is regularly failing so this PR temporarily disables it until JBTM-3307 makes the test more robust.

!MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

