### PR TITLE
JBTM-3421 remove provided scope for artefact mashona:mashona-logwriting

### DIFF
--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.mashona</groupId>
       <artifactId>mashona-logwriting</artifactId>
-      <version>1.0.0.Beta1</version>
+      <version>${version.io.mashona}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -417,6 +417,14 @@
           </plugin>
         </plugins>
       </build>
+      <dependencies>
+        <dependency>
+          <groupId>io.mashona</groupId>
+          <artifactId>mashona-logwriting</artifactId>
+          <version>${version.io.mashona}</version>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>community</id>

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,7 @@
     <version.com.github.docker-java>3.0.14</version.com.github.docker-java>
     <version.org.eclipse.microprofile.openapi>1.1.2</version.org.eclipse.microprofile.openapi>
     <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
+    <version.io.mashona>1.0.0.Beta1</version.io.mashona>
 
     <!-- Maven plugin versions -->
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3421

This is a follow up to JBTM-3417 (Add Persistent Memory SlotStore backend) to workaround a javadoc issue compiling on JDK 11. I'm not sure if it is the best fix but it will do as a stop gap (an example of the compilation failure is http://narayanaci1.eng.hst.ams2.redhat.com/job/narayana/PROFILE=CORE,jdk=jdk11.latest,label=linux/21/consoleFull).

We are using OpenJDK 64-Bit Server VM 18.9 (build 11.0.6+10-LTS, mixed mode, sharing)

MAIN CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
