### PR TITLE
BLACKTIE: NoSuchMethodError: org.apache.tools.ant.launch.Locator.fromJarURI

### DIFF
--- a/blacktie/utils/cpp-plugin/pom.xml
+++ b/blacktie/utils/cpp-plugin/pom.xml
@@ -105,6 +105,11 @@
             <version>[1.10.9,)</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant-launcher</artifactId>
+            <version>1.8.2</version>
+        </dependency>
+        <dependency>
             <groupId>ant-contrib</groupId>
             <artifactId>cpptasks</artifactId>
             <version>1.0b5</version>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3423

BLACKTIE: NoSuchMethodError: org.apache.tools.ant.launch.Locator.fromJarURI(Ljava/lang/String; while generating IDL sources RTS: InboundBridgeRecoveryTestCase.testCrashBeforeCommit:137 Recovery failed


!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

BLACKTIE