### PR TITLE
[SCRIPTS ONLY] adding a shell script to download WFLY

### DIFF
--- a/scripts/hudson/download-wildfly.sh
+++ b/scripts/hudson/download-wildfly.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#  functions to download the WildFly and to setup the JBOSS_HOME directory
+
+function download_wildfly_nightly_build() {
+  local urlNightlyBuildZip=${1:-https://ci.wildfly.org/httpAuth/repository/downloadAll/WF_Nightly/.lastSuccessful/artifacts.zip}
+  wget --user=guest --password=guest -nv "${urlNightlyBuildZip}"
+  unzip -q artifacts.zip
+  # the artifacts.zip may be wrapping several zip files: artifacts.zip -> wildfly-latest-SNAPSHOT.zip -> wildfly-###-SNAPSHOT.zip
+  wildflyLatestZipWrapper=$(ls wildfly-latest-*.zip | head -n 1)
+  if [ -f "${wildflyLatestZipWrapper}" ]; then # wrapper zip exists, let's unzip it to proceed further to distro zip
+    unzip -q "${wildflyLatestZipWrapper}"
+    [ $? -ne 0 ] && echo "Cannot unzip WildFly nightly build wrapper zip file '${wildflyLatestZipWrapper}'" && return 2
+  fi
+  wildflyDistZip=$(ls wildfly-*-SNAPSHOT.zip | head -n 1)
+  [ "x$wildflyDistZip" = "x" ] && echo "Cannot find any zip file of SNAPSHOT WildFly distribution in the nightly build artifacts" && return 1
+  unzip -q "${wildflyDistZip}"
+  [ $? -ne 0 ] && echo "Cannot unzip WildFly nightly build distribution zip file '${wildflyDistZip}'" && return 3
+  export JBOSS_HOME="${PWD}/${wildflyDistZip%.zip}"
+  [ ! -d "${JBOSS_HOME}" ] && echo "After unzipping the file '${wildflyDistZip}' the JBOSS_HOME directory at '${JBOSS_HOME}' does not exist" && return 4
+  # zip cleanup
+  rm -f artifacts.zip
+  rm -f wildfly-*-SNAPSHOT*.zip
+}
+
+function download_wildfly_dist() {
+  local urlDistZip=${1:-https://download.jboss.org/wildfly/21.0.0.Final/wildfly-21.0.0.Final.zip}
+  wget -nv "${urlDistZip}"
+  local wildflyDistZip=${urlDistZip##*/}
+  unzip -q "${wildflyDistZip}"
+  [ $? -ne 0 ] && echo "Cannot unzip WildFly distribution zip file '${wildflyDistZip}'" && return 3
+  export JBOSS_HOME="${PWD}/${wildflyDistZip%.zip}"
+  # zip cleanup
+  rm -f "${wildflyDistZip}"
+}

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -200,7 +200,7 @@ function init_test_options {
     fi
     [ $NARAYANA_TESTS ] || NARAYANA_TESTS=0	# run the narayana surefire tests
     [ $NARAYANA_BUILD ] || NARAYANA_BUILD=0 # build narayana
-    [ $AS_BUILD ] || AS_BUILD=0 # git clone and build a fresh copy of the AS
+    [ $AS_BUILD ] && [ -z "$JBOSS_HOME" ]  || AS_BUILD=0 # git clone and build a fresh copy of the AS when JBOSS_HOME is not provided
     [ $BLACKTIE ] || BLACKTIE=0 # Build BlackTie
     [ $OSGI_TESTS ] || OSGI_TESTS=0 # OSGI tests
     [ $TXF_TESTS ] || TXF_TESTS=0 # compensations tests


### PR DESCRIPTION
and provide a way to force not building JBoss AS when WFLY is downloaded

This is no change for the currently running CI matrix but it provides a helper functions and a way to skip the jboss as build when the CI job defines it.
Not building the AS may make pretty faster the axes like RTS, XTS, LRA.

AS_TESTS
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA