### PR TITLE
JBTM-3245 report request and response filter processing failures back…

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRARecord.java
@@ -356,7 +356,8 @@ public class LRARecord extends AbstractRecord implements Comparable<AbstractReco
                     responseData = response.readEntity(String.class);
                 }
             } catch (Exception e) {
-                 LRALogger.logger.warnf(e, "LRARecord.doEnd put %s failed", endPath);
+                // log an informational message (failure to contact participants is unexceptional so don't dump the stack)
+                LRALogger.logger.infof("LRARecord.doEnd put %s failed", endPath);
             } finally {
                 if (client != null) {
                     client.close();

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -218,6 +218,11 @@ public interface lraI18NLogger {
     @Message(id = 25044, value = "Error when encoding parent LRA id URL '%s' to String")
     void error_invalidFormatToEncodeParentUri(URI parentUri, @Cause Throwable t);
 
+    // message codes 251xx are for reporting problems discovered during JAX-RS filter processing
+    @LogMessage(level = WARN)
+    @Message(id = 25145, value = "Unable to process LRA annotations: %s'")
+    void warn_LRAStatusInDoubt(String reason);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3245

This PR adds error handling and reporting (to the caller). In particular it verifies the behaviour when a coordinator cannot be contacted and produces a response back to the caller indicating that the LRA is potentially in doubt.

I tested the code by break-pointing the coordinator at the appropriate places to simulate coordinator unavailability. I'm not sure if we need to simulate that using byteman in the future but for now I think doing it manually is sufficient.

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA