### PR TITLE
[JBTM-3317] adding dependencies on reactive to the shaded jars

### DIFF
--- a/ArjunaJTA/narayana-jta/pom.xml
+++ b/ArjunaJTA/narayana-jta/pom.xml
@@ -162,6 +162,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-reactive-converter-api</artifactId>
+        <version>${version.smallrye-converter-api}</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -215,6 +215,12 @@
         <version>${version.org.jboss.resteasy}</version>
         <scope>provided</scope>
     </dependency>
+    <dependency>
+        <groupId>io.smallrye.reactive</groupId>
+        <artifactId>smallrye-reactive-converter-api</artifactId>
+        <version>${version.smallrye-converter-api}</version>
+        <scope>provided</scope>
+    </dependency>
     <!-- Ensure these are in the distribution -->
     <dependency>
       <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
 to build javadoc on JDK11

https://issues.redhat.com/browse/JBTM-3317

MAIN JDK11
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !LRA
