### PR TITLE
Indicate that the artemis journal is a provided dependency

### DIFF
--- a/ArjunaJTA/narayana-jta/pom.xml
+++ b/ArjunaJTA/narayana-jta/pom.xml
@@ -168,6 +168,18 @@
         <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-journal</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>

--- a/ArjunaJTS/narayana-jts-ibmorb/pom.xml
+++ b/ArjunaJTS/narayana-jts-ibmorb/pom.xml
@@ -220,6 +220,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-journal</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>

--- a/ArjunaJTS/narayana-jts-idlj/pom.xml
+++ b/ArjunaJTS/narayana-jts-idlj/pom.xml
@@ -180,6 +180,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-journal</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>

--- a/ArjunaJTS/narayana-jts-jacorb/pom.xml
+++ b/ArjunaJTS/narayana-jts-jacorb/pom.xml
@@ -183,6 +183,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-journal</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
I noticed this was missing from narayana-jta while importing the module into an IDE. I added it to some other poms and running CI to test it. It may be required in other shaded jars?


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: JBTM-XYZ Subject
- [ ] Pull Request contains link to the JIRA issue(s)

Our style rules for submitting code are as follows:

* If you add a new file it MUST adhere to our checkstyle ruleset.
  1. If you change a file (in a non trivial way) you are allowed (MAY) to reformat the code to conform to our checkstyle ruleset (`org.wildfly.checkstyle:wildfly-checkstyle-config`).
  2. If you choose not to reformat it then you SHOULD, where possible, try to follow the same style that's already in use for that file.


The build axis can be controlled by prefixing a ! on the following as appropriate.

MAIN CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB BLACKTIE PERF LRA !NO_WIN DB_TESTS mysql db2 postgres oracle
