### PR TITLE
[JBTM-3316] use LRA TCK timeout factor instead of delays

### DIFF
--- a/rts/lra/lra-test/lra-test-tck/pom.xml
+++ b/rts/lra/lra-test/lra-test-tck/pom.xml
@@ -21,8 +21,7 @@
         <lra.tck.suite.debug.params></lra.tck.suite.debug.params> <!-- has content when -Ddebug.tck is specified -->
         <lra.tck.suite.debug.port>8788</lra.tck.suite.debug.port>
         <!-- TCK TckTests#timeLimit test needs a short, but non zero, delay -->
-        <lra.tck.consistency.shortDelay>1000</lra.tck.consistency.shortDelay>
-        <lra.tck.consistency.longDelay>20000</lra.tck.consistency.longDelay>
+        <lra.tck.timeout.factor>1.0</lra.tck.timeout.factor>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -47,8 +46,7 @@
                         <thorntail.test.logging.category.narayana>${thorntail.test.logging.category.narayana}</thorntail.test.logging.category.narayana>
                         <lra.coordinator.port>${lra.coordinator.port}</lra.coordinator.port>
                         <lra.tck.suite.debug.params>${lra.tck.suite.debug.params}</lra.tck.suite.debug.params>
-                        <lra.tck.consistency.longDelay>${lra.tck.consistency.longDelay}</lra.tck.consistency.longDelay>
-                        <lra.tck.consistency.shortDelay>${lra.tck.consistency.shortDelay}</lra.tck.consistency.shortDelay>
+                        <lra.tck.timeout.factor>${lra.tck.timeout.factor}</lra.tck.timeout.factor>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/rts/lra/lra-test/lra-test-tck/src/test/resources/arquillian-thorntail.xml
+++ b/rts/lra/lra-test/lra-test-tck/src/test/resources/arquillian-thorntail.xml
@@ -7,7 +7,7 @@
         <configuration>
             <property name="host">localhost</property>
             <property name="port">${thorntail.arquillian.daemon.port:12345}</property>
-            <property name="javaVmArguments">${lra.tck.suite.debug.params} -Dthorntail.http.host=${lra.tck.suite.host} -Dthorntail.http.port=${lra.tck.suite.port} -Dlra.tck.coordinator.hostname=localhost -Dlra.tck.coordinator.port=${lra.coordinator.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port} -Dlra.tck.consistency.shortDelay=${lra.tck.consistency.shortDelay} -Dlra.tck.consistency.longDelay=${lra.tck.consistency.longDelay} ${thorntail.test.logging.category.arjuna} ${thorntail.test.logging.category.narayana}</property>
+            <property name="javaVmArguments">${lra.tck.suite.debug.params} -Dthorntail.http.host=${lra.tck.suite.host} -Dthorntail.http.port=${lra.tck.suite.port} -Dlra.tck.coordinator.hostname=localhost -Dlra.tck.coordinator.port=${lra.coordinator.port} -Dlra.http.host=localhost -Dlra.http.port=${lra.coordinator.port} -Dlra.tck.timeout.factor=${lra.tck.timeout.factor} ${thorntail.test.logging.category.arjuna} ${thorntail.test.logging.category.narayana}</property>
         </configuration>
     </container>
 </arquillian>

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -481,7 +481,7 @@ function lra_tests {
   # we can't use 'mvn -f' option beacuse of Thorntail plugin issue THORN-2049
   cd ./rts/lra/
 
-  PRESERVE_WORKING_DIR=true ../../build.sh -fae -B -P$ARQ_PROF $CODE_COVERAGE_ARGS $ENABLE_LRA_TRACE_LOGS "$@"
+  PRESERVE_WORKING_DIR=true ../../build.sh -fae -B -P$ARQ_PROF $CODE_COVERAGE_ARGS $ENABLE_LRA_TRACE_LOGS -Dlra.tck.timeout.factor=3.0 "$@"
   [ $? = 0 ] || fatal "LRA Test failed"
   cd - # back to original directory
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3316

This fix could help in CI instability for `TckTests#timeLimit`

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA