### PR TITLE
[JBTM-3307] enabling LRACoordinatorRecovery2TestCase with timeout adjustments

### DIFF
--- a/rts/lra/coordinator/pom.xml
+++ b/rts/lra/coordinator/pom.xml
@@ -163,6 +163,7 @@
                                 <lra.coordinator.host>${lra.coordinator.host}</lra.coordinator.host>
                                 <lra.coordinator.url>${lra.coordinator.url}</lra.coordinator.url>
                                 <server.jvm.args>${server.jvm.args} -Dlra.coordinator.url=${lra.coordinator.url}</server.jvm.args>
+                                <lra.test.timeout.factor>${lra.test.timeout.factor}</lra.test.timeout.factor>
                             </systemPropertyVariables>
                             <systemProperties>
                                 <arquillian.xml>arquillian.xml</arquillian.xml>

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/TimeoutValueAdjuster.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/TimeoutValueAdjuster.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.coordinator;
+
+final class TimeoutValueAdjuster {
+    private static final String TIMEOUT_FACTOR_PROPERTY = "lra.test.timeout.factor";
+    private static final String timeoutFactorString = System.getProperty(TIMEOUT_FACTOR_PROPERTY, "1.0");
+    private static final double timeoutFactor = Double.parseDouble(timeoutFactorString);
+
+    private TimeoutValueAdjuster() {
+        // not for initialization
+    }
+
+    static long adjustTimeout(long originalTimeout)  {
+        if (timeoutFactor <= 0) {
+            return originalTimeout;
+        }
+        return (long) Math.ceil(originalTimeout * timeoutFactor);
+    }
+}

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -38,6 +38,8 @@
 
         <thorntail.test.logging.category.arjuna></thorntail.test.logging.category.arjuna>
         <thorntail.test.logging.category.narayana></thorntail.test.logging.category.narayana>
+
+        <lra.test.timeout.factor>1.0</lra.test.timeout.factor>
     </properties>
 
     <repositories>

--- a/rts/lra/test/tck/pom.xml
+++ b/rts/lra/test/tck/pom.xml
@@ -21,7 +21,6 @@
         <lra.tck.suite.debug.params></lra.tck.suite.debug.params> <!-- has content when -Ddebug.tck is specified -->
         <lra.tck.suite.debug.port>8788</lra.tck.suite.debug.port>
         <!-- TCK TckTests#timeLimit test needs a short, but non zero, delay -->
-        <lra.tck.timeout.factor>1.0</lra.tck.timeout.factor>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -46,7 +45,7 @@
                         <thorntail.test.logging.category.narayana>${thorntail.test.logging.category.narayana}</thorntail.test.logging.category.narayana>
                         <lra.coordinator.port>${lra.coordinator.port}</lra.coordinator.port>
                         <lra.tck.suite.debug.params>${lra.tck.suite.debug.params}</lra.tck.suite.debug.params>
-                        <lra.tck.timeout.factor>${lra.tck.timeout.factor}</lra.tck.timeout.factor>
+                        <lra.tck.timeout.factor>${lra.test.timeout.factor}</lra.tck.timeout.factor>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3307

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA