### PR TITLE
[JBTM-3379] Revert: make participant timeout configurable

### DIFF
--- a/rts/lra/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -44,12 +44,10 @@ public final class LRAConstants {
     public static final String HTTP_METHOD_NAME = "method"; // the name of the HTTP method used to invoke participants
 
     /**
-     * System property name which defines the connection read timeout which is used
-     * by LRA Coordinator and its friends when connecting remote participants and other coordinators.
-     * The value is in seconds. The default value is {@code 2}.
+     * Number of seconds to wait for requests to participant.
+     * The timeout is hardcoded as the protocol expects retry in case of failure and timeout.
      */
-    public static final String PARTICIPANT_TIMEOUT_PARAM = "narayana.lra.participant.timeout";
-    public static final long PARTICIPANT_TIMEOUT = Long.getLong(PARTICIPANT_TIMEOUT_PARAM, 2);
+    public static final long PARTICIPANT_TIMEOUT = 2;
 
     private static final Pattern UID_REGEXP_EXTRACT_MATCHER = Pattern.compile(".*/([^/?]+).*");
 


### PR DESCRIPTION
Revert of the adjustment for JBTM-3379 - https://issues.redhat.com/browse/JBTM-3379

LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO