### PR TITLE
JDK6 changes to run on CI testing (4.17)

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -138,6 +138,7 @@ function build_narayana {
   echo "Using Java version, Maven version with JAVA_HOME='$JAVA_HOME'"
   ./build.sh -version
 
+  # building with -Dtest + -DfailIfNoTests to get downloaded test dependencies to local maven repo on the build time
   ./build.sh -Prelease,community,all$OBJECT_STORE_PROFILE -Didlj-enabled=true "$@" $NARAYANA_ARGS -Dtest=NonExistentTest -DfailIfNoTests=false -P${ARQ_PROF} $IPV6_OPTS -B clean install
   [ $? = 0 ] || fatal "narayana build failed"
 
@@ -219,6 +220,7 @@ function build_as {
 
   export MAVEN_OPTS="$MAVEN_OPTS -Xms2048m -Xmx2048m -XX:MaxPermSize=1024m"
   export JAVA_OPTS="$JAVA_OPTS -Xms1303m -Xmx1303m -XX:MaxPermSize=512m"
+  # building with -Dtest + -DfailIfNoTests to get downloaded test dependencies to local maven repo on the build time
   (cd .. && ./build.sh -f jboss-as/pom.xml -B clean install -Dtest=NonExistentTest -DfailIfNoTests=false -Dts.smoke=false $IPV6_OPTS -Drelease=true -Dversion.org.jboss.jboss-transaction-spi=7.1.0.SP2 -Dversion.org.jboss.jbossts.jbossjts=4.17.44.Final-SNAPSHOT -Dversion.org.jboss.jbossts.jbossjts-integration=4.17.44.Final-SNAPSHOT -Dversion.org.jboss.jbossts.jbossxts=4.17.44.Final-SNAPSHOT -Dversion.org.jboss.jbossts=4.17.44.Final-SNAPSHOT $AS_XARGS)
   [ $? = 0 ] || fatal "AS build failed"
 

--- a/txframework/pom.xml
+++ b/txframework/pom.xml
@@ -148,6 +148,20 @@
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
             <version>${version.org.apache.cxf}</version>
         </dependency>
+        <!-- maven dependency download issue, need to explicitly specify the version even
+            it should be taken transitively from 'cxf-rt-frontend-javaws' -->
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.1.13</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-xjc</artifactId>
+            <version>2.1.13</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.ws</groupId>
             <artifactId>jbossws-spi</artifactId>


### PR DESCRIPTION
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB

I need to provide few more changes in 4.17 branch as not all axes work fine on JDK6 and AMS CI.
I ran jobs with this additional set of changes and with them it all seems should be working finally now.