### PR TITLE
[JBTM-3361] remove java.util.Objects which is not available in JDK6

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/NameScopedXAResource.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/NameScopedXAResource.java
@@ -21,7 +21,6 @@
 package com.arjuna.ats.internal.jta.recovery.arjunacore;
 
 import javax.transaction.xa.XAResource;
-import java.util.Objects;
 
 public class NameScopedXAResource implements NameScopedElement {
 
@@ -63,7 +62,7 @@ public class NameScopedXAResource implements NameScopedElement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(xaResource, jndiName);
+        return Objects.hash(new Object[] { xaResource, jndiName });
     }
 
     @Override

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/NameScopedXid.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/NameScopedXid.java
@@ -21,7 +21,6 @@
 package com.arjuna.ats.internal.jta.recovery.arjunacore;
 
 import javax.transaction.xa.Xid;
-import java.util.Objects;
 
 class NameScopedXid implements NameScopedElement {
 
@@ -63,7 +62,7 @@ class NameScopedXid implements NameScopedElement {
 
     @Override
     public int hashCode() {
-        return Objects.hash(xid, jndiName);
+        return Objects.hash(new Object[] { xid, jndiName });
     }
 
     @Override

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/Objects.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/recovery/arjunacore/Objects.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc. and/or its affiliates,
+ * and individual contributors as indicated by the @author tags.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ *
+ * (C) 2020,
+ * @author JBoss, by Red Hat.
+ */
+package com.arjuna.ats.internal.jta.recovery.arjunacore;
+
+import java.util.Arrays;
+
+class Objects {
+
+    public static boolean equals(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+
+    public static int hash(Object[] values) {
+        return Arrays.hashCode(values);
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3361

MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle