### PR TITLE
[JBTM-3411] enhance exception reporting for NarayanaLRAClient

### DIFF
--- a/rts/lra/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
+++ b/rts/lra/client/src/main/java/io/narayana/lra/client/NarayanaLRAClient.java
@@ -194,7 +194,7 @@ public class NarayanaLRAClient implements Closeable {
             this.coordinatorUrl = LRAConstants.getLRACoordinatorUrl(lraId);
         } catch (IllegalStateException e) {
             LRALogger.i18NLogger.error_invalidLraIdFormatToConvertToCoordinatorUrl(lraId.toASCIIString(), e);
-            throwGenericLRAException(lraId, BAD_REQUEST.getStatusCode(), e.getMessage());
+            throwGenericLRAException(lraId, BAD_REQUEST.getStatusCode(), e.getClass().getName() + ":" + e.getMessage(), null);
         }
     }
 
@@ -248,15 +248,35 @@ public class NarayanaLRAClient implements Closeable {
         return startLRA(clientID, timeout, ChronoUnit.SECONDS);
     }
 
+    /**
+     * Starting LRA. You provide client id that joins the LRA context
+     * and is passed when working with the LRA.
+     *
+     * @param clientID  client id determining the LRA
+     * @param timeout  timeout value, when timeout-ed the LRA will be compensated
+     * @param unit  timeout unit, when null seconds are used
+     * @return  LRA id as URL
+     * @throws WebApplicationException  thrown when start of the LRA failed
+     */
     private URI startLRA(String clientID, Long timeout, ChronoUnit unit) throws WebApplicationException {
         return startLRA(getCurrent(), clientID, timeout, unit);
     }
-
 
     public URI startLRA(URI parentLRA, String clientID, Long timeout, ChronoUnit unit) throws WebApplicationException {
         return startLRA(parentLRA, clientID, timeout, unit, true);
     }
 
+    /**
+     * Starting LRA. You provide client id that joins the LRA context
+     * and is passed when working with the LRA.
+     *
+     * @param parentLRA when the newly started LRA should be nested with this LRA parent, when null the newly started LRA is top-level
+     * @param clientID  client id determining the LRA
+     * @param timeout  timeout value, when timeout-ed the LRA will be compensated
+     * @param unit  timeout unit, when null seconds are used
+     * @return  LRA id as URL
+     * @throws WebApplicationException  thrown when start of the LRA failed
+     */
     public URI startLRA(URI parentLRA, String clientID, Long timeout, ChronoUnit unit, boolean verbose) throws WebApplicationException {
         Client client = null;
         Response response = null;
@@ -270,8 +290,11 @@ public class NarayanaLRAClient implements Closeable {
             timeout = 0L;
         } else if (timeout < 0) {
             throwGenericLRAException(parentLRA, BAD_REQUEST.getStatusCode(),
-                    "Invalid timeout value: " + timeout);
+                    "Invalid timeout value: " + timeout, null);
             return null;
+        }
+        if (unit == null) {
+            unit = ChronoUnit.SECONDS;
         }
 
         lraTracef("startLRA for client %s with parent %s", clientID, parentLRA);
@@ -298,7 +321,7 @@ public class NarayanaLRAClient implements Closeable {
                     LRALogger.i18NLogger.error_lraCreationUnexpectedStatus(response.getStatus(), responseEntity);
                 }
                 throwGenericLRAException(null, response.getStatus(),
-                        "LRA start returned an unexpected status code: " + response.getStatus() + ", response '" + responseEntity + "'");
+                        "LRA start returned an unexpected status code: " + response.getStatus() + ", response '" + responseEntity + "'", null);
                 return null;
             }
 
@@ -308,16 +331,16 @@ public class NarayanaLRAClient implements Closeable {
             Current.push(lra);
 
             return lra;
-        } catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException uee) {
             if (verbose) {
-                LRALogger.i18NLogger.error_invalidFormatToEncodeParentUri(parentLRA, e);
+                LRALogger.i18NLogger.error_invalidFormatToEncodeParentUri(parentLRA, uee);
             }
             throwGenericLRAException(null, INTERNAL_SERVER_ERROR.getStatusCode(),
                     "Cannot connect to the LRA coordinator: " + coordinatorUrl + " as provided parent LRA URL '" + parentLRA +
-                            "' is not in URI format (" + e.getCause().getMessage() + ")");
+                            "' is not in URI format (" + uee.getClass().getName() + ":" + uee.getCause().getMessage() + ")", uee);
             return null;
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            throw new WebApplicationException("start LRA client request timed out, try again later",
+            throw new WebApplicationException("start LRA client request timed out, try again later", e,
                     Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
         } finally {
             if (client != null) {
@@ -395,7 +418,7 @@ public class NarayanaLRAClient implements Closeable {
                 LRALogger.i18NLogger.error_lraLeaveUnexpectedStatus(response.getStatus(),
                         response.hasEntity() ? response.readEntity(String.class) : "");
                 throwGenericLRAException(null, response.getStatus(), "Leaving LRA " + lraId + " from coordinator " + coordinatorUrl
-                    + " finished with unexpected response code: " + response.getStatusInfo());
+                    + " finished with unexpected response code: " + response.getStatusInfo(), null);
             }
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new WebApplicationException("leave LRA client request timed out, try again later",
@@ -551,11 +574,10 @@ public class NarayanaLRAClient implements Closeable {
 
         try {
             lraId = uri.toURL();
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException mue) {
             throwGenericLRAException(null,
                     Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                    "Could not convert LRA to a URL: " + e.getMessage()
-            );
+                    "Could not convert LRA to a URL : " + mue.getClass().getName() + ":" + mue.getMessage(), mue);
             return null;
         }
 
@@ -581,28 +603,23 @@ public class NarayanaLRAClient implements Closeable {
 
             if (response.getStatus() != OK.getStatusCode()) {
                 LRALogger.i18NLogger.error_invalidStatusCode(coordinatorUrl, response.getStatus(), lraId);
-                throwGenericLRAException(uri,
-                    response.getStatus(),
-                    "LRA coordinator returned an invalid status code"
-                );
+                throwGenericLRAException(uri, response.getStatus(),
+                    "LRA coordinator returned an invalid status code", null);
             }
 
             if (!response.hasEntity()) {
                 LRALogger.i18NLogger.error_noContentOnGetStatus(coordinatorUrl, lraId);
-                throwGenericLRAException(uri,
-                    Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                    "LRA coordinator#getStatus returned 200 OK but no content: lra: " + lraId);
+                throwGenericLRAException(uri, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                    "LRA coordinator#getStatus returned 200 OK but no content: lra: " + lraId, null);
             }
 
             // convert the returned String into a status
             try {
                 return fromString(response.readEntity(String.class));
-            } catch (IllegalArgumentException e) {
-                LRALogger.i18NLogger.error_invalidArgumentOnStatusFromCoordinator(coordinatorUrl, lraId, e);
-                throwGenericLRAException(uri,
-                    Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                    "LRA coordinator returned an invalid status"
-                );
+            } catch (IllegalArgumentException iae) {
+                LRALogger.i18NLogger.error_invalidArgumentOnStatusFromCoordinator(coordinatorUrl, lraId, iae);
+                throwGenericLRAException(uri,Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                    "LRA coordinator returned an invalid status", iae);
             }
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new WebApplicationException("get LRA status client request timed out, try again later",
@@ -683,11 +700,9 @@ public class NarayanaLRAClient implements Closeable {
 
         try {
             lraId = uri.toURL();
-        } catch (MalformedURLException e) {
-            throwGenericLRAException(null,
-                    Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-                    "Could not convert LRA to a URL: " + e.getMessage()
-            );
+        } catch (MalformedURLException mue) {
+            throwGenericLRAException(null, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                    "Could not convert LRA to a URL : " + mue.getClass().getName() + ":" + mue.getMessage(), mue);
         }
         if (timelimit == null || timelimit < 0) {
             timelimit = 0L;
@@ -718,8 +733,7 @@ public class NarayanaLRAClient implements Closeable {
                         Response.status(GONE).entity(uri.toASCIIString()).build());
             } else if (response.getStatus() != OK.getStatusCode()) {
                 LRALogger.i18NLogger.error_failedToEnlist(lraId, coordinatorUrl, response.getStatus());
-                throwGenericLRAException(uri, response.getStatus(),
-                        "unable to register participant");
+                throwGenericLRAException(uri, response.getStatus(), "unable to register participant", null);
             }
 
             String recoveryUrl = null;
@@ -730,7 +744,7 @@ public class NarayanaLRAClient implements Closeable {
             } catch (URISyntaxException | UnsupportedEncodingException e) {
                 LRALogger.logger.infof(e,"join %s returned an invalid recovery URI '%s': %s", lraId, recoveryUrl, responseEntity);
                 throwGenericLRAException(null, Response.Status.SERVICE_UNAVAILABLE.getStatusCode(),
-                        "join " + lraId + " returned an invalid recovery URI '" + recoveryUrl + "' : " + responseEntity);
+                        "join " + lraId + " returned an invalid recovery URI '" + recoveryUrl + "' : " + responseEntity, e);
                 return null;
             }
         } catch (WebApplicationException webApplicationException) {
@@ -771,7 +785,7 @@ public class NarayanaLRAClient implements Closeable {
                 LRALogger.i18NLogger.error_lraTerminationUnexpectedStatus(response.getStatus(),
                         response.hasEntity() ? response.readEntity(String.class) : "");
                 throwGenericLRAException(lra, INTERNAL_SERVER_ERROR.getStatusCode(),
-                        "LRA finished with an unexpected status code: " + response.getStatus());
+                        "LRA finished with an unexpected status code: " + response.getStatus(), null);
             }
 
             if (response.getStatus() == NOT_FOUND.getStatusCode()) {
@@ -795,15 +809,15 @@ public class NarayanaLRAClient implements Closeable {
         if (uri == null) {
             if (!nullAllowed) {
                 throwGenericLRAException(null, NOT_ACCEPTABLE.getStatusCode(),
-                        String.format(message, "null value"));
+                        String.format(message, "null value"), null);
             }
         } else {
             try {
                 // the passed in URI should be a valid URL - verify that that is the case
                 uri.toURL();
-            } catch (MalformedURLException e) {
+            } catch (MalformedURLException mue) {
                 throwGenericLRAException(null, NOT_ACCEPTABLE.getStatusCode(),
-                        String.format(message, e.getMessage()) + " uri=" + uri);
+                        String.format(message, mue.getClass().getName() +":" + mue.getMessage()) + " uri=" + uri, mue);
             }
         }
     }
@@ -850,10 +864,9 @@ public class NarayanaLRAClient implements Closeable {
     public void close() {
     }
 
-    private void throwGenericLRAException(URI lraId, int statusCode, String message) throws WebApplicationException {
+    private void throwGenericLRAException(URI lraId, int statusCode, String message, Throwable cause) throws WebApplicationException {
         String errorMsg = String.format("%s: %s", lraId, message);
-        throw new WebApplicationException(errorMsg, Response.status(statusCode)
-                .entity(errorMsg).build());
+        throw new WebApplicationException(errorMsg, cause, Response.status(statusCode).entity(errorMsg).build());
     }
 
     private Client getClient() {

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
@@ -118,7 +118,7 @@ public class LongRunningAction extends BasicAction {
      * @return  immutable {@link LRAData} representing the current state of the LRA transaction
      */
     public LRAData getLRAData() {
-        return new LRAData(id.toASCIIString(), clientId, status, isTopLevel(), isRecovering(),
+        return new LRAData(id, clientId, status, isTopLevel(), isRecovering(),
                 startTime.toInstant(ZoneOffset.UTC).toEpochMilli(),
                 finishTime == null ? 0L : finishTime.toInstant(ZoneOffset.UTC).toEpochMilli(),
                 getHttpStatus());

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/LRAData.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/LRAData.java
@@ -1,14 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package io.narayana.lra;
 
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 
+import java.beans.Transient;
+import java.net.URI;
+
 /**
  * DTO object which serves to transfer data of particular LRA instance.
- * It's used by {@link io.narayana.lra.coordinator.api.Coordinator}
+ * It's used by {@code io.narayana.lra.coordinator.api.Coordinator}
  * for JSON response creation when LRA info is asked for.
  */
 public class LRAData {
-    private String lraId;
+    private URI lraId;
     private String clientId;
     private LRAStatus status;
     private boolean isTopLevel;
@@ -19,7 +44,7 @@ public class LRAData {
 
     public LRAData() {}
 
-    public LRAData(String lraId, String clientId, LRAStatus status, boolean isTopLevel, boolean isRecovering,
+    public LRAData(URI lraId, String clientId, LRAStatus status, boolean isTopLevel, boolean isRecovering,
                     long startTime, long finishTime, int httpStatus) {
         this.lraId = lraId;
         this.clientId = clientId;
@@ -31,12 +56,17 @@ public class LRAData {
         this.httpStatus = httpStatus;
     }
 
-    public String getLraId() {
+    public URI getLraId() {
         return this.lraId;
     }
 
-    public void setLraId(String lraId) {
+    public void setLraId(URI lraId) {
         this.lraId = lraId;
+    }
+
+    @Transient
+    public String getLraIdAsString() {
+        return this.lraId.toASCIIString();
     }
 
     public String getClientId() {

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/NarayanaLRAClientIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/NarayanaLRAClientIT.java
@@ -53,13 +53,13 @@ public class NarayanaLRAClientIT {
 
         List<LRAData> allLRAs = lraClient.getAllLRAs();
         Assert.assertTrue("Expected to find the LRA " + lra + " amongst all active ones: " + allLRAs,
-                allLRAs.stream().anyMatch(lraData -> lraData.getLraId().equals(lra.toASCIIString())));
+                allLRAs.stream().anyMatch(lraData -> lraData.getLraId().equals(lra)));
 
         lraClient.closeLRA(lra);
 
         allLRAs = lraClient.getAllLRAs();
         Assert.assertTrue("LRA " + lra + " was closed but is still referred as active one at: " + allLRAs,
-                allLRAs.stream().noneMatch(lraData -> lraData.getLraId().equals(lra.toASCIIString())));
+                allLRAs.stream().noneMatch(lraData -> lraData.getLraId().equals(lra)));
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3411

This is a change that I benefit when working with `NaraynaLRAClient` and when I'm creating new tests.
It's about adding cause for the thrown exception that could be processed in the code or assertion.
Plus, `URI` is more convenient format than String parsing.

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA
