### PR TITLE
JBTM-3297: Move LRA failure records to another part of the store

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/FailedLongRunningAction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/FailedLongRunningAction.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package io.narayana.lra.coordinator.domain.model;
+
+import com.arjuna.ats.arjuna.common.Uid;
+import io.narayana.lra.coordinator.domain.service.LRAService;
+
+public class FailedLongRunningAction extends LongRunningAction {
+
+    public static final String FAILED_LRA_TYPE = "/StateManager/BasicAction/LongRunningAction/Failed";
+
+
+    public FailedLongRunningAction(LRAService lraService, Uid rcvUid) {
+        super(lraService, rcvUid);
+    }
+
+    @Override
+    public String type() {
+        return FAILED_LRA_TYPE;
+    }
+}

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
@@ -528,15 +528,15 @@ public class LongRunningAction extends BasicAction {
             updateState(LRAStatus.Closing);
         } // otherwise status is (cancel ? LRAStatus.Cancelled : LRAStatus.Closed)
 
+        finishTime = LocalDateTime.now(ZoneOffset.UTC);
+
+        updateState(); // ensure the record is removed if it finished otherwise persisted the state
+
         if (!isRecovering()) {
             if (lraService != null) {
                 lraService.finished(this, false);
             }
         }
-
-        finishTime = LocalDateTime.now(ZoneOffset.UTC);
-
-        updateState(); // ensure the record is removed if it finished otherwise persisted the state
 
         return res;
     }

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -168,6 +168,9 @@ public class LRAService {
     }
 
     public void finished(LongRunningAction transaction, boolean fromHierarchy) {
+        if (transaction.isFailed()) {
+            getRM().moveEntryToFailedLRAPath(transaction.get_uid());
+        }
         if (transaction.isRecovering()) {
             recoveringLRAs.put(transaction.getId(), transaction);
         } else if (fromHierarchy || transaction.isTopLevel()) {

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -220,6 +220,16 @@ public interface lraI18NLogger {
     @Message(id = 25145, value = "Unable to process LRA annotations: %s'")
     String warn_LRAStatusInDoubt(String reason);
 
+    @LogMessage(level = WARN)
+    @Message(id = 25146, value = "Unable to remove the failed duclicate failed LRA record (Uid: '%s') " +
+            "(which is already present in the failedLRA record location type: '%s'.) from LRA Record location: '%s'")
+    void warn_UnableToRemoveDuplicateFailedLRARecord(String failedUid, String failedLRAType, String lraType);
+
+    @LogMessage(level = WARN)
+    @Message(id = 25147, value = "An exception was thrown while moving failed LRA record (Uid: '%s'). " +
+            "Reason: '%s'")
+    void warn_move_lra_record(String failedUid, String exceptionMessage);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3297


The build axis can be controlled by prefixing a ! on the following as appropriate.

!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
