### PR TITLE
Downgrade MP LRA to 1.0-RC2

### DIFF
--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -25,8 +25,8 @@
         <version.servlet-api>2.5</version.servlet-api>
         <version.jboss-modules>1.10.2.Final</version.jboss-modules>
 
-        <version.microprofile.lra.api>1.0</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0</version.microprofile.lra.tck>
+        <version.microprofile.lra.api>1.0-RC2</version.microprofile.lra.api>
+        <version.microprofile.lra.tck>1.0-RC2</version.microprofile.lra.tck>
         <version.microprofile.fault-tolerance>2.1.1</version.microprofile.fault-tolerance>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>
@@ -46,10 +46,6 @@
     </properties>
 
     <repositories>
-        <repository>
-            <id>lra-1.0-staging</id>
-            <url>https://oss.sonatype.org/content/repositories/orgeclipsemicroprofile-1423/</url>
-        </repository>
         <repository>
             <id>jboss-public-releases-repository-group</id>
             <name>JBoss Public Releases Maven Repository Group</name>


### PR DESCRIPTION
!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

Downgrade MP LRA to 1.0-RC2 for the CCR. This also removes the hardcoded staging repository of MP LRA 1.0. Please let me know whether a JBTM is needed for this change.