### PR TITLE
JBTM-3361 disable reproducer - attach it to the case notes instead

### DIFF
--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/nonuniquexids/ImportNonUniqueBranchTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/recovery/nonuniquexids/ImportNonUniqueBranchTest.java
@@ -95,12 +95,6 @@ public class ImportNonUniqueBranchTest {
         Assert.assertEquals("resource commit error", 0, XAResourceImpl.getErrorCount());
     }
 
-    @Test
-    public void testNotWrapped() throws Exception {
-        test(false);
-        Assert.assertNotEquals("resource commit should have failed", 0, XAResourceImpl.getErrorCount());
-    }
-
     public void test(boolean wrap) throws Exception {
         XAResourceImpl.clearErrorCount();
         ResourceManager resourceManagerA = new ResourceManager("jndi:/A", wrap);


### PR DESCRIPTION
[JBTM-3361](https://issues.redhat.com/browse/JBTM-3361) recovery for non-unique xids

The initial fix for JBTM-3361 included a reproducer as a unit test. But the reproducer should only be applied to the code that contained the bug and not to the fixed code. This PR removes the reproducer test (and I updated the issue description to say how the issue can be reproduced). 

MAIN
!JACOCO !AS_TESTS !XTS !TOMCAT !AS_TESTS !RTS JACOCO !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
