### PR TITLE
JBTM-3341 Failed LRA is not kept in FailedTo* state in the object store

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -374,6 +374,10 @@ public class Transaction extends AtomicAction {
                 (status.equals(LRAStatus.Cancelling) || status.equals(LRAStatus.Closing));
     }
 
+    public boolean isFailed() {
+        return status != null &&
+            (status.equals(LRAStatus.FailedToCancel) || status.equals(LRAStatus.FailedToClose));
+    }
 
     public boolean isCancel() {
         switch (status) {

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -179,7 +179,7 @@ public class LRAService {
 
             if (!transaction.hasPendingActions()) {
                 // this call is only required to clean up cached LRAs (JBTM-3250 will remove this cache).
-                remove(transaction.getId());
+                remove(transaction);
             }
         }
     }
@@ -198,6 +198,13 @@ public class LRAService {
         } catch (Exception e) {
             return false; // the uid segment is invalid
         }
+    }
+
+    public boolean remove(Transaction lra) {
+        if (lra.isFailed()) { // persist failed LRA state
+            lra.deactivate();
+        }
+        return remove(lra.getId());
     }
 
     public boolean remove(URI lraId) {

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/internal/RecoveringLRA.java
@@ -97,6 +97,8 @@ class RecoveringLRA extends Transaction {
                     switch (getLRAStatus()) {
                         case Closed:
                         case Cancelled:
+                        case FailedToClose:
+                        case FailedToCancel:
                             getLraService().finished(this, false);
                             break;
                         default:


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3341

!MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
