### PR TITLE
[SCRIPTS ONLY] using github token for posting comments on PRs

### DIFF
--- a/scripts/hudson/narayana-rebase.sh
+++ b/scripts/hudson/narayana-rebase.sh
@@ -19,7 +19,7 @@ function comment_on_pull
     if [ "$PULL_NUMBER" != "" ]
     then
         JSON="{ \"body\": \"$1\" }"
-        curl -d "$JSON" -ujbosstm-bot:$BOT_PASSWORD https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
+        curl -d "$JSON" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
     else
         echo "Not a pull request, so not commenting"
     fi

--- a/scripts/hudson/narayana.bat
+++ b/scripts/hudson/narayana.bat
@@ -47,6 +47,6 @@ goto:eof
    for /f "tokens=1,2,3,4 delims=/" %%a in ("%GIT_BRANCH%") do set IS_PULL=%%b&set PULL_NUM=%%c
    if not "%IS_PULL%"=="pull" goto:eof
    
-   curl -k -d "{ \"body\": \"%~1\" }" -ujbosstm-bot:%BOT_PASSWORD% https://api.github.com/repos/%GIT_ACCOUNT%/%GIT_REPO%/issues/%PULL_NUM%/comments
+   curl -k -d "{ \"body\": \"%~1\" }" -H "Authorization: token %GITHUB_TOKEN%" https://api.github.com/repos/%GIT_ACCOUNT%/%GIT_REPO%/issues/%PULL_NUM%/comments
 
 goto:eof

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -21,7 +21,7 @@ function get_pull_description {
     PULL_NUMBER=$(echo $GIT_BRANCH | awk -F 'pull' '{ print $2 }' | awk -F '/' '{ print $2 }')
 
     if [ "$PULL_NUMBER" != "" ]; then
-        echo $(curl -ujbosstm-bot:$BOT_PASSWORD -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER | grep \"body\":)
+        echo $(curl -H "Authorization: token $GITHUB_TOKEN" -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER | grep \"body\":)
     else
         echo ""
     fi
@@ -149,7 +149,7 @@ function comment_on_pull
     if [ "$PULL_NUMBER" != "" ]
     then
         JSON="{ \"body\": \"$1\" }"
-        curl -d "$JSON" -ujbosstm-bot:$BOT_PASSWORD https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
+        curl -d "$JSON" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/issues/$PULL_NUMBER/comments
     else
         echo "Not a pull request, so not commenting"
     fi
@@ -160,7 +160,7 @@ function check_if_pull_closed
     PULL_NUMBER=$(echo $GIT_BRANCH | awk -F 'pull' '{ print $2 }' | awk -F '/' '{ print $2 }')
     if [ "$PULL_NUMBER" != "" ]
     then
-	curl -ujbosstm-bot:$BOT_PASSWORD -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER | grep -q "\"state\": \"closed\""
+	curl -H "Authorization: token $GITHUB_TOKEN" -s https://api.github.com/repos/$GIT_ACCOUNT/$GIT_REPO/pulls/$PULL_NUMBER | grep -q "\"state\": \"closed\""
 	if [ $? -eq 1 ] 
 	then
 		echo "pull open"


### PR DESCRIPTION
Using github token instead of direct password for commenting on PRs.

For not getting errors like
```
{
  "message": "Requires authentication",
  "documentation_url": "https://docs.github.com/rest/reference/issues#create-an-issue-comment"
}
```

!QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTA !XTS !RTS !AS_TESTS