### PR TITLE
[RELEASE] on release deploy to deploy lra-coordinator-quarkus-runner jar as well

### DIFF
--- a/rts/lra/coordinator-quarkus/pom.xml
+++ b/rts/lra/coordinator-quarkus/pom.xml
@@ -155,7 +155,9 @@
       <profile>
         <id>quarkus-uber</id>
         <activation>
-          <activeByDefault>true</activeByDefault>
+          <property>
+            <name>!no-quarkus-uber</name>
+          </property>
         </activation>
         <properties>
           <quarkus.package.type>uber-jar</quarkus.package.type>


### PR DESCRIPTION
MAIN
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO !LRA

When we do the release we use the `-Prelease` which activates the release profile. The maven behaviour for `<activeByDefault>true</activeByDefault>` is that `activeByDefault` profile is not activated when another profile is activated explicitly with `mvn -P...`.
As we use `-Prelease` for release then the `uber-jar` profile is not activated and the `-runnner.jar` is not deployed to nexus. The uber jar profile has to be activated regardless if `-P` is or isn't used.