### PR TITLE
JBTM-3447 Improve diagnostics for slow transactions

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoordinatorEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoordinatorEnvironmentBean.java
@@ -70,6 +70,8 @@ public class CoordinatorEnvironmentBean implements CoordinatorEnvironmentBeanMBe
     private volatile long txReaperCancelWaitPeriod = TransactionReaper.defaultCancelWaitPeriod;
     private volatile long txReaperCancelFailWaitPeriod = TransactionReaper.defaultCancelFailWaitPeriod;
     private volatile int txReaperZombieMax = TransactionReaper.defaultZombieMax;
+    private volatile long txReaperTraceGracePeriod = TransactionReaper.defaultUntracedPeriod;
+    private volatile long txReaperTraceInterval = TransactionReaper.defaultTracePeriod;
 
     private volatile int defaultTimeout = 60; // seconds
     private volatile boolean transactionStatusManagerEnable = true;
@@ -517,6 +519,47 @@ public class CoordinatorEnvironmentBean implements CoordinatorEnvironmentBeanMBe
     public void setTxReaperZombieMax(int txReaperZombieMax)
     {
         this.txReaperZombieMax = txReaperZombieMax;
+    }
+
+    /**
+     * Returns the number of milliseconds delay after a transaction is started,
+     * before the reaper will start taking periodic stack traces from it.
+     *
+     * Default: 180000 (3 minutes)
+     *
+     * @return the reaper tracing grace period, in milliseconds.
+     */
+    public long getTxReaperTraceGracePeriod() {
+        return txReaperTraceGracePeriod;
+    }
+
+    /**
+     * Sets the delay after a transaction is started, before it is eligible for periodic tracing.
+     *
+     * @param txReaperTraceGracePeriod in milliseconds.
+     */
+    public void setTxReaperTraceGracePeriod(long txReaperTraceGracePeriod) {
+        this.txReaperTraceGracePeriod = txReaperTraceGracePeriod;
+    }
+
+    /**
+     * Returns the number of milliseconds interval between transaction stack trace snapshots.
+     *
+     * Default: 30000 (30 seconds)
+     *
+     * @return the reaper tracing interval, in milliseconds.
+     */
+    public long getTxReaperTraceInterval() {
+        return txReaperTraceInterval;
+    }
+
+    /**
+     * Sets the interval between stack trace snapshots.
+     *
+     * @param txReaperTraceInterval in milliseconds.
+     */
+    public void setTxReaperTraceInterval(long txReaperTraceInterval) {
+        this.txReaperTraceInterval = txReaperTraceInterval;
     }
 
     /**

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoordinatorEnvironmentBeanMBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoordinatorEnvironmentBeanMBean.java
@@ -62,6 +62,10 @@ public interface CoordinatorEnvironmentBeanMBean
 
     int getTxReaperZombieMax();
 
+    long getTxReaperTraceGracePeriod();
+
+    long getTxReaperTraceInterval();
+
     int getDefaultTimeout();
 
     boolean isTransactionStatusManagerEnable();

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/Reapable.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/Reapable.java
@@ -42,12 +42,20 @@ import com.arjuna.ats.arjuna.common.Uid;
 public interface Reapable
 {
 
-    public boolean running ();
+    boolean running();
 
-    public boolean preventCommit ();
+    boolean preventCommit();
 
-    public int cancel ();
+    int cancel();
 
-    public Uid get_uid ();
+    Uid get_uid();
+
+    default void recordStackTraces() {
+        // default null-op
+    }
+
+    default void outputCapturedStackTraces() {
+        // default null-op
+    }
     
 }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TwoPhaseCoordinator.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TwoPhaseCoordinator.java
@@ -586,7 +586,23 @@ public class TwoPhaseCoordinator extends BasicAction implements Reapable
         return synchs;
     }
 
-    private SortedSet<SynchronizationRecord> _synchs;
+	@Override
+	public synchronized void recordStackTraces() {
+		// callback for the Reaper to tell us when it's time to take a snapshot of our threads.
+		// the heavy lifting is actually done up in BasicAction, but we're Reapable and it's not.
+		super.recordStackTraces();
+	}
+
+	@Override
+	public synchronized void outputCapturedStackTraces() {
+		// callback for the Reaper to tell us when it's time to dump any previously captured
+		// thread traces, which is usually right before a timeout (cancel)
+		// as above, the heavy lifting is actually done up in BasicAction, but we're Reapable and it's not.
+		super.outputCapturedStackTraces();
+	}
+
+
+	private SortedSet<SynchronizationRecord> _synchs;
     private List<Future<Boolean>> runningSynchronizations = null;
     private CompletionService<Boolean> synchronizationCompletionService = null;
     private boolean executingInterposedSynchs = false;

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -30,6 +30,7 @@ import static org.jboss.logging.annotations.Message.Format.MESSAGE_FORMAT;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.Date;
 
 import com.arjuna.ats.arjuna.exceptions.ObjectStoreException;
 import org.jboss.logging.annotations.Cause;
@@ -510,9 +511,9 @@ public interface arjunaI18NLogger {
 	@LogMessage(level = WARN)
 	public void warn_coordinator_TransactionReaper_16(String arg0, Uid arg1, @Cause() Throwable arg2);
 
-	@Message(id = 12117, value = "TransactionReaper::check timeout for TX {0} in state  {1}", format = MESSAGE_FORMAT)
-	@LogMessage(level = WARN)
-	public void warn_coordinator_TransactionReaper_18(Uid arg0, String arg1);
+	@Message(id = 12117, value = "TransactionReaper::check processing TX {0} in state  {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = INFO)
+	public void info_coordinator_TransactionReaper_18(Uid arg0, String arg1);
 
 	@Message(id = 12118, value = "TransactionReaper NORMAL mode is deprecated. Update config to use PERIODIC for equivalent behaviour.", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
@@ -1618,6 +1619,11 @@ public interface arjunaI18NLogger {
 
 	@Message(id = 12403, value = "Can't create pmem store in ''{0}''  - may not be an fs-dax location", format = MESSAGE_FORMAT)
 	String get_pmem_not_supported(String dir);
+
+	// see also 12381/warn_multiple_threads
+	@Message(id = 12404, value = "Action id {0} - thread {1} at time {2} had stackTrace {3}", format = MESSAGE_FORMAT)
+	@LogMessage(level = INFO)
+	void info_historic_stack_trace(Uid objectUid, String threadName, String date, String stackTrace);
 
     /*
         Allocate new messages directly above this notice.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperElementManager.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperElementManager.java
@@ -94,12 +94,12 @@ public class ReaperElementManager
         // assume it must be in the sorted list, as it was likely obtained via getFirst...
         removeSorted(reaperElement);
         // we could add delay to the original timeout, but using current time is probably safer.
-        reaperElement.setAbsoluteTimeout((System.currentTimeMillis() + delayMillis));
+        reaperElement.setNextCheckAbsoluteMillis((System.currentTimeMillis() + delayMillis));
         // reinsert into its new position.
         insertSorted(reaperElement);
 
         // getFirst takes care of flushing the pending set for us.
-        return getFirst().getAbsoluteTimeout();
+        return getFirst().getNextCheckAbsoluteMillis();
     }
 
     // use only for testing, it's nasty from a performance perspective.
@@ -115,7 +115,7 @@ public class ReaperElementManager
     public synchronized void setAllTimeoutsToZero() {
         flushPending();
         for(ReaperElement reaperElement : elementsOrderedByTimeout) {
-            reaperElement.setAbsoluteTimeout(0);
+            reaperElement.setNextCheckAbsoluteMillis(0);
         }
     }
 

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperWorkerThread.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperWorkerThread.java
@@ -59,10 +59,10 @@ public void run ()
              // this thread to cancel
 
              if (tsLogger.logger.isTraceEnabled()) {
-                 tsLogger.logger.trace("Thread "+Thread.currentThread()+" waiting for cancelled TXs");
+                 tsLogger.logger.trace("Thread "+Thread.currentThread()+" waiting for transaction check tasks");
              }
 
-             _theReaper.waitForCancellations();
+             _theReaper.waitForWork();
 
              // check for shutdown before we wait again
 
@@ -72,10 +72,10 @@ public void run ()
              // get the reaper to cancel any TXs queued for cancellation.
 
              if (tsLogger.logger.isTraceEnabled()) {
-                 tsLogger.logger.trace("Thread "+Thread.currentThread()+" performing cancellations");
+                 tsLogger.logger.trace("Thread "+Thread.currentThread()+" performing transaction check work");
              }
 
-             _theReaper.doCancellations();
+             _theReaper.doWork();
 
             // check for shutdown before we wait again
 

--- a/ArjunaCore/arjuna/tests/byteman-scripts/reaper.btm
+++ b/ArjunaCore/arjuna/tests/byteman-scripts/reaper.btm
@@ -111,7 +111,7 @@ ENDRULE
 
 RULE pause transaction reaper worker 1
 CLASS com.arjuna.ats.arjuna.coordinator.TransactionReaper
-METHOD doCancellations
+METHOD doWork
 AT SYNCHRONIZE
 BIND NOTHING
 IF isRendezvous("reaperworker1", 2)
@@ -125,7 +125,7 @@ ENDRULE
 
 RULE pause transaction reaper worker 2
 CLASS com.arjuna.ats.arjuna.coordinator.TransactionReaper
-METHOD doCancellations
+METHOD doWork
 AT SYNCHRONIZE 2
 BIND NOTHING
 IF isRendezvous("reaperworker2", 2)
@@ -139,7 +139,7 @@ ENDRULE
 
 RULE pause transaction reaper worker 3
 CLASS com.arjuna.ats.arjuna.coordinator.TransactionReaper
-METHOD doCancellations
+METHOD doWork
 AT CALL cancel
 BIND NOTHING
 IF isRendezvous("reaperworker3", 2)
@@ -153,7 +153,7 @@ ENDRULE
 
 RULE pause transaction reaper worker 4
 CLASS com.arjuna.ats.arjuna.coordinator.TransactionReaper
-METHOD doCancellations
+METHOD doWork
 AT CALL preventCommit
 BIND NOTHING
 IF isRendezvous("reaperworker4", 2)
@@ -297,7 +297,7 @@ ENDRULE
 # debug tracing rules
 # RULE ReaperTestCase trace element remove
 # CLASS com.arjuna.ats.arjuna.coordinator.TransactionReaper
-# METHOD doCancellations
+# METHOD doWork
 # AT CALL removeElement
 # BIND NOTHING
 # IF TRUE

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/reaper/ReaperStacktracingTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/reaper/ReaperStacktracingTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Red Hat.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package com.hp.mwtests.ts.arjuna.reaper;
+
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.coordinator.ActionStatus;
+import com.arjuna.ats.arjuna.coordinator.Reapable;
+import com.arjuna.ats.arjuna.coordinator.TransactionReaper;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Exercises TransactionReaper periodic stack tracing functionality.
+ *
+ * @author jonathan.halliday@redhat.com, 2021-03
+ */
+public class ReaperStacktracingTest {
+
+    @Test
+    public void testReaper() throws Exception {
+
+        // run a single tx through its lifecycle and check it's doing stack trace and termination at expected times
+
+        // traces should take place at 300, 500, 700, 900 ms
+        arjPropertyManager.getCoordinatorEnvironmentBean().setTxReaperTraceGracePeriod(300);
+        arjPropertyManager.getCoordinatorEnvironmentBean().setTxReaperTraceInterval(200);
+
+        TransactionReaper reaper = TransactionReaper.transactionReaper();
+        MockReapable reapable = new MockReapable(new Uid());
+        long startTime = System.currentTimeMillis();
+        reaper.insert(reapable, 1);
+        Thread.sleep(1200);
+        TransactionReaper.terminate(false);
+
+        // check the stacktrace calls took place as expected
+        assertEquals(4, reapable.recordStackTracesCallTimes.size());
+        long interval = arjPropertyManager.getCoordinatorEnvironmentBean().getTxReaperTraceInterval();
+        long first = startTime+arjPropertyManager.getCoordinatorEnvironmentBean().getTxReaperTraceGracePeriod();
+        assertWithinTolerance(first,  reapable.recordStackTracesCallTimes.get(0));
+        assertWithinTolerance(first+(interval), reapable.recordStackTracesCallTimes.get(1));
+        assertWithinTolerance(first+(interval*2), reapable.recordStackTracesCallTimes.get(2));
+        assertWithinTolerance(first+(interval*3), reapable.recordStackTracesCallTimes.get(3));
+
+        // we should be asked to dump the captured traces once, right before being cancelled
+        assertEquals(1, reapable.outputCapturedStackTracesCallTimes.size());
+        assertWithinTolerance(startTime+1000, reapable.outputCapturedStackTracesCallTimes.get(0));
+        assertEquals(1, reapable.cancelCallTimes.size());
+        assertWithinTolerance(startTime+1000, reapable.cancelCallTimes.get(0));
+    }
+
+    public void assertWithinTolerance(long a, long b) {
+        long diff = Math.abs(a-b);
+        // 100ms should be enough to give us some wiggle room with startup overhead and thread scheduling
+        assertTrue(diff < 100);
+    }
+
+    public class MockReapable implements Reapable
+    {
+        private Uid uid;
+        public List<Long> cancelCallTimes = new ArrayList<>();
+        public List<Long> recordStackTracesCallTimes = new ArrayList<>();
+        public List<Long> outputCapturedStackTracesCallTimes = new ArrayList<>();
+
+        public MockReapable(Uid uid)
+        {
+            this.uid = uid;
+        }
+
+        public boolean running()
+        {
+            return true;
+        }
+
+        public boolean preventCommit()
+        {
+            return false;
+        }
+
+        public Uid get_uid()
+        {
+            return uid;
+        }
+
+        public int cancel()
+        {
+            cancelCallTimes.add(System.currentTimeMillis());
+            return ActionStatus.ABORTED;
+        }
+
+        @Override
+        public void recordStackTraces() {
+            recordStackTracesCallTimes.add(System.currentTimeMillis());
+        }
+
+        @Override
+        public void outputCapturedStackTraces() {
+            outputCapturedStackTracesCallTimes.add(System.currentTimeMillis());
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3447
Transaction reaper modifications to support periodically capturing thread stack trace information as the tx executes and logging them if it timesout.

MAIN CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
