### PR TITLE
[JBTM-3318][JBTM-3319] ignore the failing test on CI + using lra spec version 1.0-M1

### DIFF
--- a/rts/lra/lra-test/lra-test-tck/pom.xml
+++ b/rts/lra/lra-test/lra-test-tck/pom.xml
@@ -24,6 +24,11 @@
         <lra.tck.timeout.factor>1.0</lra.tck.timeout.factor>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <it.test>
+          <!-- https://issues.redhat.com/browse/JBTM-3318 -->
+          !TckRecoveryTests#testCancelWhenParticipantIsUnavailable
+        </it.test>
     </properties>
 
     <build>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -26,8 +26,8 @@
         <version.junit>4.12</version.junit>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
-        <version.microprofile.lra.api>1.0-20200512.061255-783</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-20200512.061305-779</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-M1</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-M1</version.microprofile.lra.tck>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3318
https://issues.redhat.com/browse/JBTM-3319

LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
