### PR TITLE
JBTM-3435 Disable JacORB logging

### DIFF
--- a/ArjunaJTS/jacorb/etc/jacorb.properties
+++ b/ArjunaJTS/jacorb/etc/jacorb.properties
@@ -78,7 +78,7 @@ jacorb.orb.print_version=on
 # 2 = warnings (WARNING)
 # 3 = informational messages (INFO)
 # 4 = debug-level output (FINE)
-jacorb.log.default.verbosity=4
+jacorb.log.default.verbosity=1
 
 # where does output go? Terminal is default
 #jacorb.logfile=LOGFILEPATH
@@ -628,7 +628,7 @@ jacorb.poa.monitoring=off
 # 2 = important messages (WARN)
 # 3 = informational messages and exceptions (INFO)
 # 4 = debug-level output (DEBUG) (may confuse the unaware user :-)
-jacorb.poa.log.verbosity=3
+jacorb.poa.log.verbosity=1
 
 # thread pool configuration for request processing
 jacorb.poa.thread_pool_max=20
@@ -696,7 +696,7 @@ jacorb.poa.queue_min=10
 # 3 = informational messages and exceptions (INFO)
 # 4 = debug-level output (DEBUG) (may confuse the unaware user :-)
 
-jacorb.naming.log.verbosity=3
+jacorb.naming.log.verbosity=1
 
 #
 # name of the logger factory. Implement your own subclass of
@@ -759,7 +759,7 @@ jacorb.notification.stop_time_supported = on
 jacorb.notification.proxy.destroy_causes_disconnect = on
 
 # Notification Service log levels:
-org.jacorb.notification.log.verbosity = 3
+org.jacorb.notification.log.verbosity = 1
 
 ########################################
 #                                      #

--- a/ArjunaJTS/jacorb/etc/jacorb_properties.template
+++ b/ArjunaJTS/jacorb/etc/jacorb_properties.template
@@ -78,7 +78,7 @@ jacorb.orb.print_version=on
 # 2 = warnings (WARNING)
 # 3 = informational messages (INFO)
 # 4 = debug-level output (FINE)
-#jacorb.log.default.verbosity=3
+#jacorb.log.default.verbosity=1
 
 # Where does output go? Terminal is default. If the filename includes
 # "$implname", that is replaced with the value of jacorb.implname, if
@@ -635,7 +635,7 @@ jacorb.poa.monitoring=off
 # 2 = important messages (WARN)
 # 3 = informational messages and exceptions (INFO)
 # 4 = debug-level output (DEBUG) (may confuse the unaware user :-)
-jacorb.poa.log.verbosity=3
+jacorb.poa.log.verbosity=1
 
 # thread pool configuration for request processing
 jacorb.poa.thread_pool_max=20
@@ -703,7 +703,7 @@ jacorb.poa.queue_min=10
 # 3 = informational messages and exceptions (INFO)
 # 4 = debug-level output (DEBUG) (may confuse the unaware user :-)
 
-jacorb.naming.log.verbosity=3
+jacorb.naming.log.verbosity=1
 
 #
 # name of the logger factory. Implement your own subclass of
@@ -766,7 +766,7 @@ jacorb.notification.stop_time_supported = on
 jacorb.notification.proxy.destroy_causes_disconnect = on
 
 # Notification Service log levels:
-org.jacorb.notification.log.verbosity = 3
+org.jacorb.notification.log.verbosity = 1
 
 ########################################
 #                                      #

--- a/ArjunaJTS/jacorb/etc/orb.properties
+++ b/ArjunaJTS/jacorb/etc/orb.properties
@@ -26,7 +26,7 @@ jacorb.config.dir=e:/JacORB_CONFIG_FEATURE
 #    0   : nothing is logged
 #    1,3 : only errors
 #    3,4 : info (which config files were loaded)
-jacorb.config.log.verbosity=3
+jacorb.config.log.verbosity=1
 
 ########################################
 #                                      #

--- a/ArjunaJTS/jtax/src/test/resources/jacorb.properties
+++ b/ArjunaJTS/jtax/src/test/resources/jacorb.properties
@@ -78,7 +78,7 @@ jacorb.orb.print_version=on
 # 2 = warnings (WARNING)
 # 3 = informational messages (INFO)
 # 4 = debug-level output (FINE)
-jacorb.log.default.verbosity=4
+jacorb.log.default.verbosity=1
 
 # where does output go? Terminal is default
 #jacorb.logfile=LOGFILEPATH
@@ -628,7 +628,7 @@ jacorb.poa.monitoring=off
 # 2 = important messages (WARN)
 # 3 = informational messages and exceptions (INFO)
 # 4 = debug-level output (DEBUG) (may confuse the unaware user :-)
-jacorb.poa.log.verbosity=3
+jacorb.poa.log.verbosity=1
 
 # thread pool configuration for request processing
 jacorb.poa.thread_pool_max=20
@@ -696,7 +696,7 @@ jacorb.poa.queue_min=10
 # 3 = informational messages and exceptions (INFO)
 # 4 = debug-level output (DEBUG) (may confuse the unaware user :-)
 
-jacorb.naming.log.verbosity=3
+jacorb.naming.log.verbosity=1
 
 #
 # name of the logger factory. Implement your own subclass of
@@ -759,7 +759,7 @@ jacorb.notification.stop_time_supported = on
 jacorb.notification.proxy.destroy_causes_disconnect = on
 
 # Notification Service log levels:
-org.jacorb.notification.log.verbosity = 3
+org.jacorb.notification.log.verbosity = 1
 
 ########################################
 #                                      #


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3435

!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS QA_JTA QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle

I've changed it to only log fatal errors (value 1). If we want to disable logging completely then the value would need to be 0.
