### PR TITLE
[SCRIPTS ONLY] correcting the name of the timeout factor attribute for WFLY integration tests

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -407,7 +407,7 @@ function build_as {
 
   # running WildFly testsuite if configured to be run by axis AS_TESTS
   if [ $AS_TESTS = 1 ]; then
-    JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" ./integration-tests.sh clean verify -B $IPV6_OPTS -Dtimeout.factor=300 -Dsurefire.forked.process.timeout=12000 -Dsurefire.extra.args='-Xmx512m' -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION} -Djboss.dist="$JBOSS_HOME" -DallTests=true -fae
+    JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=512m $JAVA_OPTS" ./integration-tests.sh clean verify -B $IPV6_OPTS -Dts.timeout.factor=300 -Dsurefire.forked.process.timeout=12000 -Dsurefire.extra.args='-Xmx512m' -Dversion.org.jboss.narayana=${NARAYANA_CURRENT_VERSION} -Djboss.dist="$JBOSS_HOME" -DallTests=true -fae
     [ $? = 0 ] || fatal "AS tests failed"
   fi
 


### PR DESCRIPTION
I checked the failing tests on our CI to understand what are the current troubles. By me the most of them are caused by timing issues (e.g. quite usual is error message like `Failed to establish connection in 16009ms`). From that I found that the script uses wrong timeout factor property which should be `ts.timeout.factor` (ie. https://github.com/wildfly/wildfly-core/blob/14.0.0.Final/testsuite/shared/src/main/java/org/jboss/as/test/shared/TimeoutUtil.java#L40).

This adjustment is an attempt to enhance the stability of the WFLY testsuite.

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS  !TOMCAT !JACOCO !LRA
AS_TESTS

/cc @tomjenkinson 