### PR TITLE
[JBTM-3377]: renaming LRA directory structure: follow-up

### DIFF
--- a/narayana-full/src/main/assembly/bin.xml
+++ b/narayana-full/src/main/assembly/bin.xml
@@ -327,7 +327,7 @@
 			<outputDirectory>quickstarts/rest-tx</outputDirectory>
 		</fileSet>
 		<fileSet>
-			<directory>../rts/lra/lra-coordinator/target/lib</directory>
+			<directory>../rts/lra/coordinator-quarkus/target/lib</directory>
 			<outputDirectory>rts/lra/lib</outputDirectory>
 		</fileSet>
 	</fileSets>


### PR DESCRIPTION
fix narayanaa-full assembly quarkus lib directory to be involved

https://issues.redhat.com/browse/JBTM-3377
follow-up to https://github.com/jbosstm/narayana/pull/1703

LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO

