### PR TITLE
[SCRIPTS ONLY] increasing AS_TESTS timeout factor for WFLY testsuite being more stable

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -408,7 +408,7 @@ function build_as {
   # running WildFly testsuite if configured to be run by axis AS_TESTS
   if [ $AS_TESTS = 1 ]; then
     JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" 
-    JAVA_OPTS="$JAVA_OPTS -Xms1303m -Xmx1303m -XX:MaxPermSize=512m" ./integration-tests.sh verify -B $IPV6_OPTS -Dtimeout.factor=300 -Dsurefire.forked.process.timeout=12000 -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION} -DallTests=true -fae
+    JAVA_OPTS="$JAVA_OPTS -Xms1303m -Xmx1303m -XX:MaxPermSize=512m" ./integration-tests.sh verify -B $IPV6_OPTS -Dtimeout.factor=400 -Dsurefire.forked.process.timeout=12000 -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION} -DallTests=true -fae
     [ $? = 0 ] || fatal "AS tests failed"
   fi
 


### PR DESCRIPTION
AS_TESTS
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA
