### PR TITLE
JBTM-3213 Allow request timeouts to be configurable. Enable throttlin…

### DIFF
--- a/rts/lra/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/rts/lra/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -125,6 +125,11 @@ public class NarayanaLRAClient implements Closeable {
      * (but it will be made available with improved guarantees in a subsequent release).
      */
     private static final long CLIENT_TIMEOUT = Long.getLong("lra.internal.client.timeout", 10);
+    private static final long START_TIMEOUT = Long.getLong("lra.internal.client.timeout.start", CLIENT_TIMEOUT);
+    private static final long JOIN_TIMEOUT = Long.getLong("lra.internal.client.timeout.join", CLIENT_TIMEOUT);
+    private static final long END_TIMEOUT = Long.getLong("lra.internal.client.end.timeout", CLIENT_TIMEOUT);
+    private static final long LEAVE_TIMEOUT = Long.getLong("lra.internal.client.leave.timeout", CLIENT_TIMEOUT);
+    private static final long QUERY_TIMEOUT = Long.getLong("lra.internal.client.query.timeout", CLIENT_TIMEOUT);
 
     private URI coordinatorUrl;
 
@@ -206,7 +211,7 @@ public class NarayanaLRAClient implements Closeable {
                         .request()
                         .async()
                         .get()
-                        .get(CLIENT_TIMEOUT, TimeUnit.SECONDS);
+                        .get(QUERY_TIMEOUT, TimeUnit.SECONDS);
 
             if (response.getStatus() != OK.getStatusCode()) {
                 LRALogger.logger.debugf("Error getting all LRAs from the coordinator, response status: %d", response.getStatus());
@@ -289,7 +294,7 @@ public class NarayanaLRAClient implements Closeable {
                 .request()
                 .async()
                 .post(null)
-                .get(CLIENT_TIMEOUT, TimeUnit.SECONDS);
+                .get(START_TIMEOUT, TimeUnit.SECONDS);
 
             // validate the HTTP status code says an LRA resource was created
             if (isUnexpectedResponseStatus(response, Response.Status.CREATED)) {
@@ -389,7 +394,7 @@ public class NarayanaLRAClient implements Closeable {
                 .request()
                 .async()
                 .put(Entity.text(body))
-            .get(CLIENT_TIMEOUT, TimeUnit.SECONDS);
+            .get(LEAVE_TIMEOUT, TimeUnit.SECONDS);
 
             if (OK.getStatusCode() != response.getStatus()) {
                 LRALogger.i18NLogger.error_lraLeaveUnexpectedStatus(response.getStatus(),
@@ -566,7 +571,7 @@ public class NarayanaLRAClient implements Closeable {
                 .request()
                     .async()
                 .get()
-                    .get(CLIENT_TIMEOUT, TimeUnit.SECONDS);
+                    .get(QUERY_TIMEOUT, TimeUnit.SECONDS);
 
             if (response.getStatus() == NOT_FOUND.getStatusCode()) {
                 String responseEntity = response.hasEntity() ? response.readEntity(String.class) : "";
@@ -703,7 +708,7 @@ public class NarayanaLRAClient implements Closeable {
                     .header("Link", linkHeader)
                         .async()
                     .put(Entity.text(compensatorData == null ? linkHeader : compensatorData))
-                .get(CLIENT_TIMEOUT, TimeUnit.SECONDS);
+                .get(JOIN_TIMEOUT, TimeUnit.SECONDS);
 
             String responseEntity = response.hasEntity() ? response.readEntity(String.class) : "";
             if (response.getStatus() == Response.Status.PRECONDITION_FAILED.getStatusCode()) {
@@ -761,7 +766,7 @@ public class NarayanaLRAClient implements Closeable {
                         .request()
                         .async()
                         .put(null)
-                        .get(CLIENT_TIMEOUT, TimeUnit.SECONDS);
+                        .get(END_TIMEOUT, TimeUnit.SECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 throw new WebApplicationException("end LRA client request timed out, try again later",
                         Response.Status.SERVICE_UNAVAILABLE.getStatusCode());

--- a/rts/lra/coordinator-quarkus/pom.xml
+++ b/rts/lra/coordinator-quarkus/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-coordinator-jar</artifactId>
             <version>${project.version}</version>

--- a/rts/lra/coordinator-thorntail/pom.xml
+++ b/rts/lra/coordinator-thorntail/pom.xml
@@ -63,6 +63,10 @@
           <artifactId>microprofile-openapi</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>microprofile-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-coordinator-jar</artifactId>
             <version>${project.version}</version>

--- a/rts/lra/coordinator/pom.xml
+++ b/rts/lra/coordinator/pom.xml
@@ -29,6 +29,12 @@
             <version>${version.microprofile.lra.api}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+            <artifactId>microprofile-fault-tolerance-api</artifactId>
+            <version>${version.microprofile.fault-tolerance}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-service-base</artifactId>
             <version>${project.version}</version>

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -63,6 +63,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -189,6 +190,7 @@ public class Coordinator {
     @POST
     @Path("start")
     @Produces(MediaType.TEXT_PLAIN)
+    @Bulkhead
     @Operation(summary = "Start a new LRA",
         description = "The LRA model uses a presumed nothing protocol: the coordinator must communicate\n"
             + "with Compensators in order to inform them of the LRA activity. Every time a\n"

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -28,6 +28,7 @@
         <version.arquillian>1.2.1.Final</version.arquillian> <!-- cannot use the up-to-date Arquillian https://issues.jboss.org/browse/THORN-2090 -->
         <version.microprofile.lra.api>1.0-M2</version.microprofile.lra.api>
         <version.microprofile.lra.tck>1.0-M2</version.microprofile.lra.tck>
+        <version.microprofile.fault-tolerance>2.1.1</version.microprofile.fault-tolerance>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
         <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -218,10 +218,8 @@ public interface lraI18NLogger {
     @Message(id = 25044, value = "Error when encoding parent LRA id URL '%s' to String")
     void error_invalidFormatToEncodeParentUri(URI parentUri, @Cause Throwable t);
 
-    // message codes 251xx are for reporting problems discovered during JAX-RS filter processing
-    @LogMessage(level = WARN)
     @Message(id = 25145, value = "Unable to process LRA annotations: %s'")
-    void warn_LRAStatusInDoubt(String reason);
+    String warn_LRAStatusInDoubt(String reason);
 
     /*
         Allocate new messages directly above this notice.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3213

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA

This is a partial fix for JBTM-3213 and the PR increases the resilience of LRA to overload. The PR:

- allows throttling of LRA start requests to be configurable;
- allows clients to control how long coordinator requests can take before giving up. The PR adds separate properties for things like starting, joining, ending LRAs etc. We need separate properties since some request failures are more serious than others (eg failure to abort an LRA is significantly more problematic than are failures to start or join with LRAs).

There is a lot we can do in this area [fault resilience] and we have a few JIRAs for tackling the various requirements.
But this PR is a basic minimum to reduce the number of errors caused by overloading the system in which LRA operates. 