### PR TITLE
[JBTM-2154] updated to increase timeout

### DIFF
--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/timeout/TimeoutClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/timeout/TimeoutClient.java
@@ -35,6 +35,7 @@ import org.omg.CORBA.INVALID_TRANSACTION;
 import org.omg.CORBA.TRANSACTION_ROLLEDBACK;
 import org.omg.CosTransactions.Control;
 
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.internal.jts.ORBManager;
 import com.arjuna.ats.internal.jts.OTSImpleManager;
 import com.arjuna.ats.internal.jts.orbspecific.CurrentImple;
@@ -48,6 +49,9 @@ import com.hp.mwtests.ts.jts.resources.TestUtility;
 
 public class TimeoutClient
 {
+    static int timeout = 8;
+    static int mfactor = arjPropertyManager.getCoreEnvironmentBean().getTimeoutFactor();
+
     public static void main(String[] args) throws Exception
     {
         ORB myORB = null;
@@ -71,12 +75,14 @@ public class TimeoutClient
 
             SetGet SetGetVar = null;
 
-            System.out.println("Setting transaction timeout to 2 seconds.");
+            System.out.println("Setting transaction timeout to " + timeout*mfactor + " seconds.");
 
-            current.set_timeout(2);
+            current.set_timeout(timeout*mfactor);
 
             current.begin();
             current.begin();
+
+            long startTime = System.currentTimeMillis();
 
             try
             {
@@ -108,9 +114,15 @@ public class TimeoutClient
 
             try
             {
-                System.out.println("Now sleeping for 5 seconds.");
+              long timeNow = System.currentTimeMillis();
+              long setTime = (timeNow - startTime);
+              long timeoutTime = (timeout * 1000 * mfactor);
+              long sleepTime =  timeoutTime - setTime;
+              if (sleepTime > 0) {
+                  System.out.println("Now sleeping for " + sleepTime*mfactor + " milliseconds.");
 
-                Thread.sleep(5000);
+                  Thread.sleep(sleepTime*mfactor);
+              }
             }
             catch (Exception e)
             {

--- a/qa/tests/src/org/jboss/jbossts/qa/junit/testgroup/TestGroup_jtsremote.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/junit/testgroup/TestGroup_jtsremote.java
@@ -34,24 +34,28 @@ public class TestGroup_jtsremote  extends TestGroupBase
     }
 
     @Test public void JTSRemote_DistributedHammerTest1() {
-        Task server1 = createTask("server1", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 480);
+        Task server1 = createTask("server1", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 960);
         server1.start("$(1)");
-        Task server2 = createTask("server2", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 480);
+        Task server2 = createTask("server2", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 960);
         server2.start("$(2)");
 
-        startAndWaitForClient(com.hp.mwtests.ts.jts.remote.hammer.DistributedHammer1.class, "$(1)", "$(2)");
+        Task client = createTask("client1", com.hp.mwtests.ts.jts.remote.hammer.DistributedHammer1.class, Task.TaskType.EXPECT_PASS_FAIL, 960);
+		client.start("$(1)", "$(2)");
+		client.waitFor();
 
         server1.terminate();
         server2.terminate();
     }
 
-    public void JTSRemote_DistributedHammerTest2() {
-        Task server1 = createTask("server1", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 480);
+    @Test public void JTSRemote_DistributedHammerTest2() {
+        Task server1 = createTask("server1", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 960);
         server1.start("$(1)");
-        Task server2 = createTask("server2", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 480);
+        Task server2 = createTask("server2", com.hp.mwtests.ts.jts.remote.servers.HammerServer.class, Task.TaskType.EXPECT_READY, 960);
         server2.start("$(2)");
 
-        startAndWaitForClient(com.hp.mwtests.ts.jts.remote.hammer.DistributedHammer2.class, "$(1)", "$(2)");
+        Task client = createTask("client1", com.hp.mwtests.ts.jts.remote.hammer.DistributedHammer2.class, Task.TaskType.EXPECT_PASS_FAIL, 960);
+		client.start("$(1)", "$(2)");
+		client.waitFor();
 
         server1.terminate();
         server2.terminate();

--- a/qa/tests/src/org/jboss/jbossts/qa/junit/testgroup/TestGroup_txcore_lockrecord.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/junit/testgroup/TestGroup_txcore_lockrecord.java
@@ -84,7 +84,9 @@ public class TestGroup_txcore_lockrecord extends TestGroupBase
 
 	@Test public void LockRecord_Test012()
 	{
-        startAndWaitForClient(org.jboss.jbossts.qa.ArjunaCore.LockManager.client.Client003.class, "$(CALLS)", "10");
+        Task client = createTask("client0", org.jboss.jbossts.qa.ArjunaCore.LockManager.client.Client003.class, Task.TaskType.EXPECT_PASS_FAIL, 960);
+		client.start("$(CALLS)", "10");
+		client.waitFor();
 	}
 
 
@@ -101,12 +103,16 @@ public class TestGroup_txcore_lockrecord extends TestGroupBase
 
 	@Test public void LockRecord_Test015()
 	{
-        startAndWaitForClient(org.jboss.jbossts.qa.ArjunaCore.LockManager.client.Client004.class, "100", "5");
+        Task client = createTask("client0", org.jboss.jbossts.qa.ArjunaCore.LockManager.client.Client004.class, Task.TaskType.EXPECT_PASS_FAIL, 960);
+		client.start("$(CALLS)", "5");
+		client.waitFor();
 	}
 
 	@Test public void LockRecord_Test016()
 	{
-        startAndWaitForClient(org.jboss.jbossts.qa.ArjunaCore.LockManager.client.Client004.class, "$(CALLS)", "10");
+        Task client = createTask("client0", org.jboss.jbossts.qa.ArjunaCore.LockManager.client.Client004.class, Task.TaskType.EXPECT_PASS_FAIL, 960);
+		client.start("$(CALLS)", "10");
+		client.waitFor();
 	}
 
 


### PR DESCRIPTION
Backporting the JBTM-2154 (https://issues.redhat.com/browse/JBTM-2154) to stabilize `QA_JTS_JACORB` axis, test `jtsremote` `JTSRemote_TimeoutTest`.

QA_JTS_JACORB QA_JTA MAIN QA_JTS_JDKORB 
!XTS