### PR TITLE
[JBTM-3349] follow-up: on joining to parent LRA the response should not be precondition failed

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -264,8 +264,6 @@ public class Coordinator {
                         client.close();
                     }
                 }
-
-                return Response.status(PRECONDITION_FAILED).build();
             }
         }
 


### PR DESCRIPTION
fix of a failure which came from the fix https://issues.redhat.com/browse/JBTM-3349
fix for https://issues.redhat.com/browse/JBTM-3375 to run the `lra-test` quickstarts fine

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA