### PR TITLE
[SCRIPTS ONLY] allow to skip CMR tests when defined in job config

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -60,8 +60,9 @@ function init_test_options {
         if [[ ! $PULL_DESCRIPTION_BODY == *!AS_TESTS* ]]; then
           comment_on_pull "Started testing this pull request with $PROFILE profile: $BUILD_URL"
           export AS_BUILD=1 AS_TESTS=1 NARAYANA_BUILD=1 NARAYANA_TESTS=0 BLACKTIE=0 XTS_AS_TESTS=0 XTS_TESTS=0 TXF_TESTS=0 txbridge=0
-          export RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=1 QA_TESTS=0 SUN_ORB=0 JAC_ORB=0 JTA_AS_TESTS=1 OSGI_TESTS=0
+          export RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=1 QA_TESTS=0 SUN_ORB=0 JAC_ORB=0 OSGI_TESTS=0
           export TOMCAT_TESTS=0 LRA_TESTS=0
+          export JTA_AS_TESTS=${JTA_AS_TESTS:-1} # possibility to disable CMR tests when running on the app server which does not implement the functionality
         else
           export COMMENT_ON_PULL=""
         fi


### PR DESCRIPTION
The CMR is not implemented in JBoss AS 7.2.0. AS the CMR is not available it's nonsense to force testing it as any such test fails.

MAIN
!QA_JTS_JACORB !QA_JTA !XTS !QA_JTS_JDKORB