### PR TITLE
[JBTM-3332] Add a constructor to the HornetQ/Artemis object store adaptor to support named bean lookup.

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/hornetq/HornetqObjectStoreAdaptor.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/hornetq/HornetqObjectStoreAdaptor.java
@@ -78,6 +78,12 @@ public class HornetqObjectStoreAdaptor implements ObjectStoreAPI
         this.store = new HornetqJournalStore(envBean);
     }
 
+    // allows us to work with named beans
+    public HornetqObjectStoreAdaptor(HornetqJournalEnvironmentBean envBean) throws IOException {
+
+        this.store = new HornetqJournalStore(envBean);
+    }
+
     // used for beans wiring type bootstrap when running embedded.
     public HornetqObjectStoreAdaptor(HornetqJournalStore store) {
         this.store = store;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3332

MAIN AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA
