### PR TITLE
[JBTM-3259][JBTM-3257] listener race condition on terminating recovery manager 4.17

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -1169,9 +1169,9 @@ public interface arjunaI18NLogger {
 	@LogMessage(level = WARN)
 	public void warn_recovery_AtomicActionRecoveryModule_3(Uid arg0, @Cause() Throwable arg1);
 
-	@Message(id = 12292, value = "Connection - IOException", format = MESSAGE_FORMAT)
+	@Message(id = 12292, value = "Connection error on running a work on the socket. IOException: {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
-	public void warn_recovery_Connection_1();
+	public void warn_recovery_Connection_1(IOException cause);
 
 	@Message(id = 12293, value = "Setting timeout exception.", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
@@ -1512,6 +1512,13 @@ public interface arjunaI18NLogger {
     @Message(id = 12396, value = "Cannot activate type ''{0}'' at object store ''{1}''", format = MESSAGE_FORMAT)
     @LogMessage(level = WARN)
     public void warn_could_not_activate_type_at_object_store(String type, ParticipantStore store, @Cause Throwable exception);
+
+	@Message(id = 12400, value = "Cannot terminate the recovery manager as the implementation is not known. Could be the recovery manager was not started yet?", format = MESSAGE_FORMAT)
+	String get_recovery_manager_implementation_is_not_set();
+
+	@Message(id = 12401, value = "There is already started a recovery manager in mode ''{0}'' which is different from the requested mode ''{1}''." +
+			"If you consider starting in a different mode then first terminate the currently running recovery manager.", format = MESSAGE_FORMAT)
+	String get_recovery_manager_already_started_in_different_mode(int startedRecoveryManagerMode, int modeProvidedToMethodParameter);
 
     /*
         Allocate new messages directly above this notice.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -31,6 +31,7 @@ import org.jboss.logging.Cause;
 import org.jboss.logging.LogMessage;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageLogger;
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -1356,9 +1357,9 @@ public interface arjunaI18NLogger {
 	@LogMessage(level = WARN)
 	public void warn_recovery_WorkerService_1(@Cause() Throwable arg0);
 
-	@Message(id = 12339, value = "IOException", format = MESSAGE_FORMAT)
+	@Message(id = 12339, value = "Cannot read line from the socket. IOException: {0}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
-	public void warn_recovery_WorkerService_2();
+	public void warn_recovery_WorkerService_2(IOException cause);
 
 	@Message(id = 12340, value = "RecoveryManager scan scheduled to begin.", format = MESSAGE_FORMAT)
 	@LogMessage(level = INFO)

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/RecoveryManager.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/RecoveryManager.java
@@ -133,7 +133,7 @@ public class RecoveryManager
 	else
 	{
 	    if (_recoveryManager.mode() != mode)
-		throw new IllegalArgumentException();
+		  throw new IllegalArgumentException(tsLogger.i18NLogger.get_recovery_manager_already_started_in_different_mode(_recoveryManager.mode(), mode));
 	}
 
 	return _recoveryManager;
@@ -442,7 +442,8 @@ public class RecoveryManager
                     }
                     catch(InterruptedException interruptedException)
                     {
-                        // do nothing
+                        System.err.println("The retry attempt was interrupted. Exiting...");
+                        throw new IllegalStateException(interruptedException);
                     }
                     manager = manager();
                 }
@@ -483,7 +484,7 @@ public class RecoveryManager
     private final void checkState ()
     {
         if (_theImple == null)
-            throw new IllegalStateException();
+            throw new IllegalStateException(tsLogger.i18NLogger.get_recovery_manager_implementation_is_not_set());
     }
 
     private RecoveryManagerImple _theImple = null;

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/RecoveryManager.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/recovery/RecoveryManager.java
@@ -209,6 +209,7 @@ public class RecoveryManager
 
         _theImple.stop(async);
         _theImple = null;
+        _recoveryManager = null;
     }
 
     /**

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/Connection.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/Connection.java
@@ -87,8 +87,8 @@ public class Connection extends Thread
 
          _service.doWork ( is, os );
       }
-      catch ( IOException ex ) {
-          tsLogger.i18NLogger.warn_recovery_Connection_1();
+      catch ( IOException ioe ) {
+          tsLogger.i18NLogger.warn_recovery_Connection_1(ioe);
       }
       finally
       {
@@ -102,12 +102,12 @@ public class Connection extends Thread
    }
 
    // What client (RecoveryManager) talks to.
-   private Socket  _server_socket;
+   private final Socket  _server_socket;
    
    // What Service is provided to the client(RecoveryManager).
-   private Service _service;
+   private final Service _service;
 
-   private Callback _callback;
+   private final Callback _callback;
 
     // abstract class instantiated by clients to allow notification that a connection has been closed
     

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/Listener.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/Listener.java
@@ -249,8 +249,8 @@ public class Listener extends Thread
            }
            try {
                wait();
-           } catch (InterruptedException e) {
-               // ignore
+           } catch (InterruptedException ie) {
+               tsLogger.logger.debug("Waiting for connection close was interrupted", ie);
            }
        }
       
@@ -259,6 +259,7 @@ public class Listener extends Thread
        try {
            this.join();
        } catch (InterruptedException ie) {
+           tsLogger.logger.debug("Waiting to ensure the listener thread has exited was interrupted", ie);
        }
    }
 

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/WorkerService.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/WorkerService.java
@@ -85,7 +85,7 @@ public class WorkerService implements Service
 		if (request.equals(RecoveryDriver.SCAN))
 		{
             synchronized (this) {
-                if (doWait) {
+                if (doWait && _periodicRecovery.getMode() != PeriodicRecovery.Mode.TERMINATED) {
                     // ok, the periodic recovery thread cannot have finished responding to the last scan request
                     // so it is safe to wait. if we delivered the request while the last scan was still going
                     // then it will have been ignored but that is ok.
@@ -95,6 +95,9 @@ public class WorkerService implements Service
 		    }
 		    catch (Exception ex)
 		    {
+                if(tsLogger.logger.isTraceEnabled()) {
+                    tsLogger.logger.trace("Waiting for recovery scan to complete finished with an exception", ex);
+                }
                 tsLogger.i18NLogger.info_recovery_WorkerService_4();
 		    }
                 }
@@ -107,8 +110,8 @@ public class WorkerService implements Service
 
 	    out.flush();
 	}
-	catch (IOException ex) {
-        tsLogger.i18NLogger.warn_recovery_WorkerService_2();
+	catch (IOException ioe) {
+        tsLogger.i18NLogger.warn_recovery_WorkerService_2(ioe);
     }
 	catch ( Exception ex ) {
         tsLogger.i18NLogger.warn_recovery_WorkerService_1(ex);

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/WorkerService.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/recovery/WorkerService.java
@@ -59,19 +59,19 @@ public class WorkerService implements Service
 	{
 	    String request = in.readLine();
 
-        if (request.equals("PING"))
+        if ("PING".equals(request))
         {
             out.println("PONG");
         }
         else
-	    if (request.equals(RecoveryDriver.SCAN) || (request.equals(RecoveryDriver.ASYNC_SCAN)))
+	    if (RecoveryDriver.SCAN.equals(request) || RecoveryDriver.ASYNC_SCAN.equals(request))
 	    {
             // hmm, we need to synchronize on the periodic recovery object in order to wake it up via notify.
             // but the periodic recovery object has to synchronize on this object and then call notify
             // in order to tell it that the last requested scan has completed. i.e. we have a two way
             // wakeup here. so we have to be careful to avoid a deadlock.
 
-            if (request.equals(RecoveryDriver.SCAN)) {
+            if (RecoveryDriver.SCAN.equals(request)) {
                 // do this before kicking the periodic recovery thread
                 synchronized (this) {
                     doWait = true;
@@ -82,7 +82,7 @@ public class WorkerService implements Service
 
             tsLogger.i18NLogger.info_recovery_WorkerService_3();
 
-		if (request.equals(RecoveryDriver.SCAN))
+		if (RecoveryDriver.SCAN.equals(request))
 		{
             synchronized (this) {
                 if (doWait && _periodicRecovery.getMode() != PeriodicRecovery.Mode.TERMINATED) {

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/recovery/RecoveryDriverUnitTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/recovery/RecoveryDriverUnitTest.java
@@ -41,25 +41,25 @@ public class RecoveryDriverUnitTest
     @Test
     public void testInvalid () throws Exception
     {
-        RecoveryDriver rd = new RecoveryDriver(0, "foobar");
+        RecoveryDriver rd = new RecoveryDriver(0, "non-existent-hostname");
         
         try
         {
             rd.asynchronousScan();
-            
-            fail();
+
+            fail("Recovery driver asynchronously calls to a non-existent host:port at 'non-existent-hostname:0'. Failure is expected.");
         }
-        catch (final Exception ex)
+        catch (final Exception expected)
         {
         }
         
         try
         {
             rd.synchronousScan();
-            
-            fail();
+
+            fail("Recovery driver synchronously calls to a non-existent host:port at 'non-existent-hostname:0'. Failure is expected.");
         }
-        catch (final Exception ex)
+        catch (final Exception expected)
         {
         }
     }

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/recovery/RecoverySocketUnitTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/recovery/RecoverySocketUnitTest.java
@@ -1,0 +1,238 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.hp.mwtests.ts.arjuna.recovery;
+
+import com.arjuna.ats.arjuna.common.recoveryPropertyManager;
+import com.arjuna.ats.arjuna.recovery.RecoveryDriver;
+import com.arjuna.ats.arjuna.recovery.RecoveryManager;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases which work with a direct connection to socket where RecoveryManager listens at.
+ */
+public class RecoverySocketUnitTest {
+    private static final Logger log = Logger.getLogger(RecoverySocketUnitTest.class);
+
+    private static boolean socketRecoveryListenerInitialState;
+    private static int periodicRecoveryPeriodInitialState, recoveryBackoffPeriodInitialState;
+
+    private InetAddress recoveryManagerHost = null;
+    private int recoveryManagerPort = 0;
+    private RecoveryManager recoveryManager;
+
+    @BeforeClass
+    public static void getInitialState() {
+        socketRecoveryListenerInitialState = recoveryPropertyManager.getRecoveryEnvironmentBean().isRecoveryListener();
+        periodicRecoveryPeriodInitialState =  recoveryPropertyManager.getRecoveryEnvironmentBean().getPeriodicRecoveryPeriod();
+        recoveryBackoffPeriodInitialState = recoveryPropertyManager.getRecoveryEnvironmentBean().getRecoveryBackoffPeriod();
+    }
+
+    @AfterClass
+    public static void resetInitialState() {
+        recoveryPropertyManager.getRecoveryEnvironmentBean().setRecoveryListener(socketRecoveryListenerInitialState);
+        recoveryPropertyManager.getRecoveryEnvironmentBean().setPeriodicRecoveryPeriod(periodicRecoveryPeriodInitialState);
+        recoveryPropertyManager.getRecoveryEnvironmentBean().setRecoveryBackoffPeriod(recoveryBackoffPeriodInitialState);
+    }
+
+    @Before
+    public void enableRecoveryListener() throws InterruptedException{
+        recoveryPropertyManager.getRecoveryEnvironmentBean().setRecoveryListener(true);
+        recoveryPropertyManager.getRecoveryEnvironmentBean().setPeriodicRecoveryPeriod(1);
+        recoveryPropertyManager.getRecoveryEnvironmentBean().setRecoveryBackoffPeriod(1);
+        recoveryManager = RecoveryManager.manager();
+    }
+
+    @After
+    public void terminateRecoveryListener() {
+        try {
+            recoveryManager.terminate();
+        } catch (IllegalStateException ise) {
+            // cannot terminate cleanly which may happen because some of the tests which terminated recovery manager before
+            log.debugf(ise,"Cannot terminate recovery manager. This is probably not a problem as the test may stopped it already. Check the prior errors.");
+        }
+    }
+
+    @Test
+    public void socketNullWrite() throws Exception {
+        Socket connectorSocket = null;
+        try {
+            connectorSocket = getSocket();
+            BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), "UTF-8"));
+            PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), "UTF-8"));
+            toServer.print("PING");
+            connectorSocket.shutdownOutput();
+            // no flush, shutting down connector + waiting for getting NPE before the JBTM-3257 was fixed
+            assertEquals("ERROR", fromServer.readLine());
+        } catch (final SocketTimeoutException stex) {
+            failOnSocketTimeout(stex, RecoveryDriver.SCAN);
+        } finally {
+            if(connectorSocket != null) {
+                try {
+                    connectorSocket.close();
+                } catch (IOException ioe) {
+                    throw new IllegalStateException("Cannot close recovery socket", ioe);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void socketScanTerminateAbruptly() throws Exception {
+        Socket connectorSocket = null;
+        try {
+            connectorSocket = getSocket();
+            // stream to RecoveryManager listener
+            PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), "UTF-8"));
+            toServer.println(RecoveryDriver.SCAN);
+            toServer.flush();
+            recoveryManager.terminate();
+        } catch (final SocketTimeoutException stex) {
+            failOnSocketTimeout(stex, RecoveryDriver.SCAN);
+        } finally {
+            if(connectorSocket != null) {
+                try {
+                    connectorSocket.close();
+                } catch (IOException ioe) {
+                    throw new IllegalStateException("Cannot close recovery socket", ioe);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void socketPing() throws Exception {
+        Socket connectorSocket = null;
+        try {
+            connectorSocket = getSocket();
+            // streams to and from the RecoveryManager listener
+            BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), "UTF-8"));
+            PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), "UTF-8"));
+
+            toServer.println(RecoveryDriver.PING);
+            toServer.flush();
+            String stringResponse = fromServer.readLine();
+            assertEquals("Expecting the correct response string for command " + RecoveryDriver.PING, RecoveryDriver.PONG, stringResponse);
+        } catch (final SocketTimeoutException stex) {
+            failOnSocketTimeout(stex, RecoveryDriver.PING);
+        } finally {
+            if(connectorSocket != null) {
+                try {
+                    connectorSocket.close();
+                } catch (IOException ioe) {
+                    throw new IllegalStateException("Cannot close recovery socket", ioe);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void socketScan() throws Exception {
+        Socket connectorSocket = null;
+        try {
+            connectorSocket = getSocket();
+            // streams to and from the RecoveryManager listener
+            BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), "UTF-8"));
+            PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), "UTF-8"));
+
+            toServer.println(RecoveryDriver.SCAN);
+            toServer.flush();
+            String stringResponse = fromServer.readLine();
+            assertEquals("Expecting SCAN to be processed correctly", "DONE", stringResponse);
+        } catch (final SocketTimeoutException stex) {
+            failOnSocketTimeout(stex, RecoveryDriver.SCAN);
+        } finally {
+            if(connectorSocket != null) {
+                try {
+                    connectorSocket.close();
+                } catch (IOException ioe) {
+                    throw new IllegalStateException("Cannot close recovery socket", ioe);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void socketTimeout() throws Exception {
+        Socket connectorSocket = null;
+        try {
+            connectorSocket = getSocket();
+            connectorSocket.setSoTimeout(500);
+            PrintWriter toServer = new PrintWriter(new OutputStreamWriter(connectorSocket.getOutputStream(), "UTF-8"));
+            BufferedReader fromServer = new BufferedReader(new InputStreamReader(connectorSocket.getInputStream(), "UTF-8"));
+            toServer.print(RecoveryDriver.PING);
+            String stringResponse = fromServer.readLine(); // waiting indefinitely as the socket call was not finished with EOL
+            fail("Expecting the socket times out as the PING call was not ended properly");
+        } catch (final SocketTimeoutException expected) {
+            log.debugf("The socket timed-out which is desired");
+        } finally {
+            if(connectorSocket != null) {
+                try {
+                    connectorSocket.close();
+                } catch (IOException ioe) {
+                    throw new IllegalStateException("Cannot close recovery socket", ioe);
+                }
+            }
+        }
+        // when the socket timed-out the next call has to succeed, let's try to ping it
+        socketPing();
+    }
+
+    private Socket getSocket() {
+        try {
+            recoveryManagerHost = RecoveryManager.getRecoveryManagerHost();
+            recoveryManagerPort = RecoveryManager.getRecoveryManagerPort();
+            Socket connectorSocket = new Socket(recoveryManagerHost, recoveryManagerPort);
+            connectorSocket.setSoTimeout(RecoveryDriver.DEFAULT_SO_TIMEOUT);
+            return connectorSocket;
+        } catch (UnknownHostException uhe) {
+            throw new IllegalStateException("Cannot obtain the data for recovery manager host", uhe);
+        } catch (IOException ioe) {
+            throw new IllegalStateException("Cannot create a socket for " + recoveryManagerHost + ":" + recoveryManagerPort, ioe);
+        }
+    }
+
+    private void failOnSocketTimeout(SocketTimeoutException stex, String failedSocketCommand) {
+        log.errorf(stex, "Cannot finish with the socket operation at %s:%d because of a timeout%n",
+                recoveryManagerHost, recoveryManagerPort);
+        Assert.fail(String.format("Socket operation '%s' timed out", failedSocketCommand));
+    }
+}


### PR DESCRIPTION
Backport of fixes on recovery manager listener which is used in tests. Not closing the recovery manager listener properly or not notyfying it may cause race conditions and hanging of the tests.

XTS
!MAIN !CORE
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !LRA !QA_JTS_JACORB
