### PR TITLE
[JBTM-3389] removing apache httpclient depenendencies as not used anymore

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
@@ -33,7 +33,7 @@ import io.narayana.lra.LRAConstants;
 import io.narayana.lra.LRAData;
 import io.narayana.lra.coordinator.domain.service.LRAService;
 import io.narayana.lra.logging.LRALogger;
-import org.apache.http.HttpHeaders;
+import javax.ws.rs.core.HttpHeaders;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery1TestCase.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery1TestCase.java
@@ -32,7 +32,6 @@ import io.narayana.lra.coordinator.domain.service.LRAService;
 import io.narayana.lra.coordinator.internal.LRARecoveryModule;
 import io.narayana.lra.filter.ServerLRAFilter;
 import io.narayana.lra.logging.LRALogger;
-import org.apache.http.HttpConnection;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -102,7 +101,6 @@ public class LRACoordinatorRecovery1TestCase extends TestBase {
         return ShrinkWrap.create(WebArchive.class, COORDINATOR_DEPLOYMENT + ".war")
                 .addPackages(false, coordinatorPackages)
                 .addPackages(false, participantPackages)
-                .addPackages(true, HttpConnection.class.getPackage())
                 .addAsManifestResource(new StringAsset(ManifestMF), "MANIFEST.MF")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery2TestCase.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/LRACoordinatorRecovery2TestCase.java
@@ -31,7 +31,6 @@ import io.narayana.lra.coordinator.domain.service.LRAService;
 import io.narayana.lra.coordinator.internal.LRARecoveryModule;
 import io.narayana.lra.filter.ServerLRAFilter;
 import io.narayana.lra.logging.LRALogger;
-import org.apache.http.HttpConnection;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -104,7 +103,6 @@ public class LRACoordinatorRecovery2TestCase extends TestBase {
         return ShrinkWrap.create(WebArchive.class, COORDINATOR_DEPLOYMENT + ".war")
                 .addPackages(false, coordinatorPackages)
                 .addPackages(false, participantPackages)
-                .addPackages(true, HttpConnection.class.getPackage())
                 .addAsManifestResource(new StringAsset(ManifestMF), "MANIFEST.MF")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }

--- a/rts/lra/jaxrs/pom.xml
+++ b/rts/lra/jaxrs/pom.xml
@@ -21,12 +21,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>org.apache.httpcomponents</groupId>
-           <artifactId>httpclient</artifactId>
-           <version>${version.apache.httpclient}</version>
-         </dependency>
-
-        <dependency>
           <groupId>org.jboss.narayana.rts</groupId>
           <artifactId>lra-proxy-api</artifactId>
           <version>${project.version}</version>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -21,7 +21,6 @@
         <version.jackson>2.9.10.1</version.jackson>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
-        <version.apache.httpclient>4.5.10</version.apache.httpclient>
         <version.cdi-api>2.0</version.cdi-api>
 
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->

--- a/rts/lra/test/basic/pom.xml
+++ b/rts/lra/test/basic/pom.xml
@@ -35,12 +35,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>${version.apache.httpclient}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.narayana.rts</groupId>
       <artifactId>lra-test-arquillian-extension</artifactId>
       <version>${project.version}</version>

--- a/rts/lra/test/tck/pom.xml
+++ b/rts/lra/test/tck/pom.xml
@@ -71,11 +71,6 @@
             <artifactId>lra-test-arquillian-extension</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${version.apache.httpclient}</version>
-        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3389

LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
