### PR TITLE
Adding version badge to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Narayana](https://design.jboss.org/narayana/logo/final/narayana_logo_600px.png)](https://narayana.io/)
+
+[![Version](https://img.shields.io/maven-central/v/org.jboss.narayana/narayana-all?logo=apache-maven&style=for-the-badge)](https://search.maven.org/artifact/org.jboss.narayana/narayana-all)
+[![License](https://img.shields.io/badge/License-LGPL%20v2.1-green.svg?style=for-the-badge)](http://www.gnu.org/licenses/lgpl-2.1)
+
 Narayana
 ========
 


### PR DESCRIPTION
This is just a minor enhancement in *readme* file to add a project version which would point to maven repository page.

These badges would be a quick info to the Narayana users/contributors or new comer to the repository. As whosever visit to any repository in git, tries to have a quick look into the readme of that project.

The eye catchy badges would give quick and important piece of information about our project without digging into files for the info.

Since the change is only in readme file, therefore triggering a CI build would not be necessary.
!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
