### PR TITLE
[JBTM-3368] provide error messages in the HTTP responses

### DIFF
--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/api/CoordinatorContainerFilter.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/api/CoordinatorContainerFilter.java
@@ -49,11 +49,10 @@ public class CoordinatorContainerFilter implements ContainerRequestFilter, Conta
             try {
                 lraId = new URI(Current.getLast(headers.get(LRA_HTTP_CONTEXT_HEADER)));
             } catch (URISyntaxException e) {
-                String msg = String.format("header %s contains an invalid URL %s",
-                        LRA_HTTP_CONTEXT_HEADER, Current.getLast(headers.get(LRA_HTTP_CONTEXT_HEADER)));
-
-                throw new WebApplicationException(Response.status(PRECONDITION_FAILED.getStatusCode())
-                        .entity(String.format("%s: %s", msg, e.getMessage())).build());
+                String errMsg = String.format("header %s contains an invalid URL %s: %s",
+                        LRA_HTTP_CONTEXT_HEADER, Current.getLast(headers.get(LRA_HTTP_CONTEXT_HEADER)), e.getMessage());
+                throw new WebApplicationException(errMsg, e,
+                        Response.status(PRECONDITION_FAILED.getStatusCode()).entity(errMsg).build());
             }
         }
 

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
@@ -54,6 +54,7 @@ import java.util.List;
 
 import static io.narayana.lra.LRAConstants.RECOVERY_COORDINATOR_PATH_NAME;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 
 @ApplicationScoped
@@ -130,9 +131,9 @@ public class RecoveryCoordinator {
                 lra = new URI(lraId);
             } catch (URISyntaxException e) {
                 LRALogger.i18NLogger.error_invalidFormatOfLraIdReplacingCompensatorURI(lraId, compensatorUrl, e);
-
-                throw new WebApplicationException(Response.status(INTERNAL_SERVER_ERROR.getStatusCode())
-                            .entity(String.format("%s: %s", lraId, e.getMessage())).build());
+                String errMsg = String.format("%s: %s", lraId, e.getMessage());
+                throw new WebApplicationException(errMsg, e,
+                        Response.status(INTERNAL_SERVER_ERROR.getStatusCode()).entity(errMsg).build());
             }
 
             lraService.updateRecoveryURI(lra, newCompensatorUrl, rcvCoordId, true);
@@ -141,7 +142,8 @@ public class RecoveryCoordinator {
         }
 
         LRALogger.i18NLogger.error_cannotFoundCompensatorUrl(compensatorUrl, lraId);
-        throw new NotFoundException(rcvCoordId);
+        String errorMsg = lraId + ": Cannot find compensator URL " + compensatorUrl;
+        throw new NotFoundException(errorMsg, Response.status(NOT_FOUND).entity(rcvCoordId).build());
     }
 
     @GET

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
@@ -112,9 +112,12 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
                 });
 
                 if (parseException[0] != null) {
-                    throw new WebApplicationException(lraId + ": Invalid link URI: " + parseException[0], BAD_REQUEST);
+                    String errorMsg = lraId + ": Invalid link URI: " + parseException[0];
+                    throw new WebApplicationException(errorMsg, parseException[0],
+                            Response.status(BAD_REQUEST).entity(errorMsg).build());
                 } else if (compensateURI == null && afterURI == null) {
-                    throw new WebApplicationException(lraId + ": Invalid link URI: missing compensator", BAD_REQUEST);
+                    String errorMsg = lraId + ": Invalid link URI: missing compensator";
+                    throw new WebApplicationException(errorMsg, Response.status(BAD_REQUEST).entity(errorMsg).build());
                 }
             } else {
                 this.compensateURI = new URI(String.format("%s/compensate", linkURI));
@@ -135,7 +138,9 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
             this.compensatorData = compensatorData;
         } catch (URISyntaxException e) {
             LRALogger.i18NLogger.error_invalidFormatToCreateLRARecord(lraId, linkURI);
-            throw new WebApplicationException(lraId + ": Invalid LRA id: " + e.getMessage(), BAD_REQUEST);
+            String errorMsg = lraId + ": Invalid LRA id: " + e.getMessage();
+            throw new WebApplicationException(errorMsg, e,
+                    Response.status(BAD_REQUEST).entity(errorMsg).build());
         }
     }
 
@@ -177,8 +182,9 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
             try {
                 link = Link.valueOf(lnk);
             } catch (Exception e) {
-                throw new WebApplicationException(Response.status(PRECONDITION_FAILED.getStatusCode())
-                        .entity(String.format("Invalid compensator join request: cannot parse link '%s'", linkStr)).build());
+                String errorMsg = "Invalid compensator join request: cannot parse link '" + linkStr + "'";
+                throw new WebApplicationException(errorMsg, e,
+                        Response.status(PRECONDITION_FAILED).entity(errorMsg).build());
             }
 
             if (COMPENSATE_REL.equals(link.getRel())) {
@@ -937,7 +943,9 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
         try {
             this.recoveryURI = new URI(recoveryURI);
         } catch (URISyntaxException e) {
-            throw new WebApplicationException(recoveryURI + ": Invalid recovery id: " + e.getMessage(), BAD_REQUEST);
+            String errorMsg = recoveryURI + ": Invalid recovery id: " + e.getMessage();
+            throw new WebApplicationException(errorMsg, e,
+                    Response.status(BAD_REQUEST).entity(errorMsg).build());
         }
     }
 

--- a/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/lra-coordinator-jar/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -53,6 +53,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static java.util.stream.Collectors.toList;
 
 @ApplicationScoped
@@ -85,7 +87,9 @@ public class LRAService {
                     }
                 }
 
-                throw new NotFoundException(Response.status(404).entity("Invalid transaction id: " + lraId).build());
+                String errorMsg = "Invalid transaction id: " + lraId;
+                throw new NotFoundException(errorMsg, // 404
+                        Response.status(NOT_FOUND).entity(errorMsg).build());
             }
 
             return recoveringLRAs.get(lraId);
@@ -252,7 +256,9 @@ public class LRAService {
 
             lra.abort();
 
-            throw new InternalServerErrorException("Could not start LRA: " + ActionStatus.stringForm(status));
+            String errorMsg = "Could not start LRA: " + ActionStatus.stringForm(status);
+            throw new InternalServerErrorException(errorMsg,
+                    Response.status(INTERNAL_SERVER_ERROR).entity(errorMsg).build());
         } else {
             try {
                 addTransaction(lra);

--- a/rts/lra/lra-proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRAParticipantResource.java
+++ b/rts/lra/lra-proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRAParticipantResource.java
@@ -112,7 +112,8 @@ public class LRAParticipantResource {
     private LRAParticipant getParticipant(String participantId) {
         LRAParticipant participant = lraParticipantRegistry.getParticipant(participantId);
         if (participant == null) {
-            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build());
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).
+                    entity(participantId + ": Cannot find participant in LRA registry").build());
         }
         return participant;
     }

--- a/rts/lra/lra-proxy/test/src/main/java/io/narayana/lra/proxy/test/service/ActivityService.java
+++ b/rts/lra/lra-proxy/test/src/main/java/io/narayana/lra/proxy/test/service/ActivityService.java
@@ -31,13 +31,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
 @ApplicationScoped
 public class ActivityService {
     private Map<String, Activity> activities = new HashMap<>();
 
     public Activity getActivity(String txId) throws NotFoundException {
         if (!activities.containsKey(txId)) {
-            throw new NotFoundException(Response.status(404).entity("Invalid activity id: " + txId).build());
+            String errorMsg = "Invalid activity id: " + txId;
+            throw new NotFoundException(errorMsg, // 404
+                    Response.status(NOT_FOUND).entity(errorMsg).build());
         }
 
         return activities.get(txId);
@@ -61,7 +65,9 @@ public class ActivityService {
         }
 
         if (failIfNotFound) {
-            throw new NotFoundException(Response.status(404).entity("Invalid activity id: " + txId).build());
+            String errorMsg = "Invalid activity id: " + txId;
+            throw new NotFoundException(errorMsg, // 404
+                    Response.status(NOT_FOUND).entity(errorMsg).build());
         }
 
         return new Activity(txId);

--- a/rts/lra/lra-service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/lra-service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -210,6 +210,14 @@ public interface lraI18NLogger {
     @Message(id = 25041, value = "Invalid format of coordinator url, was '%s'")
     void error_invalidCoordinatorId(String coordinatorUri, @Cause Throwable t);
 
+    @LogMessage(level = INFO)
+    @Message(id = 25042, value = "Failed enlisting to LRA '%s', coordinator '%s' responded with status '%d (%s)'. Returning '%d (%s)'.")
+    void info_failedToEnlistingLRANotFound(URL lraId, URI coordinatorUri, int coordinatorStatusCode,
+            String coordinatorStatusMsg, int returnStatusCode, String returnStatusMsg);
+
+    @Message(id = 25043, value = "Could not %s LRA '%s': coordinator '%s' responded with status '%s'")
+    String get_couldNotCompleteCompensateOnReturnedStatus(String actionName, URI lraId, URI coordinatorUri, String status);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/rts/lra/narayana-lra/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/narayana-lra/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -332,6 +332,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                             toURI(terminateURIs.get(STATUS)),
                             null);
                 } catch (NotFoundException e) {
+                    lraTrace(containerRequestContext, lraId, "ServerLRAFilter before: not found exception with " + e.getMessage());
                     throw e;
                 } catch (WebApplicationException e) {
                     lraTrace(containerRequestContext, lraId, "ServerLRAFilter before: aborting with " + e.getMessage());
@@ -491,7 +492,8 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
     }
 
     private void throwGenericLRAException(URI lraId, int statusCode, String message) throws WebApplicationException {
-        throw new WebApplicationException(Response.status(statusCode)
-                .entity(String.format("%s: %s", lraId, message)).build());
+        String errorMsg = String.format("%s: %s", lraId, message);
+        throw new WebApplicationException(errorMsg,
+                Response.status(statusCode).entity(errorMsg).build());
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3368

Idea of this PR is having information on error response. This helps in debugging and test investigation and expecting for users as well.

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA