### PR TITLE
[JBTM-3406](5.9) test that different node name is not recovered in XTS inbound txbridge recovery module

### DIFF
--- a/ArjunaJTS/jtax/pom.xml
+++ b/ArjunaJTS/jtax/pom.xml
@@ -338,6 +338,7 @@
                     <exclude>**/JTSTestCase.java</exclude>
                     <exclude>**/LastOnePhaseResource.java</exclude>
                     <exclude>**/implicit/**</exclude>
+                    <exclude>**/subordinate/TransactionImpleUnitTest.java</exclude>
                   </excludes>
                   <classpathDependencyExcludes>
                     <classpathDependencyExcludes>org.jboss.narayana.jts:idlj-idl</classpathDependencyExcludes>

--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
     <version.com.sun.grizzly>1.9.59</version.com.sun.grizzly>
     <version.org.codehaus.jettison>1.3.4</version.org.codehaus.jettison>
     <version.junit>4.11</version.junit>
-    <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
+    <version.org.jboss.byteman>4.0.13</version.org.jboss.byteman>
     <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
     <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR9</version.org.jboss.arquillian.container.weld>

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/common/OnServerRebootInstrumentator.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/common/OnServerRebootInstrumentator.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.jbossts.txbridge.tests.common;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.byteman.contrib.dtest.Instrumentor;
+
+/**
+ * Interface used within crash recovery tests for Byteman rule
+ * being defined at the start of the application server.
+ */
+public interface OnServerRebootInstrumentator {
+    /**
+     * Instrumentation to be done on server reboot.
+     * For details see @link {@link AbstractCrashRecoveryTests#rebootServer(ContainerController)}
+     *
+     * Note: Before each server restart it is necessary to store the instrumentation into a file and then start up the server
+     * with that file as a parameter for Byteman to ensure the appropriate classes are instrumented once the server is up.
+     */
+    void instrument(Instrumentor instrumentor) throws Exception;
+}

--- a/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/junit/OutboundCrashRecoveryTests.java
+++ b/txbridge/src/test/java/org/jboss/jbossts/txbridge/tests/outbound/junit/OutboundCrashRecoveryTests.java
@@ -86,7 +86,7 @@ public class OutboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
         deployer.deploy(OUTBOUND_CLIENT_DEPLOYMENT_NAME);
 
         instrumentor.setRedirectedSubmissionsFile(null);
-        instrumentationOnServerReboot();
+        instrument(instrumentor);
 
         instrumentor.injectOnCall(TestServiceImpl.class, "doNothing", "$0.enlistVolatileParticipant(1), $0.enlistDurableParticipant(1)");
     }
@@ -105,7 +105,7 @@ public class OutboundCrashRecoveryTests extends AbstractCrashRecoveryTests {
     }
 
     @Override
-    protected void instrumentationOnServerReboot() throws Exception {
+    public void instrument(Instrumentor instrumentor) throws Exception {
         instrumentedTestVolatileParticipant = instrumentor.instrumentClass(TestVolatileParticipant.class);
         instrumentedTestDurableParticipant = instrumentor.instrumentClass(TestDurableParticipant.class);
     }


### PR DESCRIPTION
A test for https://issues.redhat.com/browse/JBTM-3406

The master PR: https://github.com/jbosstm/narayana/pull/1768
The 4.17 PR: https://github.com/jbosstm/narayana/pull/1771

!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !LRA
XTS MAIN