### PR TITLE
[JBTM-3372] Add GH Actions workflow for LRA testing

### DIFF
--- a/.github/workflows/lra-test.yml
+++ b/.github/workflows/lra-test.yml
@@ -1,0 +1,46 @@
+name: LRA
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - "rts/lra/**"
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "rts/lra/**"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  lra-test:
+    name: LRA test with JDK ${{ matrix.java-version }}
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        java-version: [ 8, 11 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v1
+        name: Set up JDK ${{ matrix.java-version }}
+        with:
+          java-version: ${{ matrix.java-version }}
+
+      - uses: actions/cache@v2
+        name: Cache local Maven repository
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: LRA test
+        run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+          WORKSPACE=$PWD PROFILE=LRA ./scripts/hudson/narayana.sh
+        env:
+          LRA_TCK_TIMEOUT_FACTOR: 1
+


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3372

!MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA NO_WIN DB_TESTS !mysql !db2 !postgres !oracle

Examples:
https://github.com/xstefank/narayana/pull/3
https://github.com/xstefank/narayana/pull/2

Note that this action can't run the tests that depend on the running WFLY. If that is a requirement we need to setup WFLY download in the lra-coordinator-jar module.