### PR TITLE
CI SCRIPTS: a follow-up fix for stabilizing AS_TESTS axis (WFLY-1338)

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -385,7 +385,10 @@ function build_as {
   git fetch upstream
   echo "This is the JBoss-AS commit"
   echo $(git rev-parse upstream/master)
+  echo "This is the AS_BRANCH $AS_BRANCH commit"
+  echo $(git rev-parse HEAD)
 
+  echo "Rebasing the wildfly upstream/master on top of the AS_BRANCH $AS_BRANCH"
   git pull --rebase --ff-only upstream master
   [ $? = 0 ] || fatal "git rebase failed"
   
@@ -394,24 +397,28 @@ function build_as {
     rm -rf .git
   fi
 
+  # building WildFly
   export MAVEN_OPTS="-XX:MaxPermSize=512m -XX:+UseConcMarkSweepGC $MAVEN_OPTS"
+  JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" ./build.sh clean install -B -DskipTests -Dts.smoke=false $IPV6_OPTS -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION}
+  [ $? = 0 ] || fatal "AS build failed"
+
+  # init files under JBOSS_HOME before AS TESTS is started
+  init_jboss_home
+
+  # running WildFly testsuite if configured to be run by axis AS_TESTS
   if [ $AS_TESTS = 1 ]; then
     JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" 
-    JAVA_OPTS="$JAVA_OPTS -Xms1303m -Xmx1303m -XX:MaxPermSize=512m" ./build.sh clean install -B $IPV6_OPTS -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION} -DallTests=true -fae
-    [ $? = 0 ] || fatal "AS build failed"
-  else
-    JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" ./build.sh clean install -B -DskipTests -Dts.smoke=false $IPV6_OPTS -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION}
+    JAVA_OPTS="$JAVA_OPTS -Xms1303m -Xmx1303m -XX:MaxPermSize=512m" ./integration-tests.sh verify -B $IPV6_OPTS -Dtimeout.factor=300 -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION} -DallTests=true -fae
+    [ $? = 0 ] || fatal "AS tests failed"
   fi
-  [ $? = 0 ] || fatal "AS build failed"
 
   #Enable remote debugger
   echo JAVA_OPTS='"$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"' >> ./build/target/wildfly-*/bin/standalone.conf
 
-  init_jboss_home
+  cd $WORKSPACE
 }
 
 function init_jboss_home {
-  cd $WORKSPACE
   WILDFLY_VERSION_FROM_JBOSS_AS=`awk '/wildfly-parent/ { while(!/<version>/) {getline;} print; }' ${WORKSPACE}/jboss-as/pom.xml | cut -d \< -f 2|cut -d \> -f 2`
   echo "AS version is ${WILDFLY_VERSION_FROM_JBOSS_AS}"
   JBOSS_HOME=${WORKSPACE}/jboss-as/build/target/wildfly-${WILDFLY_VERSION_FROM_JBOSS_AS}
@@ -422,7 +429,7 @@ function init_jboss_home {
   cp ${JBOSS_HOME}/docs/examples/configs/standalone-rts.xml ${JBOSS_HOME}/standalone/configuration
   # configuring bigger connection timeout for jboss cli (WFLY-13385)
   CONF="${JBOSS_HOME}/bin/jboss-cli.xml"
-  sed -e 's#^\(.*</jboss-cli>\)#<connection-timeout>30</connection-timeout>\n\1#' "$CONF" > "$CONF.tmp" && mv "$CONF.tmp" "$CONF"
+  sed -e 's#^\(.*</jboss-cli>\)#<connection-timeout>30000</connection-timeout>\n\1#' "$CONF" > "$CONF.tmp" && mv "$CONF.tmp" "$CONF"
   grep 'connection-timeout' "${CONF}"
 }
 


### PR DESCRIPTION
the change of the connection-timeout has to be propagated into the jboss-cli.xml before the tests start

Another attempt around the AS_TESTS axis.

AS_TESTS
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA
