### PR TITLE
[JBTM-3406] test that different node name is not recovered

### DIFF
--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/common/OnServerRebootInstrumentator.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/common/OnServerRebootInstrumentator.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.jbossts.txbridge.tests.common;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.byteman.contrib.dtest.Instrumentor;
+
+/**
+ * Interface used within crash recovery tests for Byteman rule
+ * being defined at the start of the application server.
+ */
+public interface OnServerRebootInstrumentator {
+    /**
+     * Instrumentation to be done on server reboot.
+     * For details see @link {@link AbstractCrashRecoveryTests#rebootServer(ContainerController)}
+     *
+     * Note: Before each server restart it is necessary to store the instrumentation into a file and then start up the server
+     * with that file as a parameter for Byteman to ensure the appropriate classes are instrumented once the server is up.
+     */
+    void instrument(Instrumentor instrumentor) throws Exception;
+}

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/junit/InboundCrashRecoveryTests.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/inbound/junit/InboundCrashRecoveryTests.java
@@ -20,6 +20,8 @@
  */
 package org.jboss.jbossts.txbridge.tests.inbound.junit;
 
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import org.jboss.arquillian.container.test.api.*;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -42,6 +44,8 @@ import org.junit.runner.RunWith;
 import com.arjuna.ats.internal.arjuna.recovery.PeriodicRecovery;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.Executors;
 
 
@@ -112,11 +116,10 @@ public class InboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
     }
 
     @Override
-    protected void instrumentationOnServerReboot() throws Exception {
+    public void instrument(Instrumentor instrumentor) throws Exception {
         instrumentedTestSynchronization = instrumentor.instrumentClass(TestSynchronization.class);
         instrumentedTestXAResource = instrumentor.instrumentClass(TestXAResourceRecovered.class);
     }
-
 
     @Test
     @OperateOnDeployment(INBOUND_CLIENT_DEPLOYMENT_NAME)
@@ -210,10 +213,6 @@ public class InboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
 
         execute(baseURL + TestClient.URL_PATTERN, false);
 
-        durableParticipant.assertMethodCalled("prepare");
-        durableParticipant.assertMethodNotCalled("rollback");
-        durableParticipant.assertMethodNotCalled("commit");
-
         instrumentedTestSynchronization.assertKnownInstances(1);
         instrumentedTestSynchronization.assertMethodCalled("beforeCompletion");
         instrumentedTestSynchronization.assertMethodNotCalled("afterCompletion");
@@ -231,6 +230,38 @@ public class InboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
         instrumentedTestXAResource.assertKnownInstances(1);
         instrumentedTestXAResource.assertMethodCalled("recover");
         instrumentedTestXAResource.assertMethodCalled("rollback");
+        instrumentedTestXAResource.assertMethodNotCalled("commit");
+    }
+
+    /**
+     * Verification that a container depends on container the node name
+     * when recovering inbound bridge participants.
+     */
+    @Test
+    @OperateOnDeployment(INBOUND_CLIENT_DEPLOYMENT_NAME)
+    public void testDifferentNodeName(@ArquillianResource URL baseURL) throws Exception {
+        InstrumentedClass durableParticipant = instrumentor.instrumentClass(BridgeDurableParticipant.class);
+
+        instrumentor.injectOnCall(TestClient.class, "terminateTransaction", "$2 = true"); // shouldCommit=true
+        instrumentor.crashAtMethodExit(BridgeDurableParticipant.class, "prepare");
+
+        execute(baseURL + TestClient.URL_PATTERN, false);
+
+        instrumentedTestXAResource.assertKnownInstances(1);
+        instrumentedTestXAResource.assertMethodCalled("prepare");
+        instrumentedTestXAResource.assertMethodNotCalled("rollback");
+        instrumentedTestXAResource.assertMethodNotCalled("commit");
+
+        rebootServer(controller, instr -> {
+            this.instrument(instr);
+            instr.injectOnCall(CoreEnvironmentBean.class, "setNodeIdentifier", "$1 = \"differentName\"");
+            instr.injectOnCall(JTAEnvironmentBean.class, "setXaRecoveryNodes", "$1 = java.util.Arrays.asList(new String[]{\"differentName\"})");
+        });
+
+        doRecovery();
+
+        instrumentedTestXAResource.assertMethodCalled("recover");
+        instrumentedTestXAResource.assertMethodNotCalled("rollback");
         instrumentedTestXAResource.assertMethodNotCalled("commit");
     }
 

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/junit/OutboundCrashRecoveryTests.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/junit/OutboundCrashRecoveryTests.java
@@ -86,7 +86,7 @@ public class OutboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
         deployer.deploy(OUTBOUND_CLIENT_DEPLOYMENT_NAME);
 
         instrumentor.setRedirectedSubmissionsFile(null);
-        instrumentationOnServerReboot();
+        instrument(instrumentor);
 
         instrumentor.injectOnCall(TestServiceImpl.class, "doNothing", "$0.enlistVolatileParticipant(1), $0.enlistDurableParticipant(1)");
     }
@@ -105,7 +105,7 @@ public class OutboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
     }
 
     @Override
-    protected void instrumentationOnServerReboot() throws Exception {
+    public void instrument(Instrumentor instrumentor) throws Exception {
         instrumentedTestVolatileParticipant = instrumentor.instrumentClass(TestVolatileParticipant.class);
         instrumentedTestDurableParticipant = instrumentor.instrumentClass(TestDurableParticipant.class);
     }


### PR DESCRIPTION
Tests for the fix of https://issues.redhat.com/browse/JBTM-3406
@jhalliday may you take a look, please?

XTS
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !LRA
