### PR TITLE
JBTM-3312 After LRA notifications can keep the LRA in Active state

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -525,8 +525,6 @@ public class Transaction extends AtomicAction {
             status = cancel ? LRAStatus.FailedToCancel : LRAStatus.FailedToClose;
         } else if (getSize(pendingList) != 0 || getSize(preparedList) != 0) {
             status = LRAStatus.Closing;
-        } else {
-            status = toLRAStatus(res);
         }
 
         if (!isRecovering()) {


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3312

!MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

I believe this else statement is wrong because the value of `res` is not changed since at least line [508](https://github.com/jbosstm/narayana/compare/master...xstefank:jbtm-3312?expand=1#diff-57ec69ca0d35bbed0ad018339b532a7dL508) which is in case of after LRA method present H_HAZARD. This state of the BasicAction is then changed in `runPostLRAActions()` method by a call to `super.phase2Commit(true);` which changes the state of the BasicAction to H_COMMIT but this value is not returned. So the switch in `toLRAStatus` gets the H_HAZARD value which is not present and thus the default branch return Active status for the LRA.

I tested with this change and it significantly reduces the number of [LRAs left in not finished state](https://issues.redhat.com/browse/JBTM-3308?focusedCommentId=14077110&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14077110). It also passes everything but Failed LRAs tests in basic testsuite which I was also able to reproduce with the current master branch and failed a [JBTM-3313](https://issues.redhat.com/browse/JBTM-3313).
