### PR TITLE
[SCRIPTS ONLY] using github token for posting comments on PRs

### DIFF
--- a/scripts/hudson/narayana-rebase.sh
+++ b/scripts/hudson/narayana-rebase.sh
@@ -19,7 +19,7 @@ function comment_on_pull
     if [ "$PULL_NUMBER" != "" ]
     then
         JSON="{ \"body\": \"$1\" }"
-        curl -d "$JSON" -ujbosstm-bot:$BOT_PASSWORD https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
+        curl -d "$JSON" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
     else
         echo "Not a pull request, so not commenting"
     fi

--- a/scripts/hudson/narayana.bat
+++ b/scripts/hudson/narayana.bat
@@ -107,6 +107,6 @@ goto:eof
    for /f "tokens=1,2,3,4 delims=/" %%a in ("%GIT_BRANCH%") do set IS_PULL=%%b&set PULL_NUM=%%c
    if not "%IS_PULL%"=="pull" goto:eof
    
-   curl -k -d "{ \"body\": \"%~1\" }" -ujbosstm-bot:%BOT_PASSWORD% https://api.github.com/repos/%GIT_ACCOUNT%/%GIT_REPO%/issues/%PULL_NUM%/comments
+   curl -k -d "{ \"body\": \"%~1\" }" -H "Authorization: token %GITHUB_TOKEN%" https://api.github.com/repos/%GIT_ACCOUNT%/%GIT_REPO%/issues/%PULL_NUM%/comments
 
 goto:eof

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -213,7 +213,7 @@ function initGithubVariables
      if [ "$PULL_NUMBER" != "" ]
      then
          [ "x${PULL_DESCRIPTION}" = "x" ] &&\
-             PULL_DESCRIPTION=$(curl -ujbosstm-bot:$BOT_PASSWORD -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER)
+             PULL_DESCRIPTION=$(curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER)
          [ "x${PULL_DESCRIPTION_BODY}" = "x" ] &&\
              PULL_DESCRIPTION_BODY=$(printf '%s' "$PULL_DESCRIPTION" | grep \"body\":)
      else
@@ -229,7 +229,7 @@ function comment_on_pull
     if [ "$PULL_NUMBER" != "" ]
     then
         JSON="{ \"body\": \"$1\" }"
-        curl -d "$JSON" -ujbosstm-bot:$BOT_PASSWORD https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
+        curl -d "$JSON" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
     else
         echo "Not a pull request, so not commenting"
     fi


### PR DESCRIPTION
Using github token instead of direct password for commenting on PRs.
For not getting errors like 

```
{
  "message": "Requires authentication",
  "documentation_url": "https://docs.github.com/rest/reference/issues#create-an-issue-comment"
}
```

!QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTA !XTS !RTS !AS_TESTS 