### PR TITLE
[JBTM-3443] exclude orson dependency from thorntail-coordinator to not generate error on build

### DIFF
--- a/rts/lra/coordinator-thorntail/pom.xml
+++ b/rts/lra/coordinator-thorntail/pom.xml
@@ -70,6 +70,12 @@
             <groupId>org.jboss.narayana.rts</groupId>
             <artifactId>lra-coordinator-jar</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>orson</groupId>
+                <artifactId>orson</artifactId>
+              </exclusion>
+            </exclusions> 
         </dependency>
         <dependency>
           <groupId>org.eclipse.microprofile.lra</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3443

superseding the PR: https://github.com/jbosstm/narayana/pull/1801

CORE WIN LRA
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF !RTS !AS_TESTS !TOMCAT !JACOCO
