### PR TITLE
JBTM-3391 LRA Transaction#isInEndState method can fail the LRA if fai…

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/Transaction.java
@@ -605,9 +605,9 @@ public class Transaction extends AtomicAction {
     protected boolean isInEndState() {
         // update the status first by checking for heuristics and failed participants
         if (status == LRAStatus.Cancelling && allFinished(heuristicList, failedList)) {
-            status = ((failedList != null) && (failedList.size() == 0)) ? LRAStatus.Cancelled : LRAStatus.FailedToCancel;
+            status = ((failedList == null) || (failedList.size() == 0)) ? LRAStatus.Cancelled : LRAStatus.FailedToCancel;
         } else if (status == LRAStatus.Closing && allFinished(heuristicList, failedList)) {
-            status = ((failedList != null) && (failedList.size() == 0)) ? LRAStatus.Closed : LRAStatus.FailedToClose;
+            status = ((failedList == null) || (failedList.size() == 0)) ? LRAStatus.Closed : LRAStatus.FailedToClose;
         }
 
         return isFinished();


### PR DESCRIPTION
…ledList is not created before

https://issues.redhat.com/browse/JBTM-3391

!MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF LRA NO_WIN !DB_TESTS !MySQL !db2 !postgres !oracle
