### PR TITLE
[JBTM-3343] fix for arq test being executed within coordinator module

### DIFF
--- a/rts/lra/coordinator/pom.xml
+++ b/rts/lra/coordinator/pom.xml
@@ -145,6 +145,7 @@
             <properties>
                 <lra.coordinator.host>localhost</lra.coordinator.host>
                 <lra.coordinator.url>http://localhost:8080/${lra.coordinator.path}</lra.coordinator.url>
+                <skipITs>false</skipITs>
             </properties>
             <dependencies>
                 <dependency>
@@ -187,6 +188,7 @@
             <properties>
                 <lra.coordinator.host>[::1]</lra.coordinator.host>
                 <lra.coordinator.url>http://[::1]:8080/${lra.coordinator.path}</lra.coordinator.url>
+                <skipITs>false</skipITs>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3343

With changing the tests in `lra/test` module I forgot to make this change in `lra/coordinator`. This change could be unnecessary when PR #1764 merged but until that it would be good to enable tests in `coordinator`. What this small adjustment enables.

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA
