### PR TITLE
JBTM-3357 Do not cache CMR properties

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/CommitMarkableResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/CommitMarkableResourceRecord.java
@@ -41,6 +41,7 @@ import javax.transaction.xa.Xid;
 import com.arjuna.ats.arjuna.exceptions.ObjectStoreException;
 import com.arjuna.ats.internal.jta.resources.XAResourceErrorHandler;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.jta.common.CmrJndiConfig;
 import org.jboss.tm.ConnectableResource;
 import org.jboss.tm.XAResourceWrapper;
 
@@ -112,8 +113,6 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 	private static CommitMarkableResourceRecordRecoveryModule commitMarkableResourceRecoveryModule;
 	private static final JTAEnvironmentBean jtaEnvironmentBean = BeanPopulator
 			.getDefaultInstance(JTAEnvironmentBean.class);
-	private static final Map<String, String> commitMarkableResourceTableNameMap = jtaEnvironmentBean
-			.getCommitMarkableResourceTableNameMap();
 	private static final String defaultTableName = jtaEnvironmentBean
 			.getDefaultCommitMarkableTableName();
 	private boolean isPerformImmediateCleanupOfBranches = jtaEnvironmentBean
@@ -121,8 +120,6 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 	private Connection preparedConnection;
 	private static final boolean isNotifyRecoveryModuleOfCompletedBranches = jtaEnvironmentBean
 			.isNotifyCommitMarkableResourceRecoveryModuleOfCompleteBranches();
-	private static final Map<String, Boolean> isPerformImmediateCleanupOfCommitMarkableResourceBranchesMap = jtaEnvironmentBean
-			.getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap();
 
 	static {
 		commitMarkableResourceRecoveryModule = null;
@@ -174,7 +171,9 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 		this.basicAction = basicAction;
 		heuristic = TwoPhaseOutcome.FINISH_OK;
 
-		String tableName = commitMarkableResourceTableNameMap
+		CmrJndiConfig cmrConfig = jtaEnvironmentBean.getCmrJndiConfig();
+		String tableName = cmrConfig
+				.getCommitMarkableResourceTableNameMap()
 				.get(commitMarkableJndiName);
 		if (tableName != null) {
 			this.tableName = tableName;
@@ -182,7 +181,8 @@ public class CommitMarkableResourceRecord extends AbstractRecord {
 			this.tableName = defaultTableName;
 		}
 
-		Boolean boolean1 = isPerformImmediateCleanupOfCommitMarkableResourceBranchesMap
+		Boolean boolean1 = cmrConfig
+				.getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap()
 				.get(commitMarkableJndiName);
 		if (boolean1 != null) {
 			isPerformImmediateCleanupOfBranches = boolean1;

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -793,7 +793,11 @@ public class TransactionImple implements javax.transaction.Transaction,
         {
             if (xaRes instanceof ConnectableResource) {
             	String jndiName = ((XAResourceWrapper)xaRes).getJndiName();
-            	if (commitMarkableResourceJNDINames.contains(jndiName)) {
+
+            	// NB the CMR JNDI names can change so re-read them from the config
+            	if (BeanPopulator
+						.getDefaultInstance(JTAEnvironmentBean.class)
+						.getCommitMarkableResourceJNDINames().contains(jndiName)) {
             		try {
 						return new CommitMarkableResourceRecord(this, ((ConnectableResource)xaRes), xid, _theTransaction);
 					} catch (IllegalStateException | RollbackException
@@ -1744,10 +1748,6 @@ public class TransactionImple implements javax.transaction.Transaction,
 	}
 
 	private static final ConcurrentHashMap _transactions = new ConcurrentHashMap();
-	
-	private static final List<String> commitMarkableResourceJNDINames = BeanPopulator
-			.getDefaultInstance(JTAEnvironmentBean.class)
-			.getCommitMarkableResourceJNDINames();
 
 	private static final boolean STRICTJTA12DUPLICATEXAENDPROTOERR = jtaPropertyManager.getJTAEnvironmentBean().isStrictJTA12DuplicateXAENDPROTOErr();
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/common/CmrJndiConfig.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/common/CmrJndiConfig.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.arjuna.ats.jta.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CmrJndiConfig {
+    List<String> commitMarkableResourceJNDINames;
+    Map<String, String> commitMarkableResourceTableNameMap;
+    Map<String, Boolean> performImmediateCleanupOfCommitMarkableResourceBranchesMap;
+    Map<String, Integer> commitMarkableResourceRecordDeleteBatchSizeMap;
+
+    public List<String> getCommitMarkableResourceJNDINames() {
+        return commitMarkableResourceJNDINames;
+    }
+
+    public Map<String, String> getCommitMarkableResourceTableNameMap() {
+        return commitMarkableResourceTableNameMap;
+    }
+
+    public Map<String, Boolean> getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap() {
+        return performImmediateCleanupOfCommitMarkableResourceBranchesMap;
+    }
+
+    public Map<String, Integer> getCommitMarkableResourceRecordDeleteBatchSizeMap() {
+        return commitMarkableResourceRecordDeleteBatchSizeMap;
+    }
+
+    public CmrJndiConfig(List<String> commitMarkableResourceJNDINames,
+                         Map<String, String> commitMarkableResourceTableNameMap,
+                         Map<String, Boolean> performImmediateCleanupOfCommitMarkableResourceBranchesMap,
+                         Map<String, Integer> commitMarkableResourceRecordDeleteBatchSizeMap) {
+        this.commitMarkableResourceJNDINames = new ArrayList<>(commitMarkableResourceJNDINames);
+        this.commitMarkableResourceTableNameMap = new HashMap<>(commitMarkableResourceTableNameMap);
+        this.performImmediateCleanupOfCommitMarkableResourceBranchesMap = new HashMap<>(performImmediateCleanupOfCommitMarkableResourceBranchesMap);
+        this.commitMarkableResourceRecordDeleteBatchSizeMap = new HashMap<>(commitMarkableResourceRecordDeleteBatchSizeMap);
+    }
+}

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/common/JTAEnvironmentBean.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/common/JTAEnvironmentBean.java
@@ -1182,7 +1182,7 @@ public class JTAEnvironmentBean implements JTAEnvironmentBeanMBean
 	/**
 	 * Alter the default batch size or set to -1 to disable batch deletion of
 	 * CommitMarkableResourceRecord from the database.
-	 * 
+	 *
 	 * @param batchSize
 	 *            -1 to prevent batching.
 	 */
@@ -1242,6 +1242,42 @@ public class JTAEnvironmentBean implements JTAEnvironmentBeanMBean
 			boolean notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches) {
 		this.notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches = notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches;
 	}
+
+    /**
+     * Remove a resource from the list of Markable Resources
+     */
+    public void removeCommitMarkableResource(String jndiName) {
+        synchronized (this) {
+            commitMarkableResourceJNDINames.remove(jndiName);
+            commitMarkableResourceTableNameMap.remove(jndiName);
+            performImmediateCleanupOfCommitMarkableResourceBranchesMap.remove(jndiName);
+            commitMarkableResourceRecordDeleteBatchSizeMap.remove(jndiName);
+        }
+    }
+
+    /**
+     * Add a resource to the list of Markable Resources
+     */
+    public void addCommitMarkableResource(String jndiName, String tableName, boolean immediateCleanup, int batchSize) {
+        synchronized (this) {
+            commitMarkableResourceJNDINames.add(jndiName);
+            commitMarkableResourceTableNameMap.put(jndiName, tableName);
+            performImmediateCleanupOfCommitMarkableResourceBranchesMap.put(jndiName, immediateCleanup);
+            commitMarkableResourceRecordDeleteBatchSizeMap.put(jndiName, batchSize);
+
+            // use the standard setter for notifyCommitMarkableResourceRecoveryModuleOfCompleteBranches,
+            // commitMarkableResourceRecordDeleteBatchSize and commitMarkableResourceTableName
+        }
+    }
+
+    public CmrJndiConfig getCmrJndiConfig() {
+        synchronized (this) {
+            return new CmrJndiConfig(commitMarkableResourceJNDINames,
+                    commitMarkableResourceTableNameMap,
+                    performImmediateCleanupOfCommitMarkableResourceBranchesMap,
+                    commitMarkableResourceRecordDeleteBatchSizeMap);
+        }
+    }
 
     /**
      * <p>

--- a/ArjunaJTA/jta/src/test/resources/standalone-cmr.xml
+++ b/ArjunaJTA/jta/src/test/resources/standalone-cmr.xml
@@ -140,8 +140,16 @@
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:4.0">
             <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" connectable="true">
                     <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS2" pool-name="ExampleDS2" enabled="true" use-java-context="true" connectable="true">
+                    <connection-url>jdbc:h2:./cmr;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                     <driver>h2</driver>
                     <security>
                         <user-name>sa</user-name>
@@ -382,6 +390,9 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <commit-markable-resources>
                 <commit-markable-resource jndi-name="java:jboss/datasources/ExampleDS">
+                    <xid-location name="xids" batch-size="1" immediate-cleanup="false"/>
+                </commit-markable-resource>
+                <commit-markable-resource jndi-name="java:jboss/datasources/ExampleDS2">
                     <xid-location name="xids" batch-size="1" immediate-cleanup="false"/>
                 </commit-markable-resource>
             </commit-markable-resources>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3357

MAIN !TOMCAT AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

This PR replaces #1670
The CMR collection based properties are dependent on each other and need to be set as a group (see JTAEnvironmentBean). 
