### PR TITLE
Intermittent test failure stabilization (4.17)

### DIFF
--- a/ArjunaJTA/jta/src/test/resources/standalone-cmr.xml
+++ b/ArjunaJTA/jta/src/test/resources/standalone-cmr.xml
@@ -135,7 +135,7 @@
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" connectable="true">
-                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=10000</connection-url>
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</connection-url>
                     <driver>h2</driver>
                     <security>
                         <user-name>sa</user-name>


### PR DESCRIPTION
After few prior PRs for 4.17 JDK6 compatibility and ability to run tests with JDK6 this one fixes some failures which I got on further running of the tests.
CMR tests requires a bit more time for data insertion and XTS has got troubles with network errors which seem to be caused by not asking for IPv4 explicitly.

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB