### PR TITLE
[JBTM-3357] Do not cache CMR configuration properties

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/RecoveryEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/RecoveryEnvironmentBean.java
@@ -470,6 +470,19 @@ public class RecoveryEnvironmentBean implements RecoveryEnvironmentBeanMBean
     }
 
     /**
+     * Reloads the RecoveryModule.
+     *
+     * This method will reload the RecoveryModules forcibly.
+     *
+     * @return the copy of list of RecoveryModule instances
+     */
+    public List<RecoveryModule> reloadRecoveryModules() {
+        List<RecoveryModule> instances = ClassloadingUtility.loadAndInstantiateClassesWithInit(RecoveryModule.class, recoveryModuleClassNames);
+        setRecoveryModules(instances);
+        return new ArrayList<>(instances);
+    }
+
+    /**
      * Sets the instances of RecoveryModule.
      * The provided list will be copied, not retained.
      *

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/PeriodicRecovery.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/PeriodicRecovery.java
@@ -885,7 +885,7 @@ public class PeriodicRecovery extends Thread
      */
     private void loadModules ()
     {
-        _recoveryModules.addAll(recoveryPropertyManager.getRecoveryEnvironmentBean().getRecoveryModules());
+        _recoveryModules.addAll(recoveryPropertyManager.getRecoveryEnvironmentBean().reloadRecoveryModules());
     }
 
     /**

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/CommitMarkableResourceRecordRecoveryModule.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/CommitMarkableResourceRecordRecoveryModule.java
@@ -42,12 +42,10 @@ import javax.naming.NamingException;
 import javax.sql.DataSource;
 import javax.transaction.xa.Xid;
 
-import com.arjuna.ats.arjuna.AtomicAction;
 import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.arjuna.coordinator.ActionStatus;
 import com.arjuna.ats.arjuna.exceptions.ObjectStoreException;
 import com.arjuna.ats.arjuna.logging.tsLogger;
-import com.arjuna.ats.arjuna.objectstore.ObjectStoreIterator;
 import com.arjuna.ats.arjuna.objectstore.RecoveryStore;
 import com.arjuna.ats.arjuna.objectstore.StoreManager;
 import com.arjuna.ats.arjuna.recovery.RecoveryModule;
@@ -106,23 +104,24 @@ public class CommitMarkableResourceRecordRecoveryModule implements
 
 	private TransactionStatusConnectionManager transactionStatusConnectionMgr;
 
-	private static JTAEnvironmentBean jtaEnvironmentBean = BeanPopulator
-			.getDefaultInstance(JTAEnvironmentBean.class);
-	private Map<String, String> commitMarkableResourceTableNameMap = jtaEnvironmentBean
-			.getCommitMarkableResourceTableNameMap();
+	private final JTAEnvironmentBean jtaEnvironmentBean;
+	private final Map<String, String> commitMarkableResourceTableNameMap;
 	private Map<String, List<Xid>> completedBranches = new HashMap<String, List<Xid>>();
     private boolean inFirstPass;
-	private static String defaultTableName = jtaEnvironmentBean
-			.getDefaultCommitMarkableTableName();
+	private final String defaultTableName;
 
 	public CommitMarkableResourceRecordRecoveryModule() throws NamingException,
 			ObjectStoreException {
 		context = new InitialContext();
-		JTAEnvironmentBean jtaEnvironmentBean = BeanPopulator
+		this.jtaEnvironmentBean = BeanPopulator
 				.getDefaultInstance(JTAEnvironmentBean.class);
 		jndiNamesToContact.addAll(jtaEnvironmentBean
 				.getCommitMarkableResourceJNDINames());
-		
+		this.commitMarkableResourceTableNameMap = jtaEnvironmentBean
+				.getCommitMarkableResourceTableNameMap();
+		this.defaultTableName = jtaEnvironmentBean
+				.getDefaultCommitMarkableTableName();
+
 		if (tsLogger.logger.isTraceEnabled()) {
 			tsLogger.logger
 					.trace("CommitMarkableResourceRecordRecoveryModule::list to contact");

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -98,6 +98,9 @@ public class TransactionImple implements javax.transaction.Transaction,
 
 	public TransactionImple(int timeout)
 	{
+		this.commitMarkableResourceJNDINames = BeanPopulator
+				.getDefaultInstance(JTAEnvironmentBean.class)
+				.getCommitMarkableResourceJNDINames();
 		_theTransaction = new AtomicAction();
 
 		_theTransaction.begin(timeout);
@@ -1222,6 +1225,10 @@ public class TransactionImple implements javax.transaction.Transaction,
 
 	protected TransactionImple(BasicAction curr)
 	{
+		this.commitMarkableResourceJNDINames = BeanPopulator
+				.getDefaultInstance(JTAEnvironmentBean.class)
+				.getCommitMarkableResourceJNDINames();
+
 		try
 		{
 			if (curr == null)
@@ -1744,10 +1751,8 @@ public class TransactionImple implements javax.transaction.Transaction,
 	}
 
 	private static final ConcurrentHashMap _transactions = new ConcurrentHashMap();
-	
-	private static final List<String> commitMarkableResourceJNDINames = BeanPopulator
-			.getDefaultInstance(JTAEnvironmentBean.class)
-			.getCommitMarkableResourceJNDINames();
+
+	private final List<String> commitMarkableResourceJNDINames;
 
 	private static final boolean STRICTJTA12DUPLICATEXAENDPROTOERR = jtaPropertyManager.getJTAEnvironmentBean().isStrictJTA12DuplicateXAENDPROTOErr();
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBTM-3357

MAIN AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: JBTM-XYZ Subject
- [ ] Pull Request contains link to the JIRA issue(s)

Our style rules for submitting code are as follows:

* If you add a new file it MUST adhere to our checkstyle ruleset.
  1. If you change a file (in a non trivial way) you are allowed (MAY) to reformat the code to conform to our checkstyle ruleset (`org.wildfly.checkstyle:wildfly-checkstyle-config`).
  2. If you choose not to reformat it then you SHOULD, where possible, try to follow the same style that's already in use for that file.


The build axis can be controlled by prefixing a ! on the following as appropriate.

MAIN TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB BLACKTIE PERF LRA !NO_WIN DB_TESTS mysql db2 postgres oracle
