### PR TITLE
CI SCRIPT ONLY: Fail the build if wget of openjdk-orb jar does not work

### DIFF
--- a/scripts/hudson/narayana.bat
+++ b/scripts/hudson/narayana.bat
@@ -40,7 +40,7 @@ IF NOT EXIST wildfly-%WILDFLY_MASTER_VERSION%.zip copy c:\Users\hudson\Downloads
 if %ERRORLEVEL% NEQ 0 (call:comment_on_pull "Pull failed on Windows - could not download http://download.jboss.org/wildfly/%WILDFLY_MASTER_VERSION%/wildfly-%WILDFLY_MASTER_VERSION%.zip" & exit -1)
 unzip wildfly-%WILDFLY_MASTER_VERSION%
 rem REPLACE THE OPENJDK-ORB WITH THE 8.0.8.Final
-wget --no-check-certificate https://repository.jboss.org/nexus/content/repositories/releases/org/jboss/openjdk-orb/openjdk-orb/8.0.8.Final/openjdk-orb-8.0.8.Final.jar -O %JBOSS_HOME%\modules\system\layers\base\javax\orb\api\main\openjdk-orb-8.0.8.Final.jar
+call wget --no-check-certificate https://repository.jboss.org/nexus/content/repositories/releases/org/jboss/openjdk-orb/openjdk-orb/8.0.8.Final/openjdk-orb-8.0.8.Final.jar -O %JBOSS_HOME%\modules\system\layers\base\javax\orb\api\main\openjdk-orb-8.0.8.Final.jar || (call:fail_build & exit -1)
 set OPENJDK_ORB_MODULE_XML=%JBOSS_HOME%\modules\system\layers\base\javax\orb\api\main\module.xml
 powershell -Command "((Get-Content ($env:OPENJDK_ORB_MODULE_XML)).replace('8.0.6.Final', '8.0.8.Final') | Set-Content ($env:OPENJDK_ORB_MODULE_XML))"
 unzip wildfly-blacktie\build\target\wildfly-blacktie-build-5.10.7.Final-SNAPSHOT-bin.zip -d %JBOSS_HOME%

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -533,6 +533,9 @@ function blacktie {
     if [ $JAVA_VERSION -ge "9" ]; then
       # replace the openjdk-orb with the 8.0.8.Final
       wget https://repository.jboss.org/nexus/content/repositories/releases/org/jboss/openjdk-orb/openjdk-orb/8.0.8.Final/openjdk-orb-8.0.8.Final.jar -O blacktie/wildfly-${WILDFLY_MASTER_VERSION}/modules/system/layers/base/javax/orb/api/main/openjdk-orb-8.0.8.Final.jar
+      if [ "$?" != "0" ]; then
+            fatal "Pull failed - could not wget https://repository.jboss.org/nexus/content/repositories/releases/org/jboss/openjdk-orb/openjdk-orb/8.0.8.Final/openjdk-orb-8.0.8.Final.jar"
+      fi
       sed -i s/8.0.6.Final/8.0.8.Final/g blacktie/wildfly-${WILDFLY_MASTER_VERSION}/modules/system/layers/base/javax/orb/api/main/module.xml
       JBOSS_HOME=`pwd`/blacktie/wildfly-${WILDFLY_MASTER_VERSION} JAVA_OPTS="--add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED -Xms256m -Xmx256m $JAVA_OPTS" blacktie/wildfly-${WILDFLY_MASTER_VERSION}/bin/standalone.sh -c standalone-blacktie.xml -Djboss.bind.address=$JBOSSAS_IP_ADDR -Djboss.bind.address.unsecure=$JBOSSAS_IP_ADDR -Djboss.bind.address.management=$JBOSSAS_IP_ADDR&
     else


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: JBTM-XYZ Subject
- [ ] Pull Request contains link to the JIRA issue(s)

Our style rules for submitting code are as follows:

* If you add a new file it MUST adhere to our checkstyle ruleset.
  1. If you change a file (in a non trivial way) you are allowed (MAY) to reformat the code to conform to our checkstyle ruleset (`org.wildfly.checkstyle:wildfly-checkstyle-config`).
  2. If you choose not to reformat it then you SHOULD, where possible, try to follow the same style that's already in use for that file.


The build axis can be controlled by prefixing a ! on the following as appropriate.

NO_WIN !MAIN !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB BLACKTIE !PERF !LRA !DB_TESTS mysql db2 postgres oracle
