### PR TITLE
[JBTM-3294] adding HTTP version headers for coordinator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,7 @@
     <version.org.eclipse.microprofile.openapi>1.1.2</version.org.eclipse.microprofile.openapi>
     <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
     <version.io.mashona>1.0.0.Beta1</version.io.mashona>
+    <version.hamcrest>2.2</version.hamcrest>
 
     <!-- Maven plugin versions -->
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>

--- a/rts/lra/API.adoc
+++ b/rts/lra/API.adoc
@@ -1,0 +1,68 @@
+= Versioning of Narayna LRA REST API
+
+The goal of this document is summarize the approach to REST API versioning
+in Narayana LRA coordinator service.
+This document is written for developer of Narayana LRA services.
+
+The version format is `major.minor` and both components are required.
+
+Client may demand behaviour based on particular API version
+by providing HTTP header link:./service-base/src/main/java/io/narayana/lra/LRAConstants.java[`Narayana-LRA-API-version`] on the call.
+
+If the caller is able to accept more than one version then the caller should include the header for each one.
+
+== Listing of API versions
+
+.Support status of Narayana LRA API versions
+[options="header"]
+|===
+
+| Version | Support status
+
+| `1.0`   | Supported
+
+|===
+
+== API definition as Open API document
+
+The Narayana LRA API is documented with Open API annotations at the java
+classes. The Open API definition needs to be published at the http://narayana.io
+page.
+
+== Changes in LRA REST API
+
+The Narayana LRA REST API is expected to support for at least two previous
+`major` versions (ie. support is expected in parallel at least
+of versions 1.x, 2.x and 3.x until the 4.0 is released).
+Still versions other than the last three may be supported.
+
+Changes which do not make a trouble for backward compatibility
+from client perspective (i.e., addition of features or enhancing the API
+with return types or similar) are considered to bump a `minor` version.
+Incompatible changes needs to bump the `major` version.
+
+== Unsupported version errors
+
+When client demands unsupported version from the REST API endpoint
+the code returns HTTP status
+link:http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.18[`417` EXPECTATION_FAILED`].
+
+On returning the `417` error the API is expected to return the header
+`Narayana-LRA-API-version` with the highest supported
+API version.
+
+For an unsupported version is considered any request to the REST API endpoint
+which demands (via HTTP header `Narayana-LRA-API-version`) version
+higher than the current API version (i.e., the highest version that the API
+is created for).
+
+Multiple versions of the API may be supported in parallel.
+The current version can be discovered by:
+
+* Either looking at <<_listing_of_api_versions, the listing above>>.
+* And/or by sending a request without the version header.
+  The response will include the version header containing
+  the latest supported version
+
+Typically the last 3 versions are supported
+but older version may also be maintained

--- a/rts/lra/client/pom.xml
+++ b/rts/lra/client/pom.xml
@@ -30,14 +30,20 @@
             <version>${version.microprofile.lra.api}</version>
         </dependency>
         <dependency>
-          <groupId>org.jboss.narayana.rts</groupId>
-          <artifactId>lra-service-base</artifactId>
-          <version>${project.version}</version>
+            <groupId>org.jboss.narayana.rts</groupId>
+            <artifactId>lra-service-base</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.json</groupId>
             <artifactId>jboss-json-api_1.0_spec</artifactId>
-            <version>1.0.0.Final</version>
+            <version>${version.jboss.json-api}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${version.cdi-api}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/rts/lra/coordinator/pom.xml
+++ b/rts/lra/coordinator/pom.xml
@@ -69,6 +69,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${version.cdi-api}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <version>${version.org.jboss.servlet.api}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-client</artifactId>
             <version>${project.version}</version>

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -56,9 +56,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -89,19 +89,22 @@ import static io.narayana.lra.LRAConstants.RECOVERY_COORDINATOR_PATH_NAME;
 import static io.narayana.lra.LRAConstants.STATUS;
 import static io.narayana.lra.LRAConstants.STATUS_PARAM_NAME;
 import static io.narayana.lra.LRAConstants.TIMELIMIT_PARAM_NAME;
+import static io.narayana.lra.LRAConstants.CURRENT_API_VERSION_STRING;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static javax.ws.rs.core.Response.Status.OK;
+import static io.narayana.lra.LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
 
 @ApplicationScoped
 @Path(COORDINATOR_PATH_NAME)
-@Tag(name = "LRA Coordinator")
 @OpenAPIDefinition(
         info = @Info(title = "LRA Coordinator", version = Coordinator.LRA_API_VERSION),
         tags = @Tag(name = "LRA Coordinator")
 )
+@Tag(name = "LRA Coordinator", description = "Operations to work with active LRAs (to start, to get a status, to finish, etc.)")
 public class Coordinator extends Application {
     static final String LRA_API_VERSION = "1.0-RC1";
 
@@ -121,107 +124,131 @@ public class Coordinator extends Application {
         lraService = LRARecoveryModule.getService();
     }
 
-    // Performing a GET on /lra-io.narayana.lra.coordinator returns a list of all LRAs.
     @GET
     @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Returns all LRAs",
-        description = "Gets both active and recovering LRAs")
-    @APIResponse(description = "The LRA",
-        content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = LRAData.class))
-    )
-    public Collection<LRAData> getAllLRAs(
+    @Operation(summary = "Returns all LRAs", description = "Gets both active and recovering LRAs")
+    @APIResponses({
+        @APIResponse(responseCode = "200", description = "The LRAData json array which is known to coordinator",
+            content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = LRAData.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)}),
+        @APIResponse(responseCode = "400", description = "Provided Status is not recognized as a valid LRA status value",
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)}),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
+    })
+    public Response getAllLRAs(
             @Parameter(name = STATUS_PARAM_NAME, description = "Filter the returned LRAs to only those in the give state (see CompensatorStatus)")
-            @QueryParam(STATUS_PARAM_NAME) @DefaultValue("") String state) {
+            @QueryParam(STATUS_PARAM_NAME) @DefaultValue("") String state,
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) {
         LRAStatus requestedLRAStatus = null;
-        if(!state.isEmpty()) {
-            requestedLRAStatus = LRAStatus.valueOf(state);
+        if (!state.isEmpty()) {
+            try {
+                requestedLRAStatus = LRAStatus.valueOf(state);
+            } catch (IllegalArgumentException e) {
+                String errorMsg = "Status " + state + " is not a valid LRAStatus value";
+                throw new WebApplicationException(errorMsg, e,
+                        Response.status(BAD_REQUEST).header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version).entity(errorMsg).build());
+            }
         }
 
-        Collection<LRAData> lras = lraService.getAll(requestedLRAStatus);
+        List<LRAData> lras = lraService.getAll(requestedLRAStatus);
 
-        if (lras == null) {
-            LRALogger.i18NLogger.error_invalidQueryForGettingLraStatuses(state);
-            String errMsg = String.format("Invalid query '%s' to get LRAs", state);
-            throw new WebApplicationException(errMsg,
-                    Response.status(BAD_REQUEST).entity(errMsg).build());
-        }
-
-        return lras;
+        return Response.ok()
+            .entity(lras)
+            .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version).build();
     }
 
     @GET
     @Path("{LraId}/status")
     @Produces(MediaType.TEXT_PLAIN)
     @Operation(summary = "Obtain the status of an LRA as a string")
-    @Schema(implementation = String.class)
     @APIResponses({
-        @APIResponse(responseCode = "404",
-            description = "The coordinator has no knowledge of this LRA"),
-        @APIResponse(responseCode = "204",
-            description = "The LRA exists and has not yet been asked to close or cancel"),
-        @APIResponse(responseCode = "200",
-            description = "The LRA exists. The status is reported in the content body.")
+        @APIResponse(responseCode = "200", description = "The LRA exists. The status is reported in the content body.",
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
     })
     public Response getLRAStatus(
-        @Parameter(name = "LraId",
-            description = "The unique identifier of the LRA", required = true)
-        @PathParam("LraId")String lraId) throws NotFoundException {
-        LongRunningAction transaction = lraService.getTransaction(toURI(lraId));
+        @Parameter(name = "LraId", description = "The unique identifier of the LRA." +
+                "Expecting to be a valid URL where the participant can be contacted at. If not in URL format it will be considered " +
+                "to be an id which will be declared to exist at URL where coordinator is deployed at.", required = true)
+        @PathParam("LraId")String lraId,
+        @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+        @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version)
+            throws NotFoundException {
+        LongRunningAction transaction = lraService.getTransaction(toURI(lraId)); // throws NotFoundException -> response 404
         LRAStatus status = transaction.getLRAStatus();
 
         if (status == null) {
             status = LRAStatus.Active;
         }
 
-        return Response.ok(status.name()).build();
+        return Response.ok()
+            .entity(status.name())
+            .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version).build();
     }
 
     @GET
     @Path("{LraId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Obtain the status of an LRA as a JSON structure")
+    @Operation(summary = "Obtain the information about an LRA as a JSON structure")
     @APIResponses({
-        @APIResponse(responseCode = "404",
-            description = "The coordinator has no knowledge of this LRA",
-            content = @Content(schema = @Schema(implementation = LRAData.class))),
-        @APIResponse(responseCode = "204",
-            description = "The LRA exists and has not yet been asked to close or cancel",
-            content = @Content(schema = @Schema(implementation = LRAData.class))),
-        @APIResponse(responseCode = "200",
-            description = "The LRA exists. The status is reported in the content body.",
-            content = @Content(schema = @Schema(implementation = LRAData.class)))
+        @APIResponse(responseCode = "200", description = "The LRA exists and the information is packed as JSON in the content body.",
+            content = @Content(schema = @Schema(implementation = LRAData.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
     })
-    public LRAData getLRAInfo(
+    public Response getLRAInfo(
             @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
-            @PathParam("LraId") String lraId) throws NotFoundException {
-
-        return lraService.getLRA(toURI(lraId));
+            @PathParam("LraId") String lraId,
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) {
+        URI lraIdURI = toURI(lraId);
+        LRAData lraData = lraService.getLRA(lraIdURI);
+        return Response.status(OK).entity(lraData)
+                .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version).build();
     }
 
-    // Performing a POST on /lra-io.narayana.lra.coordinator/start?ClientID=<ClientID> will start a new lra with a default timeout and
-    // return a lra URL of the form <machine>/lra-io.narayana.lra.coordinator/<LraId>.
-    // Adding a query parameter, timeout=<timeout>, will start a new lra with the specified timeout.
-    // If the lra is terminated because of a timeout, the lra URL is deleted and all further invocations on the URL will return 404.
-    // The invoker can assume this was equivalent to a compensate operation.
+    /**
+     * Performing a POST on {@value LRAConstants#COORDINATOR_PATH_NAME}/start?ClientID=<ClientID>
+     * will start a new lra with a default timeout and return an LRA URL
+     * of the form <coordinator url>/{@value LRAConstants#COORDINATOR_PATH_NAME}/<LraId>.
+     * Adding a query parameter, {@value LRAConstants#TIMELIMIT_PARAM_NAME}=<timeout>, will start a new lra with the specified timeout.
+     * If the lra is terminated because of a timeout, the lra URL is deleted and all further invocations on the URL will return 404.
+     * The invoker can assume this was equivalent to a compensate operation.
+     */
     @POST
     @Path("start")
     @Produces(MediaType.TEXT_PLAIN)
     @Bulkhead
     @Operation(summary = "Start a new LRA",
-        description = "The LRA model uses a presumed nothing protocol: the coordinator must communicate\n"
-            + "with Compensators in order to inform them of the LRA activity. Every time a\n"
-            + "Compensator is enrolled with a LRA, the coordinator must make information about\n"
-            + "it durable so that the Compensator can be contacted when the LRA terminates,\n"
-            + "even in the event of subsequent failures. Compensators, clients and coordinators\n"
-            + "cannot make any presumption about the state of the global transaction without\n"
+        description = "The LRA model uses a presumed nothing protocol: the coordinator must communicate "
+            + "with Compensators in order to inform them of the LRA activity. Every time a "
+            + "Compensator is enrolled with an LRA, the coordinator must make information about "
+            + "it durable so that the Compensator can be contacted when the LRA terminates, "
+            + "even in the event of subsequent failures. Compensators, clients and coordinators "
+            + "cannot make any presumption about the state of the global transaction without "
             + "consulting the coordinator and all compensators, respectively.")
     @APIResponses({
         @APIResponse(responseCode = "201",
             description = "The request was successful and the response body contains the id of the new LRA",
-            content = @Content(schema = @Schema(title = "An LRA id", description = "An URI of the new LRA"))),
-        @APIResponse(responseCode = "500",
-            description = "A new LRA could not be started")
+            content = @Content(schema = @Schema(description = "An URI of the new LRA", implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "404", description = "Parent LRA id cannot be joint to the started LRA",
+            content = @Content(schema = @Schema(description = "Message containing problematic LRA id", implementation = String.class))),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "500", description = "A new LRA could not be started. Coordinator internal error.",
+                content = @Content(schema = @Schema(implementation = String.class)))
     })
     public Response startLRA(
             @Parameter(name = CLIENT_ID_PARAM_NAME,
@@ -236,7 +263,9 @@ public class Coordinator extends Application {
             @QueryParam(TIMELIMIT_PARAM_NAME) @DefaultValue("0") Long timelimit,
             @Parameter(name = PARENT_LRA_PARAM_NAME,
                 description = "The enclosing LRA if this new LRA is nested")
-            @QueryParam(PARENT_LRA_PARAM_NAME) @DefaultValue("") String parentLRA) throws WebApplicationException {
+            @QueryParam(PARENT_LRA_PARAM_NAME) @DefaultValue("") String parentLRA,
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) throws WebApplicationException {
 
         URI parentId = (parentLRA == null || parentLRA.trim().isEmpty()) ? null : toURI(parentLRA);
         String coordinatorUrl = String.format("%s%s", context.getBaseUri(), COORDINATOR_PATH_NAME);
@@ -255,18 +284,23 @@ public class Coordinator extends Application {
                     client = ClientBuilder.newClient();
                     response = client.target(parentId)
                         .request()
+                        .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, CURRENT_API_VERSION_STRING)
                         .async()
                         .put(Entity.text(compensatorUrl))
                         .get(PARTICIPANT_TIMEOUT, TimeUnit.SECONDS);
 
                     if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                        String errMessage = String.format("The coordinator at %s returned an unexpected response: %d",
-                                parentId, response.getStatus());
+                        String errMessage = String.format("The coordinator at %s returned an unexpected response: %d"
+                                + "when the LRA '%s' tried to join the parent LRA '%s'", parentId, response.getStatus(), lraId, parentLRA);
                         return Response.status(response.getStatus()).entity(errMessage).build();
                     }
                 } catch (Exception e) {
-                    LRALogger.logger.debugf("Cannot contact the LRA Coordinator at %s", parentLRA);
-                    throw new WebApplicationException(e);
+                    String errorMsg = String.format("Cannot contact the LRA Coordinator at '%s' for LRA '%s' joining parent LRA '%s'",
+                            parentId, lraId, parentLRA);
+                    LRALogger.logger.debugf(errorMsg);
+                    throw new WebApplicationException(errorMsg, e,
+                            Response.status(INTERNAL_SERVER_ERROR).header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+                                    .entity(errorMsg).build());
                 } finally {
                     if (client != null) {
                         client.close();
@@ -280,27 +314,37 @@ public class Coordinator extends Application {
         return Response.created(lraId)
                 .entity(lraId)
                 .header(LRA_HTTP_CONTEXT_HEADER, Current.getContexts())
+                .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
                 .build();
     }
 
     @PUT
     @Path("{LraId}/renew")
     @Operation(summary = "Update the TimeLimit for an existing LRA",
-        description = "LRAs can be automatically cancelled if they aren't closed or cancelled before the TimeLimit\n"
-            + "specified at creation time is reached.\n"
-            + "The time limit can be updated.\n")
+        description = "LRAs can be automatically cancelled if they aren't closed or cancelled before the TimeLimit "
+            + "specified at creation time is reached. The time limit can be updated.")
     @APIResponses({
-        @APIResponse(responseCode = "200", description = "If the LRA timelimit has been updated"),
-        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA"),
-        @APIResponse(responseCode = "412",
-            description = "The LRA is not longer active (ie the complete or compensate messages have been sent")
+        @APIResponse(responseCode = "200", description = "If the LRA time limit has been updated",
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA or " +
+            "the LRA is not longer active (ie the complete or compensate messages have been sent",
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
     })
     public Response renewTimeLimit(
+            @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
+            @PathParam("LraId") String lraId,
             @Parameter(name = TIMELIMIT_PARAM_NAME, description = "The new time limit for the LRA", required = true)
-            @QueryParam(TIMELIMIT_PARAM_NAME) @DefaultValue("0") Long timelimit,
-            @PathParam("LraId")String lraId) throws NotFoundException {
-
-        return Response.status(lraService.renewTimeLimit(toURI(lraId), timelimit)).build();
+            @QueryParam(TIMELIMIT_PARAM_NAME) @DefaultValue("0") Long timeLimit,
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) {
+        return Response.status(lraService.renewTimeLimit(toURI(lraId), timeLimit))
+            .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+            .entity(lraId)
+            .build();
     }
 
     @GET
@@ -358,11 +402,14 @@ public class Coordinator extends Application {
         return Response.ok().build();
     }
 
-    // Performing a PUT on lra-coordinator/<LraId>/close will trigger the successful completion of the lra and all
-    // compensators will be dropped by the io.narayana.lra.coordinator.
-    // The complete message will be sent to the compensators. Question: is this message best effort or at least once?
-    // Upon termination, the URL is implicitly deleted. If it no longer exists, then 404 will be returned.
-    // The invoker cannot know for sure whether the lra completed or compensated without enlisting a participant.
+    /**
+     * Performing a PUT on {@value LRAConstants#COORDINATOR_PATH_NAME}/<LraId>/close will trigger the successful completion
+     * of the LRA and all compensators will be dropped by the LRA Coordinator.
+     * The complete message will be sent to the compensators.
+     * Upon termination, the URL is implicitly deleted. If it no longer exists, then 404 will be returned.
+     * The invoker cannot know for sure whether the lra completed or compensated without enlisting a participant.
+     */
+    // TODO: Question: is this message best effort or at least once?
     // TODO rework spec to allow an LRAStatus header everywhere
     @PUT
     @Path("{LraId}/close")
@@ -375,15 +422,23 @@ public class Coordinator extends Application {
             + " The invoker cannot know for sure whether the lra completed"
             + " or compensated without enlisting a participant.")
     @APIResponses({
-        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA"),
-        @APIResponse(responseCode = "200", description = "The complete message was sent to all coordinators",
-            content = @Content(
-                schema = @Schema(title = "one of the LRAStatus enum values", implementation = String.class)))
+            @APIResponse(responseCode = "200", description = "The complete message was sent to all coordinators",
+                content = @Content(schema = @Schema(implementation = String.class)),
+                headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+            @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA",
+                    content = @Content(schema = @Schema(implementation = String.class)),
+                    headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+            @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                    content = @Content(schema = @Schema(implementation = String.class))),
     })
     public Response closeLRA(
             @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
-            @PathParam("LraId")String txId) throws NotFoundException {
-        return Response.ok(endLRA(toURI(txId), false, false).name()).build();
+            @PathParam("LraId") String txId,
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version) {
+        return Response.ok(endLRA(toURI(txId), false, false).name())
+                .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+                .build();
     }
 
     @PUT
@@ -395,15 +450,24 @@ public class Coordinator extends Application {
             + " Upon termination, the URL is implicitly deleted."
             + " The invoker cannot know for sure whether the lra completed or compensated without enlisting a participant.")
     @APIResponses({
-        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA"),
         @APIResponse(responseCode = "200", description = "The compensate message was sent to all coordinators",
-            content = @Content(
-                schema = @Schema(title = "one of the LRAStatus enum values", implementation = String.class)))
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA",
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
     })
     public Response cancelLRA(
-            @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
-            @PathParam("LraId")String lraId) throws NotFoundException {
-        return Response.ok(endLRA(toURI(lraId), true, false).name()).build();
+        @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
+        @PathParam("LraId")String lraId,
+        @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+        @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version)
+            throws NotFoundException {
+        return Response.ok(endLRA(toURI(lraId), true, false).name())
+                .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+                .build();
     }
 
 
@@ -418,48 +482,55 @@ public class Coordinator extends Application {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "A Compensator can join with the LRA at any time prior to the completion of an activity")
     @APIResponses({
-        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA"),
-        @APIResponse(responseCode = "412",
-            description = "The LRA is no longer active (ie the complete or compensate message has been sent"),
         @APIResponse(responseCode = "200",
-            description = "The participant was successfully registered with the LRA and"
-                + " the response body contains a unique resource reference for that participant:\n"
-                + " - HTTP GET on the reference returns the original participant URL;\n"
-                + " - HTTP PUT on the reference will overwrite the old participant URL with the new one supplied.",
-        headers = @Header(name = LRA_HTTP_RECOVERY_HEADER,
-            description = "If the participant is successfully registered with the LRA then this header\n"
-                + " will contain a unique resource reference for that participant:\n"
-                + " - HTTP GET on the reference returns the original participant URL;\n"
-                + " - HTTP PUT on the reference will overwrite the old participant URL with the new one supplied.",
-            schema = @Schema(implementation = String.class)),
-        content = @Content(schema = @Schema(title = "A new LRA recovery id", description = "An URI representing the " +
-            "recovery id of this join request")))
+            description = "The participant was successfully registered with the LRA",
+            content = @Content(schema = @Schema(description = "A URI representing the recovery id of this join request",implementation = String.class)),
+            headers = {
+                @Header(name = LRA_HTTP_RECOVERY_HEADER, description = "It contains a unique resource reference for that participant:\n"
+                        + " - HTTP GET on the reference returns the original participant URL;\n" // TODO: verify recovery coordinator works this way
+                        + " - HTTP PUT on the reference will overwrite the old participant URL with the new one supplied.",
+                    schema = @Schema(implementation = String.class)),
+                @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "400", description = "Link does not contain all required fields for joining the LRA. " +
+                "Probably no compensator or after 'rel' is available.",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "412",
+            description = "The LRA is not longer active (ie the complete or compensate message has been sent), or wrong format of compensator data",
+            content = @Content(schema = @Schema(implementation = String.class)),
+            headers = {@Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)}),
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "500", description = "Format of the compensator data (e.g. Link format) could not be processed",
+            content = @Content(schema = @Schema(implementation = String.class))),
     })
     public Response joinLRAViaBody(
             @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
             @PathParam("LraId")String lraId,
             @Parameter(name = TIMELIMIT_PARAM_NAME,
-                description = "The time limit (in seconds) that the Compensator can guarantee that it can compensate "
+                description = "The time limit in milliseconds that the Compensator can guarantee that it can compensate "
                     + "the work performed by the service. After this time period has elapsed, it may no longer be "
                     + "possible to undo the work within the scope of this (or any enclosing) LRA. It may therefore "
                     + "be necessary for the application or service to start other activities to explicitly try to "
                     + "compensate this work. The application or coordinator may use this information to control the "
-                    + "lifecycle of a LRA.")
+                    + "lifecycle of an LRA.")
             @QueryParam(TIMELIMIT_PARAM_NAME) @DefaultValue("0") long timeLimit,
             @Parameter(name = "Link",
                 description = "The resource paths that the coordinator will use to complete or compensate and to request"
                     + " the status of the participant. The link rel names are"
                     + " complete, compensate and status.")
             @HeaderParam("Link") @DefaultValue("") String compensatorLink,
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version,
             @RequestBody(name = "Compensator data",
-                description = "opaque data that will be stored with the coordinator and passed back to\n"
-                    + "the participant when the LRA is closed or cancelled.\n")
-                    String compensatorData) throws NotFoundException {
+                description = "opaque data that will be stored with the coordinator and passed back to "
+                    + "the participant when the LRA is closed or cancelled.") String compensatorData) throws NotFoundException {
         // test to see if the join request contains any participant specific data
         boolean isLink = isLink(compensatorData);
 
         if (compensatorLink != null && !compensatorLink.isEmpty()) {
-            return joinLRA(toURI(lraId), timeLimit, null, compensatorLink, compensatorData);
+            return joinLRA(toURI(lraId), timeLimit, null, compensatorLink, compensatorData, version);
         }
 
         if (!isLink) { // interpret the content as a standard participant url
@@ -472,16 +543,19 @@ public class Coordinator extends Application {
                 terminateURIs.put(COMPLETE, new URL(compensatorData + "complete").toExternalForm());
                 terminateURIs.put(STATUS, new URL(compensatorData + "status").toExternalForm());
             } catch (MalformedURLException e) {
+                String errorMsg = String.format("Cannot join to LRA id '%s' with body as compensator url '%s' is invalid",
+                        lraId, compensatorData);
                 if (LRALogger.logger.isTraceEnabled()) {
-                    LRALogger.logger.tracef(e, "Cannot join to LRA id '%s' with body as compensator url '%s' is invalid",
-                            lraId, compensatorData);
+                    LRALogger.logger.trace(errorMsg, e);
                 }
 
-                return Response.status(PRECONDITION_FAILED).build();
+                return Response.status(PRECONDITION_FAILED)
+                        .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+                        .entity(errorMsg)
+                        .build();
             }
 
-            // register with the coordinator
-            // put the lra id in an http header
+            // register with the coordinator, put the lra id in an http header
             StringBuilder linkHeaderValue = new StringBuilder();
 
             terminateURIs.forEach((k, v) -> makeLink(linkHeaderValue, "", k, v)); // or use Collectors.joining(",")
@@ -489,7 +563,7 @@ public class Coordinator extends Application {
             compensatorData = linkHeaderValue.toString();
         }
 
-        return joinLRA(toURI(lraId), timeLimit, null, compensatorData, null);
+        return joinLRA(toURI(lraId), timeLimit, null, compensatorData, null, version);
     }
 
 
@@ -519,7 +593,7 @@ public class Coordinator extends Application {
         }
     }
 
-    private Response joinLRA(URI lraId, long timeLimit, String compensatorUrl, String linkHeader, String userData)
+    private Response joinLRA(URI lraId, long timeLimit, String compensatorUrl, String linkHeader, String userData, String version)
             throws NotFoundException {
         final String recoveryUrlBase = String.format("%s%s/%s",
                 context.getBaseUri().toASCIIString(), COORDINATOR_PATH_NAME, RECOVERY_COORDINATOR_PATH_NAME);
@@ -533,40 +607,49 @@ public class Coordinator extends Application {
                     .entity(recoveryUrl.toString())
                     .location(new URI(recoveryUrl.toString()))
                     .header(LRA_HTTP_RECOVERY_HEADER, recoveryUrl)
+                    .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
                     .build();
         } catch (URISyntaxException e) {
             LRALogger.i18NLogger.error_invalidRecoveryUrlToJoinLRAURI(recoveryUrl.toString(), lraId);
             String errorMsg = lraId + ": Invalid recovery URL " + recoveryUrl.toString();
             throw new WebApplicationException(errorMsg, e ,
-                    Response.status(INTERNAL_SERVER_ERROR).entity(errorMsg).build());
+                    Response.status(INTERNAL_SERVER_ERROR).entity(errorMsg)
+                            .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+                            .build());
         }
     }
 
-    // A participant can resign from a lra at any time prior to the completion of an activity by performing a
-    // PUT on lra-coordinator/<LraId>/remove with the URL of the participant.
+    /**
+     * A participant can resign from an LRA at any time prior to the completion of an activity by performing a PUT
+     * PUT on {@value LRAConstants#COORDINATOR_PATH_NAME}/<LraId>/remove with the URL of the participant.
+     */
     @PUT
     @Path("{LraId}/remove")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "A Compensator can resign from the LRA at any time prior to the completion of an activity")
     @APIResponses({
-        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA"),
+        @APIResponse(responseCode = "200", description = "If the participant was successfully removed from the LRA",
+            headers = { @Header(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) }),
+        @APIResponse(responseCode = "400", description = "The coordinator has no knowledge of this participant compensator URL",
+            content = @Content(schema = @Schema(implementation = String.class))),
+        @APIResponse(responseCode = "404", description = "The coordinator has no knowledge of this LRA",
+                content = @Content(schema = @Schema(implementation = String.class))),
         @APIResponse(responseCode = "412",
             description = "The LRA is not longer active (ie in the complete or compensate messages have been sent"),
-        @APIResponse(responseCode = "200", description = "If the participant was successfully removed from the LRA")
+        @APIResponse(responseCode = "417", description = "The requested version provided in HTTP Header is not supported by this end point",
+                content = @Content(schema = @Schema(implementation = String.class))),
     })
     public Response leaveLRA(
             @Parameter(name = "LraId", description = "The unique identifier of the LRA", required = true)
             @PathParam("LraId") String lraId,
-            String compensatorUrl) throws NotFoundException, URISyntaxException {
-        String reqUri = context.getRequestUri().toString();
+            @Parameter(ref = LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME)
+            @HeaderParam(LRAConstants.NARAYANA_LRA_API_VERSION_HEADER_NAME) @DefaultValue(CURRENT_API_VERSION_STRING) String version,
+            String participantCompensatorUrl) throws NotFoundException {
+        int status = lraService.leave(toURI(lraId), participantCompensatorUrl);
 
-        reqUri =  reqUri.substring(0, reqUri.lastIndexOf('/'));
-
-        int status = 0;
-
-        status = lraService.leave(new URI(reqUri), compensatorUrl);
-
-        return Response.status(status).build();
+        return Response.status(status)
+                .header(NARAYANA_LRA_API_VERSION_HEADER_NAME, version)
+                .build();
     }
 
     private URI toURI(String lraId) {

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
@@ -113,11 +113,11 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
                 });
 
                 if (parseException[0] != null) {
-                    String errorMsg = lraId + ": Invalid link URI: " + parseException[0];
+                    String errorMsg = lra.getId() + ": Invalid link URI: " + parseException[0];
                     throw new WebApplicationException(errorMsg, parseException[0],
                             Response.status(BAD_REQUEST).entity(errorMsg).build());
                 } else if (compensateURI == null && afterURI == null) {
-                    String errorMsg = lraId + ": Invalid link URI: missing compensator";
+                    String errorMsg = lra.getId() + ": Invalid link URI: missing compensator or after LRA callback";
                     throw new WebApplicationException(errorMsg, Response.status(BAD_REQUEST).entity(errorMsg).build());
                 }
             } else {
@@ -156,7 +156,7 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
 
     static String cannonicalForm(String linkStr) throws URISyntaxException {
         if (!linkStr.contains(">;")) {
-            return cannonicalURI(new URI(linkStr)).toASCIIString();
+            return new URI(linkStr).toASCIIString();
         }
 
         SortedMap<String, String> lm = new TreeMap<>();

--- a/rts/lra/coordinator/src/test/resources/arquillian.xml
+++ b/rts/lra/coordinator/src/test/resources/arquillian.xml
@@ -28,6 +28,7 @@
         <configuration>
             <property name="managementAddress">${lra.coordinator.host}</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:120}</property>
+            <property name="allowConnectingToRunningServer">true</property>
         </configuration>
     </container>
 </arquillian>

--- a/rts/lra/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -540,7 +540,7 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                 String failureMessage =  processLRAOperationFailures(progress);
 
                 if (failureMessage != null) {
-                    LRALogger.logger.warn(LRALogger.i18NLogger.warn_LRAStatusInDoubt(failureMessage));
+                    LRALogger.logger.warn(failureMessage);
 
                     // the actual failure(s) will also have been added to the i18NLogger logs at the time they occured
                     responseContext.setEntity(failureMessage, null, MediaType.TEXT_PLAIN_TYPE);

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><!--
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
   ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jboss.narayana.rts</groupId>
@@ -76,6 +78,18 @@
 
     <dependencies>
         <!-- for testing -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${version.hamcrest}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${version.hamcrest}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -17,13 +17,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.json.api>1.1</version.json.api>
         <version.jackson>2.9.10.1</version.jackson>
 
         <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
         <version.cdi-api>2.0</version.cdi-api>
         <version.servlet-api>2.5</version.servlet-api>
         <version.jboss-modules>1.10.2.Final</version.jboss-modules>
+        <version.jboss.json-api>1.0.0.Final</version.jboss.json-api>
+        <version.org.jboss.servlet.api>1.0.0.Final</version.org.jboss.servlet.api>
 
         <version.microprofile.lra.api>1.0-RC2</version.microprofile.lra.api>
         <version.microprofile.lra.tck>1.0-RC2</version.microprofile.lra.tck>
@@ -74,19 +75,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- for Intellij -->
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-all-7.0</artifactId>
-            <version>1.0.3.Final</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-            <version>${version.javax.ws.rs-api}</version>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/rts/lra/proxy/api/src/main/java/io/narayana/lra/proxy/logging/lraI18NLogger.java
+++ b/rts/lra/proxy/api/src/main/java/io/narayana/lra/proxy/logging/lraI18NLogger.java
@@ -23,7 +23,6 @@
 package io.narayana.lra.proxy.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.WARN;
 
 import java.util.concurrent.ExecutionException;
 
@@ -48,17 +47,14 @@ public interface lraI18NLogger {
     @LogMessage(level = ERROR)
     void error_cannotSerializeParticipant(String participantToString, @Cause Throwable e);
 
-    @Message(id = 25003, value = "Participant '%s' exception during completion")
+    @Message(id = 25002, value = "Participant '%s' exception during completion")
     @LogMessage(level = ERROR)
     void error_participantExceptionOnCompletion(String name, @Cause ExecutionException e);
 
-    @Message(id = 25004, value = "Cannot get status of participant '%s' of lra id '%s'")
+    @Message(id = 25003, value = "Cannot get status of participant '%s' of lra id '%s'")
     @LogMessage(level = ERROR)
     void error_gettingParticipantStatus(String participant, String lraId, @Cause Throwable e);
 
-    @Message(id = 25005, value = "Participant deserialization failed for LRA '%s' using deserializer class %s: '%s'")
-    @LogMessage(level = WARN)
-    void warn_cannotDeserializeParticipant(String lraId, String deserializer, String message);
 
     /*
         Allocate new messages directly above this notice.

--- a/rts/lra/service-base/pom.xml
+++ b/rts/lra/service-base/pom.xml
@@ -18,6 +18,11 @@
       <artifactId>microprofile-lra-api</artifactId>
       <version>${version.microprofile.lra.api}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+      <version>${version.javax.ws.rs-api}</version>
+    </dependency>
 
     <!-- jboss logging -->
     <dependency>

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -45,6 +45,25 @@ public final class LRAConstants {
     public static final String RECOVERY_PARAM = "recoveryCount";
     public static final String HTTP_METHOD_NAME = "method"; // the name of the HTTP method used to invoke participants
 
+    /*
+     * Supported Narayana LRA API versions.
+     * Any version not mentioned in the list of the supported versions is unsupported
+     * and will fail on incoming HTTP call.
+     * The valid version format is specified in API.adoc document.
+     * When a new version with a new features is added consider adding API tests under 'test/basic'.
+     */
+    public static final String[] NARAYANA_LRA_API_SUPPORTED_VERSIONS = new String[] {
+            "1.0"
+    };
+
+    /**
+     * The Narayana API version for LRA coordinator supported for the release.
+     * Any higher version is considered as unimplemented and unknown.
+     */
+    public static final String CURRENT_API_VERSION_STRING = "1.0";
+
+    public static final String NARAYANA_LRA_API_VERSION_HEADER_NAME = "Narayana-LRA-API-version";
+
     /**
      * Number of seconds to wait for requests to participant.
      * The timeout is hardcoded as the protocol expects retry in case of failure and timeout.

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -31,8 +31,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import javax.json.JsonObject;
-
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -113,9 +111,11 @@ public interface lraI18NLogger {
     @Message(id = 25017, value = "Trying to aquire an in use connection for coordinator '%s'")
     void error_connectionInUse(URI coordinator);
 
+    /*
     @LogMessage(level = INFO)
     @Message(id = 25018, value = "Error parsing json LRAStatus from JSON '%s'")
     void warn_failedParsingStatusFromJson(JsonObject json, @Cause Throwable t);
+     */
 
     @LogMessage(level = ERROR)
     @Message(id = 25019, value = "Invalid query format '%s' to get lra statuses")

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/lraI18NLogger.java
@@ -26,7 +26,6 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -49,186 +48,120 @@ public interface lraI18NLogger {
         Allocate new messages by following instructions at the bottom of the file.
      */
     @LogMessage(level = ERROR)
-    @Message(id = 25001, value = "Can't construct URL from LRA id '%s'")
-    void error_urlConstructionFromStringLraId(String lraId, @Cause Throwable t);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25002, value = "LRA created with an unexpected status code: %d, coordinator response '%s'")
+    @Message(id = 25001, value = "LRA created with an unexpected status code: %d, coordinator response '%s'")
     void error_lraCreationUnexpectedStatus(int status, String response);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25004, value = "Cannot create URL from coordinator response '%s'")
-    void error_cannotCreateUrlFromLCoordinatorResponse(String response, @Cause Throwable t);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25005, value = "Error on contacting the LRA coordinator '%s'")
-    void error_cannotContactLRACoordinator(URI coordinator, @Cause Throwable t);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25006, value = "LRA renewal ends with an unexpected status code: %d, coordinator response '%s'")
-    void error_lraRenewalUnexpectedStatus(int status, String response);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25007, value = "Leaving LRA ends with an unexpected status code: %d, coordinator response '%s'")
+    @Message(id = 25002, value = "Leaving LRA ends with an unexpected status code: %d, coordinator response '%s'")
     void error_lraLeaveUnexpectedStatus(int status, String response);
 
     @LogMessage(level = WARN)
-    @Message(id = 25008, value = "JAX-RS @Suspended annotation is untested")
-    void warn_suspendAnnotationIsUntested();
-
-    @LogMessage(level = WARN)
-    @Message(id = 25009, value = "LRA participant class '%s' with asynchronous temination but no @Status or @Forget annotations")
+    @Message(id = 25003, value = "LRA participant class '%s' with asynchronous temination but no @Status or @Forget annotations")
     void error_asyncTerminationBeanMissStatusAndForget(Class<?> clazz);
 
-    @Message(id = 25010, value = "LRA finished with an unexpected status code: %d, coordinator response '%s'")
+    @Message(id = 25004, value = "LRA finished with an unexpected status code: %d, coordinator response '%s'")
     String error_lraTerminationUnexpectedStatus(int status, String response);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25011, value = "Cannot access coordinator '%s' when getting status for LRA '%s'")
-    void error_cannotAccessCoordinatorWhenGettingStatus(URI coordinator, URL lra, @Cause Throwable t);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25012, value = "LRA coordinator '%s' returned an invalid status code '%s' for LRA '%s'")
+    @Message(id = 25005, value = "LRA coordinator '%s' returned an invalid status code '%s' for LRA '%s'")
     void error_invalidStatusCode(URI coordinator, int status, URL lra);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25013, value = "LRA coordinator '%s' returned no content on #getStatus call for LRA '%s'")
+    @Message(id = 25006, value = "LRA coordinator '%s' returned no content on #getStatus call for LRA '%s'")
     void error_noContentOnGetStatus(URI coordinator, URL lra);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25014, value = "LRA coordinator '%s' returned an invalid status for LRA '%s'")
+    @Message(id = 25007, value = "LRA coordinator '%s' returned an invalid status for LRA '%s'")
     void error_invalidArgumentOnStatusFromCoordinator(URI coordinator, URL lra, @Cause Throwable t);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25015, value = "Too late to join with the LRA '%s', coordinator response: '%s'")
+    @Message(id = 25008, value = "Too late to join with the LRA '%s', coordinator response: '%s'")
     void error_tooLateToJoin(URL lra, String response);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25016, value = "Failed enlisting to LRA '%s', coordinator '%s' responded with status '%s'")
+    @Message(id = 25009, value = "Failed enlisting to LRA '%s', coordinator '%s' responded with status '%s'")
     void error_failedToEnlist(URL lra, URI coordinator, int status);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25017, value = "Trying to aquire an in use connection for coordinator '%s'")
-    void error_connectionInUse(URI coordinator);
-
-    /*
-    @LogMessage(level = INFO)
-    @Message(id = 25018, value = "Error parsing json LRAStatus from JSON '%s'")
-    void warn_failedParsingStatusFromJson(JsonObject json, @Cause Throwable t);
-     */
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25019, value = "Invalid query format '%s' to get lra statuses")
-    void error_invalidQueryForGettingLraStatuses(String query);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25020, value = "Invalid format of coordinator url, was '%s'")
-    void error_invalidCoordinatorUrl(URL coordinatorUrl, @Cause Throwable t);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25022, value = "Error when converting String '%s' to URL")
+    @Message(id = 25010, value = "Error when converting String '%s' to URL")
     void error_invalidStringFormatOfUrl(String string, @Cause Throwable t);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25023, value = "Error when encoding LRA id URL '%s' to String")
-    void error_invalidFormatToEncodeUrl(URL url, @Cause Throwable t);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25024, value = "Invalid LRA id format to create LRA record from LRA id '%s', link URI '%s'")
+    @Message(id = 25011, value = "Invalid LRA id format to create LRA record from LRA id '%s', link URI '%s'")
     void error_invalidFormatToCreateLRARecord(String lraId, String linkURI);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25025, value = "Cannot get status of nested lra '%s' as outer one '%s' is still active")
-    void error_cannotGetStatusOfNestedLra(String nestedLraId, URL lraId);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25026, value = "Invalid recovery url '%s' to join lra '%s'")
-    void error_invalidRecoveryUrlToJoinLRA(String recoveryUrl, URL lraId);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25027, value = "Cannot found compensator url '%s' for lra '%s'")
+    @Message(id = 25012, value = "Cannot found compensator url '%s' for lra '%s'")
     void error_cannotFoundCompensatorUrl(String recoveryUrl, String lraId);
 
-    @LogMessage(level = ERROR)
-    @Message(id = 25028, value = "Invalid format of lra id '%s' to replace compensator '%s'")
-    void error_invalidFormatOfLraIdReplacingCompensator(String recoveryUrl, String lraId, @Cause MalformedURLException e);
-
-    @LogMessage(level = ERROR)
-    @Message(id = 25029, value = "Invalid format of request uri '%s' for lra id '%s' to replace compensator '%s'")
-    void error_invalidFormatOfRequestUri(URI uri, String recoveryUrl, String lraId, @Cause MalformedURLException e);
-
-    @Message(id = 25030, value = "Could not recreate abstract record '%s'")
+    @Message(id = 25013, value = "Could not recreate abstract record '%s'")
     @LogMessage(level = WARN)
     void warn_coordinatorNorecordfound(String recordType, @Cause Throwable t);
 
-    @Message(id = 25031, value = "Cannot retrieve compensator status data '%s' of lra id '%s'")
-    @LogMessage(level = WARN)
-    void warn_cannotGetCompensatorStatusData(String data, URL lraId, @Cause Throwable t);
-
-    @Message(id = 25032, value = "reason '%s': container request for method '%s': lra: '%s'")
+    @Message(id = 25014, value = "reason '%s': container request for method '%s': lra: '%s'")
     @LogMessage(level = WARN)
     void warn_lraFilterContainerRequest(String reason, String method, String lra);
 
-    @Message(id = 25033, value = "trying to aquire an in use connection")
-    @LogMessage(level = ERROR)
-    void error_cannotAquireInUseConnection();
-
-    @Message(id = 25034, value = "LRA participant completion for asynchronous method %s#%s should return %d and not %d")
+    @Message(id = 25015, value = "LRA participant completion for asynchronous method %s#%s should return %d and not %d")
     @LogMessage(level = WARN)
     void warn_lraParticipantqForAsync(String clazz, String method, int statusCorrect, int statusWrong);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25035, value = "Cannot get status of nested lra '%s' as outer one '%s' is still active")
+    @Message(id = 25016, value = "Cannot get status of nested lra '%s' as outer one '%s' is still active")
     void error_cannotGetStatusOfNestedLraURI(String nestedLraId, URI lraId);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25036, value = "Invalid recovery url '%s' to join lra '%s'")
+    @Message(id = 25017, value = "Invalid recovery url '%s' to join lra '%s'")
     void error_invalidRecoveryUrlToJoinLRAURI(String recoveryUrl, URI lraId);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25037, value = "Invalid format of lra id '%s' to replace compensator '%s'")
+    @Message(id = 25018, value = "Invalid format of lra id '%s' to replace compensator '%s'")
     void error_invalidFormatOfLraIdReplacingCompensatorURI(String recoveryUrl, String lraId, @Cause URISyntaxException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 25038, value = "LRA participant `%s` returned immediate state (Compensating/Completing) from CompletionStage. LRA id: %s")
+    @Message(id = 25019, value = "LRA participant `%s` returned immediate state (Compensating/Completing) from CompletionStage. LRA id: %s")
     void warn_participantReturnsImmediateStateFromCompletionStage(String participantId, String lraId);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25039, value = "Cannot process non JAX-RS LRA participant")
+    @Message(id = 25020, value = "Cannot process non JAX-RS LRA participant")
     void error_cannotProcessParticipant(@Cause ReflectiveOperationException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 25040, value = "CDI cannot be detected, non JAX-RS LRA participants will not be processed")
+    @Message(id = 25021, value = "CDI cannot be detected, non JAX-RS LRA participants will not be processed")
     void warn_nonJaxRsParticipantsNotAllowed();
 
     @LogMessage(level = ERROR)
-    @Message(id = 25041, value = "Invalid format of LRA id to be converted to LRA coordinator url, was '%s'")
+    @Message(id = 25022, value = "Invalid format of LRA id to be converted to LRA coordinator url, was '%s'")
     void error_invalidLraIdFormatToConvertToCoordinatorUrl(String lraId, @Cause Throwable t);
 
     @LogMessage(level = INFO)
-    @Message(id = 25042, value = "Failed enlisting to LRA '%s', coordinator '%s' responded with status '%d (%s)'. Returning '%d (%s)'.")
+    @Message(id = 25023, value = "Failed enlisting to LRA '%s', coordinator '%s' responded with status '%d (%s)'. Returning '%d (%s)'.")
     void info_failedToEnlistingLRANotFound(URL lraId, URI coordinatorUri, int coordinatorStatusCode,
             String coordinatorStatusMsg, int returnStatusCode, String returnStatusMsg);
 
-    @Message(id = 25043, value = "Could not %s LRA '%s': coordinator '%s' responded with status '%s'")
+    @Message(id = 25024, value = "Could not %s LRA '%s': coordinator '%s' responded with status '%s'")
     String get_couldNotCompleteCompensateOnReturnedStatus(String actionName, URI lraId, URI coordinatorUri, String status);
 
     @LogMessage(level = ERROR)
-    @Message(id = 25044, value = "Error when encoding parent LRA id URL '%s' to String")
+    @Message(id = 25025, value = "Error when encoding parent LRA id URL '%s' to String")
     void error_invalidFormatToEncodeParentUri(URI parentUri, @Cause Throwable t);
 
-    @Message(id = 25145, value = "Unable to process LRA annotations: %s'")
+    @Message(id = 25026, value = "Unable to process LRA annotations: %s'")
     String warn_LRAStatusInDoubt(String reason);
 
     @LogMessage(level = WARN)
-    @Message(id = 25146, value = "Unable to remove the failed duclicate failed LRA record (Uid: '%s') " +
+    @Message(id = 25027, value = "Unable to remove the failed duclicate failed LRA record (Uid: '%s') " +
             "(which is already present in the failedLRA record location type: '%s'.) from LRA Record location: '%s'")
     void warn_UnableToRemoveDuplicateFailedLRARecord(String failedUid, String failedLRAType, String lraType);
 
     @LogMessage(level = WARN)
-    @Message(id = 25147, value = "An exception was thrown while moving failed LRA record (Uid: '%s'). " +
+    @Message(id = 25028, value = "An exception was thrown while moving failed LRA record (Uid: '%s'). " +
             "Reason: '%s'")
     void warn_move_lra_record(String failedUid, String exceptionMessage);
+
+    @Message(id = 25029, value = "Demanded API version '%s' is not in the list of the supported versions '%s'. " +
+            "Please, provide the right version for the API.")
+    String get_wrongAPIVersionDemanded(String demandedApiVersion, String supportedVersions);
 
     /*
         Allocate new messages directly above this notice.

--- a/rts/lra/service-base/src/test/java/io/narayana/lra/LRAConstantsTest.java
+++ b/rts/lra/service-base/src/test/java/io/narayana/lra/LRAConstantsTest.java
@@ -33,7 +33,6 @@ public class LRAConstantsTest {
     public void getCoordinatorFromUsualLRAId() {
         URI lraId = URI.create("http://localhost:8080/lra-coordinator/0_ffff0a28054b_9133_5f855916_a7?query=1#fragment");
         URI coordinatorUri = LRAConstants.getLRACoordinatorUrl(lraId);
-        System.out.println(">>>> " + coordinatorUri);
         Assert.assertEquals("http", coordinatorUri.getScheme());
         Assert.assertEquals("localhost", coordinatorUri.getHost());
         Assert.assertEquals(8080, coordinatorUri.getPort());

--- a/rts/lra/test/arquillian-extension/pom.xml
+++ b/rts/lra/test/arquillian-extension/pom.xml
@@ -64,7 +64,11 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-shaded</artifactId>
       <version>${version.org.jboss.weld.se}</version>
-      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
     </dependency>
   </dependencies>
 

--- a/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/AppServerCoordinatorDeploymentObserver.java
+++ b/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/AppServerCoordinatorDeploymentObserver.java
@@ -43,6 +43,9 @@ public class AppServerCoordinatorDeploymentObserver {
     /**
      * When the container name {@link Container#getName()} contains this string
      * then this observer prepares the 'war' deployment of the LRA Coordinator and serve it to the container.
+     * This string needs to be part of the container {@code qualifier} as defined
+     * in {@code arquillian.xml}.<br/>
+     * For example: {@code <container qualifier="wildfly-managed-run-as-coordinator">}.
      */
     private static final String CONTAINER_NAME_RECOGNITION = "as-coordinator";
     private static final String LRA_COORDINATOR_DEPLOYMENT_NAME = "lra-coordinator";
@@ -53,7 +56,7 @@ public class AppServerCoordinatorDeploymentObserver {
      * which is deployed when the app server starts.
      */
     public void handleAfterStartup(@Observes AfterStart event, Container container) throws Exception {
-        if(!container.getName().contains(CONTAINER_NAME_RECOGNITION)) {
+        if (!container.getName().contains(CONTAINER_NAME_RECOGNITION)) {
             log.debugf("Handling before after start-up event for container '%s'. The container name does not contain substring '%s' " +
                             "thus skipping execution.", container.getName(), CONTAINER_NAME_RECOGNITION);
             return;
@@ -61,7 +64,7 @@ public class AppServerCoordinatorDeploymentObserver {
 
         log.debugf("handleAfterStartup for container %s", container.getName());
         Archive<?> deployment = createLRACoordinatorDeployment();
-        if(deployments.put(deployment.getName(), deployment) == null) {
+        if (deployments.put(deployment.getName(), deployment) == null) {
             log.infof("Deploying LRA Coordinator war deployment: %s", deployment.getName());
             container.getDeployableContainer()
                     .deploy(deployment);
@@ -73,14 +76,14 @@ public class AppServerCoordinatorDeploymentObserver {
      * {@link #handleAfterStartup(AfterStart, Container)}.
      */
     public void handleBeforeStop(@Observes BeforeStop event, Container container) throws Exception {
-        if(!container.getName().contains(CONTAINER_NAME_RECOGNITION)) {
+        if (!container.getName().contains(CONTAINER_NAME_RECOGNITION)) { // container name taken from 'qualifier' string of arquillian.xml
             log.debugf("Handling before stop event for container '%s'. The container name does not contain substring '%s' " +
                     "thus skipping execution.", container.getName(), CONTAINER_NAME_RECOGNITION);
             return;
         }
 
         log.debugf("handleBeforeStop for container %s", container.getName());
-        for(Archive<?> deployment: deployments.values()) {
+        for (Archive<?> deployment: deployments.values()) {
             log.infof("Undeploying LRA Coordinator war deployment: %s", deployment.getName());
             container.getDeployableContainer().undeploy(deployment);
         }
@@ -98,12 +101,12 @@ public class AppServerCoordinatorDeploymentObserver {
                 .withTransitivity().asFile();
 
         ZipImporter zip = ShrinkWrap.create(ZipImporter.class, LRA_COORDINATOR_DEPLOYMENT_NAME + ".war");
-        for(File file: files) {
+        for (File file: files) {
             zip.importFrom(file);
         }
         WebArchive war = zip.as(WebArchive.class);
 
-        if(log.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debugf("Content of the LRA Coordinator deployment is:%n%s%n", war.toString(true));
         }
         return war;

--- a/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/ArquillianParametrized.java
+++ b/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/ArquillianParametrized.java
@@ -1,0 +1,248 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Ignore;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.Parameterized;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import java.lang.reflect.Field;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Parameterized Arquillian JUnit runner adding the possibility to run parameterized JUnit test cases ,
+ * while using the functionality of Arquillian of executing tests within the container.
+ *
+ * Adjusted from the HAL testsuite (https://github.com/hal/testsuite).
+ */
+public class ArquillianParametrized extends ParentRunner<Arquillian> {
+
+    private List<Arquillian> arquillians = new ArrayList<>();
+    private final List<FrameworkMethod> ignoredMethods;
+
+    public ArquillianParametrized(Class<?> testClass) throws Throwable {
+        super(testClass);
+        Parameterized.Parameters parameters = getParametersMethod().getAnnotation(
+                Parameterized.Parameters.class);
+        ignoredMethods = new ArrayList<>(getTestClass().getAnnotatedMethods(Ignore.class));
+        createRunnersForParameters(allParameters(), parameters.name());
+    }
+
+    @Override
+    protected List<Arquillian> getChildren() {
+        return arquillians;
+    }
+
+    @Override
+    protected Description describeChild(Arquillian child) {
+        return child.getDescription();
+    }
+
+    @Override
+    protected void runChild(Arquillian child, RunNotifier notifier) {
+        // This is a workaround for parameterized test cases which single test method is ignored
+        if (ignoredMethods.size() == 1) {
+            notifier.fireTestIgnored(getDescription());
+            return;
+        }
+        child.run(notifier);
+    }
+
+    private class TestClassEnricher extends Arquillian {
+
+        private final Object[] fParameters;
+
+        private final String fName;
+
+        TestClassEnricher(Class<?> testClass, Object[] fParameters, String fName) throws InitializationError {
+            super(testClass);
+            this.fParameters = fParameters;
+            this.fName = fName;
+        }
+
+        @Override
+        public Object createTest() throws Exception {
+            if (fieldsAreAnnotated()) {
+                return createTestUsingFieldInjection();
+            } else {
+                return createTestUsingConstructorInjection();
+            }
+        }
+
+        private Object createTestUsingConstructorInjection() throws Exception {
+            return getTestClass().getOnlyConstructor().newInstance(fParameters);
+        }
+
+        private Object createTestUsingFieldInjection() throws Exception {
+            List<FrameworkField> annotatedFieldsByParameter = getAnnotatedFieldsByParameter();
+            if (annotatedFieldsByParameter.size() != fParameters.length) {
+                throw new Exception("Wrong number of parameters and @Parameter fields." +
+                        " @Parameter fields counted: " + annotatedFieldsByParameter.size() + ", available parameters: " + fParameters.length + ".");
+            }
+            Object testClassInstance = getTestClass().getJavaClass().newInstance();
+            for (FrameworkField each : annotatedFieldsByParameter) {
+                Field field = each.getField();
+                Parameterized.Parameter annotation = field.getAnnotation(Parameterized.Parameter.class);
+                int index = annotation.value();
+                try {
+                    field.set(testClassInstance, fParameters[index]);
+                } catch (IllegalArgumentException iare) {
+                    throw new Exception(getTestClass().getName() + ": Trying to set " + field.getName() +
+                            " with the value " + fParameters[index] +
+                            " that is not the right type (" + fParameters[index].getClass().getSimpleName() + " instead of " +
+                            field.getType().getSimpleName() + ").", iare);
+                }
+            }
+            return testClassInstance;
+        }
+
+        @Override
+        protected String getName() {
+            return fName;
+        }
+
+        @Override
+        protected String testName(FrameworkMethod method) {
+            return method.getName() + getName();
+        }
+
+        @Override
+        protected void validateConstructor(List<Throwable> errors) {
+            validateOnlyOneConstructor(errors);
+            if (fieldsAreAnnotated()) {
+                validateZeroArgConstructor(errors);
+            }
+        }
+
+        @Override
+        protected void validateFields(List<Throwable> errors) {
+            super.validateFields(errors);
+            if (fieldsAreAnnotated()) {
+                List<FrameworkField> annotatedFieldsByParameter = getAnnotatedFieldsByParameter();
+                int[] usedIndices = new int[annotatedFieldsByParameter.size()];
+                for (FrameworkField each : annotatedFieldsByParameter) {
+                    int index = each.getField().getAnnotation(Parameterized.Parameter.class).value();
+                    if (index < 0 || index > annotatedFieldsByParameter.size() - 1) {
+                        errors.add(
+                                new Exception("Invalid @Parameter value: " + index + ". @Parameter fields counted: " +
+                                        annotatedFieldsByParameter.size() + ". Please use an index between 0 and " +
+                                        (annotatedFieldsByParameter.size() - 1) + ".")
+                        );
+                    } else {
+                        usedIndices[index]++;
+                    }
+                }
+                for (int index = 0; index < usedIndices.length; index++) {
+                    int numberOfUse = usedIndices[index];
+                    if (numberOfUse == 0) {
+                        errors.add(new Exception("@Parameter(" + index + ") is never used."));
+                    } else if (numberOfUse > 1) {
+                        errors.add(new Exception("@Parameter(" + index + ") is used more than once (" + numberOfUse + ")."));
+                    }
+                }
+            }
+        }
+    }
+
+    private Iterable<Object[]> allParameters() throws Throwable {
+        Object parameters = getParametersMethod().invokeExplosively(null);
+        if (parameters instanceof Iterable) {
+            // verification if it's arrays of arrays or just single value array; if so need to wrap
+            Iterator iter = ((Iterable) parameters).iterator();
+            if (iter.hasNext()) {
+                if (!(iter.next() instanceof Object[])) { // it's single value
+                    List<Object[]> multiValue = new ArrayList<>();
+                    for (Object parameter: (Iterable<? extends Object>) parameters) {
+                        multiValue.add(new Object[]{parameter});
+                    }
+                    return multiValue;
+                }
+            }
+            return (Iterable<Object[]>) parameters;
+        } else {
+            throw parametersMethodReturnedWrongType();
+        }
+    }
+
+    private FrameworkMethod getParametersMethod() throws Exception {
+        List<FrameworkMethod> methods = getTestClass().getAnnotatedMethods(
+                Parameterized.Parameters.class);
+        for (FrameworkMethod each : methods) {
+            if (each.isStatic() && each.isPublic()) {
+                return each;
+            }
+        }
+
+        throw new Exception("No public static parameters method on class "
+                + getTestClass().getName());
+    }
+
+    private void createRunnersForParameters(Iterable<Object[]> allParameters,
+                                            String namePattern) throws InitializationError, Exception {
+        try {
+            int i = 0;
+            for (Object[] parametersOfSingleTest : allParameters) {
+                String name = nameFor(namePattern, i, parametersOfSingleTest);
+                TestClassEnricher enrichedArquillianRunner = new TestClassEnricher(
+                        getTestClass().getJavaClass(), parametersOfSingleTest,
+                        name);
+                arquillians.add(enrichedArquillianRunner);
+                ++i;
+            }
+        } catch (ClassCastException e) {
+            throw parametersMethodReturnedWrongType();
+        }
+    }
+
+    private String nameFor(String namePattern, int index, Object[] parameters) {
+        String finalPattern = namePattern.replaceAll("\\{index\\}",
+                Integer.toString(index));
+        String name = MessageFormat.format(finalPattern, parameters);
+        return "[" + name + "]";
+    }
+
+    private Exception parametersMethodReturnedWrongType() throws Exception {
+        String className = getTestClass().getName();
+        String methodName = getParametersMethod().getName();
+        String message = MessageFormat.format(
+                "{0}.{1}() must return an Iterable of arrays.",
+                className, methodName);
+        return new Exception(message);
+    }
+
+    private List<FrameworkField> getAnnotatedFieldsByParameter() {
+        return getTestClass().getAnnotatedFields(Parameterized.Parameter.class);
+    }
+
+    private boolean fieldsAreAnnotated() {
+        return !getAnnotatedFieldsByParameter().isEmpty();
+    }
+}

--- a/rts/lra/test/basic/pom.xml
+++ b/rts/lra/test/basic/pom.xml
@@ -51,6 +51,21 @@
       <version>${version.org.codehaus.jettison}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${version.org.jboss.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-json-binding-provider</artifactId>
+      <version>${version.org.jboss.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/api/CoordinatorApiIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/api/CoordinatorApiIT.java
@@ -1,0 +1,882 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.api;
+
+import io.narayana.lra.LRAConstants;
+import io.narayana.lra.LRAData;
+import io.narayana.lra.arquillian.ArquillianParametrized;
+import io.narayana.lra.arquillian.Deployer;
+import io.narayana.lra.client.NarayanaLRAClient;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.hamcrest.core.IsNot.not;
+
+/**
+ * <p>
+ * REST API tests for Narayana LRA Coordinator.<br/>
+ * Each test case corresponds by name with the method in the {@link io.narayana.lra.coordinator.api.Coordinator}.
+ * The test case verifies the expected API responses.
+ * It verifies the status code, the return data, data format, headers etc.
+ * </p>
+ * <p>
+ * The test may be annotated with {@link ValidTestVersions}.
+ * That way we can say the test will be executed only for the defined versions.
+ * The execution for a version not defined in the annotation is skipped.
+ *
+ * When a new API version is added - when the new version
+ * <ul>
+ *     <li>does <b>not</b> change the functionality of the API endpoint
+ *         then nothing is needed - the test will be executed with the new version as well</li>
+ *     <li>changes the functionality of the API endpoint
+ *         then the test needs to be limited for execution with preceding API versions
+ *         and the creation of a new test to document the new behaviour should be considered</li>
+ * </ul>
+ * </p>
+ */
+@RunWith(ArquillianParametrized.class)
+@RunAsClient
+public class CoordinatorApiIT {
+    private static final Logger log = Logger.getLogger(CoordinatorApiIT.class);
+
+    private Client client;
+    private NarayanaLRAClient lraClient;
+    private String coordinatorUrl;
+    private List<URI> lrasToAfterFinish;
+
+    // not reusing the LRAConstants as the API tests need to be independent to functionality code changes
+    static final String LRA_API_VERSION_HEADER_NAME = "Narayana-LRA-API-version";
+    static final String RECOVERY_HEADER_NAME = "Long-Running-Action-Recovery";
+    static final String STATUS_PARAM_NAME = "Status";
+    static final String CLIENT_ID_PARAM_NAME = "ClientID";
+    static final String TIME_LIMIT_PARAM_NAME = "TimeLimit";
+    static final String PARENT_LRA_PARAM_NAME = "ParentLRA";
+
+    @Parameterized.Parameters(name = "#{index}, version: {0}")
+    public static Iterable<?> parameters() {
+        return Arrays.asList(LRAConstants.NARAYANA_LRA_API_SUPPORTED_VERSIONS);
+    }
+
+    @Parameterized.Parameter
+    public String version;
+
+    @Rule
+    public ValidTestVersionsRule testRule = new ValidTestVersionsRule();
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(CoordinatorApiIT.class.getSimpleName());
+    }
+
+    @Before
+    public void before() {
+        log.info("Running test " + testRule.getMethodName());
+        client = ClientBuilder.newClient();
+        lraClient = new NarayanaLRAClient();
+        coordinatorUrl = lraClient.getCoordinatorUrl();
+        lrasToAfterFinish = new ArrayList<>();
+    }
+
+    @After
+    public void after() {
+        for (URI lraToFinish: lrasToAfterFinish) {
+            lraClient.cancelLRA(lraToFinish);
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    /**
+     * GET - /
+     * To gets all active LRAs.
+     */
+    @Test
+    public void getAllLRAs() {
+        // be aware of risk of non monotonic java time, ie. https://www.javaadvent.com/2019/12/measuring-time-from-java-to-kernel-and-back.html
+        long beforeTime = Instant.now().toEpochMilli();
+
+        String clientId1 = testRule.getMethodName() + "_OK_1";
+        String clientId2 = testRule.getMethodName() + "_OK_2";
+        URI lraId1 = lraClient.startLRA(clientId1);
+        URI lraId2 = lraClient.startLRA(lraId1, clientId2, 0L, null);
+        lrasToAfterFinish.add(lraId1); // lraId2 is nested and will be closed in regards to lraId1
+
+        List<LRAData> data;
+        try (Response response = client.target(coordinatorUrl)
+                .request().header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("Expected that the call succeeds, GET/200.", Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Provided API header, expected that one is returned",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            data = response.readEntity(new GenericType<List<LRAData>>() {});
+        }
+
+        Optional<LRAData> lraTopOptional = data.stream().filter(record -> record.getLraId().equals(lraId1)).findFirst();
+        Assert.assertTrue("Expected to find the top-level LRA id " + lraId1 + " from REST get all call", lraTopOptional.isPresent());
+        LRAData lraTop = lraTopOptional.get();
+        Optional<LRAData> lraNestedOptional = data.stream().filter(record -> record.getLraId().equals(lraId2)).findFirst();
+        Assert.assertTrue("Expected to find the nested LRA id " + lraId2 + " from REST get all call", lraNestedOptional.isPresent());
+        LRAData lraNested = lraNestedOptional.get();
+
+        Assert.assertEquals("Expected top-level LRA '" + lraTop + "'  being active",
+                LRAStatus.Active, lraTop.getStatus());
+        Assert.assertEquals("Expected top-level LRA '" + lraTop + "'  being active, HTTP status 204.",
+                Status.NO_CONTENT.getStatusCode(), lraTop.getHttpStatus());
+        Assert.assertFalse("Expected top-level LRA '" + lraTop + "' not being recovering", lraTop.isRecovering());
+        Assert.assertTrue("Expected top-level LRA '" + lraTop + "' to be top level", lraTop.isTopLevel());
+        MatcherAssert.assertThat("Expected the start time of top-level LRA '" + lraTop + "' is after the test start time",
+                beforeTime, lessThan(lraTop.getStartTime()));
+
+        Assert.assertEquals("Expected nested LRA '" + lraNested + "'  being active",
+                LRAStatus.Active, lraNested.getStatus());
+        Assert.assertEquals("Expected nested LRA '" + lraNested + "'  being active, HTTP status 204.",
+                Status.NO_CONTENT.getStatusCode(), lraNested.getHttpStatus());
+        Assert.assertFalse("Expected nested LRA '" + lraNested + "' not being recovering", lraNested.isRecovering());
+        Assert.assertFalse("Expected nested LRA '" + lraNested + "' to be nested", lraNested.isTopLevel());
+        MatcherAssert.assertThat("Expected the start time of nested LRA '" + lraNested + "' is after the test start time",
+                beforeTime, lessThan(lraNested.getStartTime()));
+    }
+
+    /**
+     * GET - /?Status=Active
+     * To gets active LRAs with status.
+     */
+    @Test
+    public void getAllLRAsStatusFilter() {
+        String clientId1 = testRule.getMethodName() + "_1";
+        String clientId2 = testRule.getMethodName() + "_2";
+        URI lraId1 = lraClient.startLRA(clientId1);
+        URI lraId2 = lraClient.startLRA(lraId1, clientId2, 0L, null);
+        lrasToAfterFinish.add(lraId1);
+        lraClient.closeLRA(lraId2);
+
+        try (Response response = client.target(coordinatorUrl).request()
+                .header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("Expected that the call succeeds, GET/200.", Status.OK.getStatusCode(), response.getStatus());
+            List<LRAData> data = response.readEntity(new GenericType<List<LRAData>>() {});
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            Collection<URI> returnedLraIds = data.stream().map(LRAData::getLraId).collect(Collectors.toList());
+            MatcherAssert.assertThat("Expected the coordinator returns the first started and second closed LRA",
+                    returnedLraIds, hasItems(lraId1, lraId2));
+        }
+        try (Response response = client.target(coordinatorUrl)
+                .queryParam(STATUS_PARAM_NAME, "Active").request().get()) {
+            Assert.assertEquals("Expected that the call succeeds, GET/200.", Status.OK.getStatusCode(), response.getStatus());
+            List<LRAData> data = response.readEntity(new GenericType<List<LRAData>>() {});
+            Collection<URI> returnedLraIds = data.stream().map(LRAData::getLraId).collect(Collectors.toList());
+            MatcherAssert.assertThat("Expected the coordinator returns the first started top-level LRA",
+                    returnedLraIds, hasItem(lraId1));
+            MatcherAssert.assertThat("Expected the coordinator filtered out the non-active nested LRA",
+                    returnedLraIds, not(hasItem(lraId2)));
+        }
+    }
+
+    /**
+     * GET - /?Status=NonExistingStatus
+     * Asking for LRAs with status while providing a wrong status.
+     */
+    @Test
+    public void getAllLRAsFailedStatus() {
+        String nonExistingStatusValue = "NotExistingStatusValue";
+        try (Response response = client.target(coordinatorUrl)
+                .queryParam(STATUS_PARAM_NAME, nonExistingStatusValue).request()
+                .header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("Expected that the call fails on wrong status, GET/500.",
+                    Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            MatcherAssert.assertThat("Expected the failure to contain the wrong status value",
+                    response.readEntity(String.class), containsString(nonExistingStatusValue));
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+        }
+    }
+
+    /**
+     * GET - /{lraId}/status
+     * Finding a status of a started LRA.
+     */
+    @Test
+    public void getLRAStatus() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl).path(encodedLraId).path("status")
+                .request().header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("Expected that the get status call succeeds, GET/200.", Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            Assert.assertEquals("Expected the returned LRA status is Active",
+                    "Active", response.readEntity(String.class));
+        }
+    }
+
+    /**
+     * GET - /{lraId}/status
+     * Finding a status of a non existing LRA or wrong LRA id.
+     */
+    @Test
+    public void getLRAStatusFailed() {
+        String nonExistingLRAUrl = "http://localhost:1234/Non-Existing-LRA-id";
+        try (Response response = client.target(coordinatorUrl).path(nonExistingLRAUrl).path("status")
+                .request().header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("URL " + nonExistingLRAUrl + " was expected not being found, GET/404.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected the failure message to contain the wrong LRA id",
+                    response.readEntity(String.class), containsString(nonExistingLRAUrl));
+        }
+
+        String nonExistingLRAWrongUrlFormat = "Non-Existing-LRA-id";
+        try (Response response = client.target(coordinatorUrl).path(nonExistingLRAWrongUrlFormat).path("status").request().get()) {
+            Assert.assertEquals("LRA id " + nonExistingLRAWrongUrlFormat + " was expected not being found , GET/404.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            MatcherAssert.assertThat("Expected the failure message to contain the wrong LRA id",
+                    response.readEntity(String.class), containsString(lraClient.getCoordinatorUrl() + "/" + nonExistingLRAWrongUrlFormat));
+        }
+    }
+
+    /**
+     * GET - /{lraId}
+     * Obtaining info of a started LRA.
+     */
+    @Test
+    public void getLRAInfo() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl).path(encodedLraId)
+                .request().header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("Expected that the get status call succeeds, GET/200.", Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            LRAData data = response.readEntity(new GenericType<LRAData>() {});
+            Assert.assertEquals("Expected the returned LRA to be the one that was started by test", lraId, data.getLraId());
+            Assert.assertEquals("Expected the returned LRA being Active", LRAStatus.Active, data.getStatus());
+            Assert.assertTrue("Expected the returned LRA is top-level", data.isTopLevel());
+            Assert.assertEquals("Expected the returned LRA get HTTP status as active, HTTP status 204.",
+                    Status.NO_CONTENT.getStatusCode(), data.getHttpStatus());
+        }
+    }
+
+    /**
+     * GET - /{lraId}
+     * Obtaining info of a non-existing LRA.
+     */
+    @Test
+    public void getLRAInfoNotExisting() {
+        String nonExistingLRA = "Non-Existing-LRA-id";
+        try (Response response = client.target(coordinatorUrl).path(nonExistingLRA).request()
+                .header(LRA_API_VERSION_HEADER_NAME, version).get()) {
+            Assert.assertEquals("Expected that the call fails on LRA not found, GET/404.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected the failure message to contain the wrong LRA id",
+                    response.readEntity(String.class), containsString(nonExistingLRA));
+        }
+    }
+
+    /**
+     * POST - /start?TimeLimit=...&ClientID=...&ParentLRA=...
+     * PUT - /{lraId}/close
+     * Starting and closing an LRA.
+     */
+    @Test
+    public void startCloseLRA() throws UnsupportedEncodingException {
+        URI lraId1, lraId2;
+
+        try (Response response = client.target(coordinatorUrl)
+                .path("start")
+                .queryParam(CLIENT_ID_PARAM_NAME, testRule.getMethodName() + "_1")
+                .queryParam(TIME_LIMIT_PARAM_NAME, "-42") // negative time limit is permitted by spec
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .post(null)) {
+            Assert.assertEquals("Creating top-level LRA should be successful, POST/201 is expected.",
+                    Status.CREATED.getStatusCode(), response.getStatus());
+            lraId1 = URI.create(response.readEntity(String.class));
+            Assert.assertNotNull("Expected non null LRA id to be returned from start call", lraId1);
+            lrasToAfterFinish.add(lraId1);
+
+            URI lraIdFromLocationHeader = URI.create(response.getHeaderString(HttpHeaders.LOCATION));
+            Assert.assertEquals("Expected the LOCATION header containing the started top-level LRA id",
+                    lraId1, lraIdFromLocationHeader);
+            // context header is returned strangely to client, some investigation will be needed
+            // URI lraIdFromLRAContextHeader = URI.create(response.getHeaderString(LRA.LRA_HTTP_CONTEXT_HEADER));
+            // Assert.assertEquals("Expecting the LRA context header configures the same LRA id as entity content on starting top-level LRA",
+            //        lraId1, lraIdFromLRAContextHeader);
+            Assert.assertEquals("Expecting to get the same API version as used for the request on top-level LRA start",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+        }
+
+        String encodedLraId1 = URLEncoder.encode(lraId1.toString(), StandardCharsets.UTF_8.name());
+        try(Response response = client.target(coordinatorUrl)
+                .path("start")
+                .queryParam(CLIENT_ID_PARAM_NAME, testRule.getMethodName() + "_2")
+                .queryParam(PARENT_LRA_PARAM_NAME, encodedLraId1)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .post(null)) {
+            Assert.assertEquals("Creating nested LRA should be successful, POST/201 is expected.",
+                    Status.CREATED.getStatusCode(), response.getStatus());
+            lraId2 = URI.create(response.readEntity(String.class));
+            Assert.assertNotNull("Expected non null nested LRA id being returned in the response body", lraId2);
+
+            // the nested LRA id is in format <nested LRA id>?ParentLRA=<parent LRA id>
+            URI lraIdFromLocationHeader = URI.create(response.getHeaderString(HttpHeaders.LOCATION));
+            Assert.assertEquals("Expected the LOCATION header containing the started nested LRA id",
+                    lraId2, lraIdFromLocationHeader);
+            // context header is returned strangely to client, some investigation will be needed
+            // String lraContextHeader = response.getHeaderString(LRA.LRA_HTTP_CONTEXT_HEADER);
+            // the context header is in format <parent LRA id>,<nested LRA id>?ParentLRA=<parent LRA id>
+            // MatcherAssert.assertThat("Expected the nested LRA context header gives the parent LRA id at first",
+            //        lraContextHeader, startsWith(lraId1.toASCIIString()));
+            // MatcherAssert.assertThat("Expected the nested LRA context header provides LRA id of started nested LRA",
+            //        lraContextHeader, containsString("," + lraId2.toASCIIString()));
+            Assert.assertEquals("Expecting to get the same API version as used for the request on nested LRA start",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+        }
+
+        Collection<URI> returnedLraIds = lraClient.getAllLRAs().stream().map(LRAData::getLraId).collect(Collectors.toList());
+        MatcherAssert.assertThat("Expected the coordinator knows about the top-level LRA", returnedLraIds, hasItem(lraId1));
+        MatcherAssert.assertThat("Expected the coordinator knows about the nested LRA", returnedLraIds, hasItem(lraId2));
+
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId1 + "/close")
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(null)) {
+            lrasToAfterFinish.clear(); // we've closed the LRA manually here, skipping the @After
+            Assert.assertEquals("Closing top-level LRA should be successful, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Closing top-level LRA should return the right status.",
+                    LRAStatus.Closed.name(), response.readEntity(String.class));
+            Assert.assertEquals("Expecting to get the same API version as used for the request to close top-level LRA",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+        }
+
+        Collection<LRAData> activeLRAsAfterClosing = lraClient.getAllLRAs().stream()
+                .filter(data -> data.getLraId().equals(lraId1) || data.getLraId().equals(lraId2))
+                .filter(data -> data.getStatus() != LRAStatus.Closing && data.getStatus() != LRAStatus.Closed)
+                .collect(Collectors.toList());
+        MatcherAssert.assertThat("Expecting the started LRAs are no more active after closing the top-level one",
+                activeLRAsAfterClosing, emptyCollectionOf(LRAData.class));
+    }
+
+    /**
+     * POST - /start?ClientID=...
+     * PUT - /{lraId}/cancel
+     * Starting and canceling an LRA.
+     */
+    @Test
+    public void startCancelLRA() throws UnsupportedEncodingException {
+        URI lraId;
+        try (Response response = client.target(coordinatorUrl)
+                .path("start")
+                .queryParam(CLIENT_ID_PARAM_NAME, testRule.getMethodName())
+                .request()
+                .post(null)) {
+            Assert.assertEquals("Creating top-level LRA should be successful, POST/201 is expected.",
+                    Status.CREATED.getStatusCode(), response.getStatus());
+            lraId = URI.create(response.readEntity(String.class));
+            Assert.assertNotNull("Expected non null LRA id to be returned from start call", lraId);
+            lrasToAfterFinish.add(lraId);
+            Assert.assertTrue("API version header is expected on response despite no API version header was provided on request",
+                    response.getHeaders().containsKey(LRA_API_VERSION_HEADER_NAME));
+        }
+
+        Collection<URI> returnedLraIds = lraClient.getAllLRAs().stream().map(LRAData::getLraId).collect(Collectors.toList());
+        MatcherAssert.assertThat("Expected the coordinator knows about the LRA", returnedLraIds, hasItem(lraId));
+        try (Response response = client.target(coordinatorUrl)
+                .path(URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name()) + "/cancel")
+                .request()
+                .put(null)) {
+            lrasToAfterFinish.clear(); // we've closed the LRA manually just now, skipping the @After
+            Assert.assertEquals("Closing LRA should be successful, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Canceling top-level LRA should return the right status.",
+                    LRAStatus.Cancelled.name(), response.readEntity(String.class));
+            Assert.assertTrue("API version header is expected on response despite no API header parameter was provided on request",
+                    response.getHeaders().containsKey(LRA_API_VERSION_HEADER_NAME));
+        }
+
+        Collection<LRAData> activeLRAsAfterClosing = lraClient.getAllLRAs().stream()
+                .filter(data -> data.getLraId().equals(lraId)).collect(Collectors.toList());
+        MatcherAssert.assertThat("Expecting the started LRA is no more active after closing it",
+                activeLRAsAfterClosing, emptyCollectionOf(LRAData.class));
+    }
+
+    /**
+     * POST - /start?ClientId=...&ParentLRA=...
+     * Starting a nested LRA with a non-existing parent.
+     */
+    @Test
+    public void startLRANotExistingParentLRA() {
+        String notExistingParentLRA = "not-existing-parent-lra-id";
+        try (Response response = client.target(coordinatorUrl)
+                .path("start")
+                .queryParam(CLIENT_ID_PARAM_NAME, testRule.getMethodName())
+                .queryParam(PARENT_LRA_PARAM_NAME, notExistingParentLRA)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .post(null)) {
+            Assert.assertEquals("Expected failure on non-existing parent LRA, POST/404 is expected.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            String errorMsg = response.readEntity(String.class);
+            MatcherAssert.assertThat("Expected error message to contain the not found parent LRA id",
+                    errorMsg, containsString(notExistingParentLRA));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}/close
+     * Closing a non-existing LRA.
+     */
+    @Test
+    public void closeNotExistingLRA() {
+        String notExistingLRAid = "not-existing-lra-id";
+        try (Response response = client.target(coordinatorUrl)
+                .path(notExistingLRAid)
+                .path("close")
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(null)) {
+            Assert.assertEquals("Expected failure on non-existing LRA id, PUT/404 is expected.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            String errorMsg = response.readEntity(String.class);
+            MatcherAssert.assertThat("Expected error message to contain the not found LRA id",
+                    errorMsg, containsString(notExistingLRAid));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}/cancel
+     * Canceling a non-existing LRA.
+     */
+    @Test
+    public void cancelNotExistingLRA() {
+        String notExistingLRAid = "not-existing-lra-id";
+        try (Response response = client.target(coordinatorUrl)
+                .path(notExistingLRAid)
+                .path("cancel")
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(null)) {
+            Assert.assertEquals("Expected failure on non-existing LRA id, PUT/404 is expected.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            String errorMsg = response.readEntity(String.class);
+            MatcherAssert.assertThat("Expected error message to contain the not found LRA id",
+                    errorMsg, containsString(notExistingLRAid));
+        }
+    }
+
+    /**
+     * PUT - /renew?TimeLimit=
+     * Renewing the time limit of the started LRA.
+     */
+    @Test
+    public void renewTimeLimit() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        Optional<LRAData> data = lraClient.getAllLRAs().stream().filter(l -> l.getLraId().equals(lraId)).findFirst();
+        Assert.assertTrue("Expected the started LRA will be retrieved by LRA client get", data.isPresent());
+        Assert.assertEquals("Expected not defined finish time", 0L, data.get().getFinishTime());
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .path("renew")
+                .queryParam(TIME_LIMIT_PARAM_NAME, Integer.MAX_VALUE)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(null)) {
+            Assert.assertEquals("Expected time limit request to succeed, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected the found LRA id is returned",
+                    response.readEntity(String.class), containsString(lraId.toString()));
+        }
+
+        data = lraClient.getAllLRAs().stream().filter(l -> l.getLraId().equals(lraId)).findFirst();
+        Assert.assertTrue("Expected the started LRA will be retrieved by LRA client get", data.isPresent());
+        MatcherAssert.assertThat("Expected finish time to not be 0 as time limit was defined",
+                data.get().getFinishTime(), greaterThan(0L));
+    }
+
+    /**
+     * PUT - /renew?TimeLimit=
+     * Renewing the time limit of a non-existing LRA.
+     */
+    @Test
+    public void renewTimeLimitNotExistingLRA() {
+        String notExistingLRAid = "not-existing-lra-id";
+        try (Response response = client.target(coordinatorUrl)
+                .path(notExistingLRAid)
+                .path("renew")
+                .queryParam(TIME_LIMIT_PARAM_NAME, Integer.MAX_VALUE)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(null)) {
+            Assert.assertEquals("Expected time limit request to fail for non existing LRA id, PUT/404",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            String errorMsg = response.readEntity(String.class);
+            MatcherAssert.assertThat("Expected error message to contain the not found LRA id",
+                    errorMsg, containsString(notExistingLRAid));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via entity body.
+     */
+    @Test
+    public void joinLRAWithBody() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(Entity.text("http://compensator.url:8080"))) {
+            Assert.assertEquals("Expected joining LRA succeeded, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            String recoveryHeaderUrlMessage = response.getHeaderString(RECOVERY_HEADER_NAME);
+            String recoveryUrlBody = response.readEntity(String.class);
+            URI recoveryUrlLocation = response.getLocation();
+            Assert.assertEquals("Expecting returned body and recovery header have got the same content",
+                    recoveryUrlBody, recoveryHeaderUrlMessage);
+            Assert.assertEquals("Expecting returned body and location have got the same content",
+                    recoveryUrlBody, recoveryUrlLocation.toString());
+            MatcherAssert.assertThat("Expected returned message contains the subpath of LRA recovery URL",
+                    recoveryUrlBody, containsString("lra-coordinator/recovery"));
+            MatcherAssert.assertThat("Expected returned message contains the LRA id",
+                    recoveryUrlBody, containsString(encodedLraId));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via link header.
+     */
+    @Test
+    public void joinLRAWithLinkSimple() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .header("Link", "http://compensator.url:8080")
+                .put(null)) {
+            Assert.assertEquals("Expected joining LRA succeeded, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            String recoveryHeaderUrlMessage = response.getHeaderString(RECOVERY_HEADER_NAME);
+            String recoveryUrlBody = response.readEntity(String.class);
+            URI recoveryUrlLocation = response.getLocation();
+            Assert.assertEquals("Expecting returned body and recovery header have got the same content",
+                    recoveryUrlBody, recoveryHeaderUrlMessage);
+            Assert.assertEquals("Expecting returned body and location have got the same content",
+                    recoveryUrlBody, recoveryUrlLocation.toString());
+            MatcherAssert.assertThat("Expected returned message contains the subpath of LRA recovery URL",
+                    recoveryUrlBody, containsString("lra-coordinator/recovery"));
+            MatcherAssert.assertThat("Expected returned message contains the LRA id",
+                    recoveryUrlBody, containsString(encodedLraId));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via link header with link rel specified.
+     */
+    @Test
+    public void joinLRAWithLinkCompensate() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        Link link = Link.fromUri("http://compensate.url:8080").rel("compensate").build();
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header("Link", link.toString())
+                .put(null)) {
+            Assert.assertEquals("Expected joining LRA succeeded, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertTrue("API version header is expected on response despite no API version header was provided on request",
+                    response.getHeaders().containsKey(LRA_API_VERSION_HEADER_NAME));
+            String recoveryHeaderUrlMessage = response.getHeaderString(RECOVERY_HEADER_NAME);
+            String recoveryUrlBody = response.readEntity(String.class);
+            Assert.assertEquals("Expecting returned body and recovery header have got the same content",
+                    recoveryUrlBody, recoveryHeaderUrlMessage);
+            MatcherAssert.assertThat("Expected returned message contains the subpath of LRA recovery URL",
+                    recoveryUrlBody, containsString("lra-coordinator/recovery"));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via link header with link after specified.
+     */
+    @Test
+    public void joinLRAWithLinkAfter() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        Link afterLink = Link.fromUri("http://after.url:8080").rel("after").build();
+        Link unknownLink = Link.fromUri("http://unknow.url:8080").rel("uknown").build();
+        String linkList = afterLink.toString() + "," + unknownLink.toString();
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header("Link", linkList)
+                .put(null)) {
+            Assert.assertEquals("Expected joining LRA succeeded, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            String recoveryHeaderUrlMessage = response.getHeaderString(RECOVERY_HEADER_NAME);
+            String recoveryUrlBody = response.readEntity(String.class);
+            Assert.assertEquals("Expecting returned body and recovery header have got the same content",
+                    recoveryUrlBody, recoveryHeaderUrlMessage);
+            MatcherAssert.assertThat("Expected returned message contains the subpath of LRA recovery URL",
+                    URLDecoder.decode(recoveryUrlBody, StandardCharsets.UTF_8.name()), containsString("lra-coordinator/recovery"));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via link header with wrong link format.
+     */
+    @Test
+    public void joinLRAIncorrectLinkFormat() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header("Link", "<link>;rel=myrel;<wrong>")
+                .put(null)) {
+            Assert.assertEquals("Expected the join failing, PUT/500 is expected.",
+                    Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining a non-existing LRA.
+     */
+    @Test
+    public void joinLRAUnknownLRA() {
+        String notExistingLRAid = "not-existing-lra-id";
+        try (Response response = client.target(coordinatorUrl)
+                .path(notExistingLRAid)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(Entity.text("http://localhost:8080"))) {
+            Assert.assertEquals("Expected the join failing on unknown LRA id, PUT/404 is expected.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected error message to contain the LRA id where enlist failed",
+                    response.readEntity(String.class), containsString(notExistingLRAid));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via entity body of a wrong format.
+     */
+    @Test
+    public void joinLRAWrongCompensatorData() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(Entity.text("this-is-not-an-url::::"))) {
+            Assert.assertEquals("Expected the join failing on wrong compensator data format, PUT/412 is expected.",
+                    Status.PRECONDITION_FAILED.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected error message to contain the LRA id where enlist failed",
+                    response.readEntity(String.class), containsString(lraId.toString()));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}
+     * Joining an LRA participant via link header missing required rel items.
+     */
+    @Test
+    public void joinLRAWithLinkNotEnoughData() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+
+        String encodedLraId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        Link link = Link.fromUri("http://complete.url:8080").rel("complete").build();
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLraId)
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .header("Link", link.toString())
+                .put(null)) {
+            Assert.assertEquals("Expected the joining fails as no compensate in link, PUT/400 is expected.",
+                    Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            String errorMsg = response.readEntity(String.class);
+            MatcherAssert.assertThat("Expected error message to contain the LRA id where enlist failed",
+                    errorMsg, containsString(lraId.toString()));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}/remove
+     * Leaving an LRA as participant.
+     */
+    @Test
+    public void leaveLRA() throws UnsupportedEncodingException {
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+        URI recoveryUri = lraClient.joinLRA(lraId, 0L, URI.create("http://localhost:8080"), "");
+
+        String encodedLRAId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLRAId)
+                .path("remove")
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(Entity.text(recoveryUri.toString()))) {
+            Assert.assertEquals("Expected leaving the LRA to succeed, PUT/200 is expected.",
+                    Status.OK.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            Assert.assertFalse("Expecting 'remove' API call returns no entity body", response.hasEntity());
+        }
+
+        try (Response response = client.target(coordinatorUrl)
+                .path(encodedLRAId)
+                .path("remove")
+                .request()
+                .header(LRA_API_VERSION_HEADER_NAME, version)
+                .put(Entity.text(recoveryUri.toString()))) {
+            Assert.assertEquals("Expected leaving the LRA to fail as it was removed just before, PUT/400 is expected.",
+                    Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            MatcherAssert.assertThat("Expected the failure message to contain the non existing participant id",
+                    response.readEntity(String.class), containsString(recoveryUri.toASCIIString()));
+        }
+    }
+
+    /**
+     * PUT - /{lraId}/remove
+     * Leaving a non-existing LRA as participant.
+     */
+    @Test
+    public void leaveLRANonExistingFailure() throws UnsupportedEncodingException {
+        String nonExistingLRAId = "http://localhost:1234/Non-Existing-LRA-id";
+        String encodedNonExistingLRAId = URLEncoder.encode(nonExistingLRAId, StandardCharsets.UTF_8.name());
+        try (Response response = client.target(coordinatorUrl).path(encodedNonExistingLRAId).path("remove").request()
+                .header(LRA_API_VERSION_HEADER_NAME, version).put(Entity.text("nothing"))) {
+            Assert.assertEquals("Expected that the call finds not found of " + encodedNonExistingLRAId + ", PUT/404.",
+                    Status.NOT_FOUND.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected the failure message to contain the wrong LRA id",
+                    response.readEntity(String.class), containsString(nonExistingLRAId));
+        }
+
+        URI lraId = lraClient.startLRA(testRule.getMethodName());
+        lrasToAfterFinish.add(lraId);
+        String encodedLRAId = URLEncoder.encode(lraId.toString(), StandardCharsets.UTF_8.name());
+        String nonExistingParticipantUrl = "http://localhost:1234/Non-Existing-participant-LRA";
+        try (Response response = client.target(coordinatorUrl).path(encodedLRAId).path("remove").request()
+                .header(LRA_API_VERSION_HEADER_NAME, version).put(Entity.text(nonExistingParticipantUrl))) {
+            Assert.assertEquals("Expected that the call fails on LRA participant " + nonExistingParticipantUrl + " not found , PUT/400.",
+                    Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            Assert.assertEquals("Expected API header to be returned with the version provided in request",
+                    version, response.getHeaderString(LRA_API_VERSION_HEADER_NAME));
+            MatcherAssert.assertThat("Expected the failure message to contain the wrong participant id",
+                    response.readEntity(String.class), containsString(nonExistingParticipantUrl));
+        }
+    }
+
+}

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/api/CoordinatorApiWrongVersionIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/api/CoordinatorApiWrongVersionIT.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.api;
+
+import io.narayana.lra.arquillian.Deployer;
+import io.narayana.lra.client.NarayanaLRAClient;
+import org.hamcrest.MatcherAssert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * This testcase verifies behaviour of API endpoints when an unsupported version is provided within
+ * the header {@link io.narayana.lra.LRAConstants#NARAYANA_LRA_API_VERSION_HEADER_NAME}
+ * (see supported versions at {@link io.narayana.lra.LRAConstants#NARAYANA_LRA_API_SUPPORTED_VERSIONS}).
+ *
+ * When client requests the unsupported version then is expected that
+ * the implementation responds with {@code 417} HTTP status code.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class CoordinatorApiWrongVersionIT {
+    private static final Logger log = Logger.getLogger(CoordinatorApiWrongVersionIT.class);
+
+    private Client client;
+    private String coordinatorUrl;
+
+    static final String NARAYANA_LRA_API_VERSION_HEADER = "Narayana-LRA-API-version";
+    static final String NOT_SUPPORTED_FUTURE_LRA_VERSION = Integer.MAX_VALUE + ".1";
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(CoordinatorApiWrongVersionIT.class.getSimpleName());
+    }
+
+    @Before
+    public void before() {
+        log.info("Running test " + testName.getMethodName());
+        client = ClientBuilder.newClient();
+        coordinatorUrl = new NarayanaLRAClient().getCoordinatorUrl();
+    }
+
+    @After
+    public void after() {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void getAllLRAsWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl)
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).get());
+    }
+
+    @Test
+    public void getLRAStatusWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("status")
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).get());
+    }
+
+    @Test
+    public void getLRAInfoWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("lra-id")
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).get());
+    }
+
+    @Test
+    public void startLRAWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("start")
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).post(null));
+    }
+
+    @Test
+    public void renewTimeLimitWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("lra-id").path("renew")
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).put(null));
+    }
+
+    @Test
+    public void closeLRAWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("lra-id").path("close")
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).put(null));
+    }
+
+    @Test
+    public void cancelLRAWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("lra-id").path("cancel")
+                .request().header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).put(null));
+    }
+
+    @Test
+    public void joinViaBodyWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("lra-id").request()
+                .header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).put(Entity.text("compensator-url")));
+    }
+
+    @Test
+    public void leaveLRAWrongVersion() {
+        verifyStatusCode(() -> client.target(coordinatorUrl).path("lra-id").path("remove").request()
+                .header(NARAYANA_LRA_API_VERSION_HEADER, NOT_SUPPORTED_FUTURE_LRA_VERSION).put(Entity.text("participant-url")));
+    }
+
+    private static void verifyStatusCode(Supplier<Response> responseSupplier) {
+        try (Response response = responseSupplier.get()) {
+            Assert.assertEquals("Expected different error code when used unsupported version at Coordinator REST API endpoint",
+                    Status.EXPECTATION_FAILED.getStatusCode(), response.getStatus());
+            MatcherAssert.assertThat("Expected the response to contain error message with the unsupported version included",
+                    response.readEntity(String.class), containsString(NOT_SUPPORTED_FUTURE_LRA_VERSION));
+        }
+    }
+}

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/api/ValidTestVersions.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/api/ValidTestVersions.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotations used within JUnit rule {@link ValidTestVersionsRule}.
+ *
+ * The annotation is used to limit the test method execution for particular API version values.
+ *
+ * The {@link ValidTestVersionsRule} verifies what is content of the {@code version} field in test class
+ * and then checks if {@code version} matches to values in the annotation.
+ * When it matches the test method is executed, if it does not match then the test method is skipped.
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface ValidTestVersions {
+    String[] value();
+}

--- a/rts/lra/test/basic/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/rts/lra/test/basic/src/test/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3294

I'm publishing this withouth having finished similar work which I would like to do with `RecoveryCoordinator`. I hope for `Coordinator` this is acceptable to be discussed and hopefully merged.

!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
LRA

/cc @xstefank 