### PR TITLE
[JBTM-3454] JTA CDI should roll-back when java.lang.Error is thrown from the @Transactional method

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/SneakyThrow.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/SneakyThrow.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.arjuna.ats.jta.cdi;
+
+/**
+ * An utility class which makes possible to throw any exception as a {@link RuntimeException}.
+ * It means to throw checked exception (subtype of Throwable or Exception) as un-checked exception.
+ * This considers the Java 8 inference rule that states that a {@code throws E} is inferred as {@code RuntimeException}.
+ */
+public class SneakyThrow {
+        private SneakyThrow() {
+            throw new IllegalStateException("utility class, do not instance");
+        }
+
+        /**
+         * This method can be used in {@code throw} statement
+         * such as: {@code throw sneakyThrow(exception);}.
+         */
+        @SuppressWarnings("unchecked")
+        public static <E extends Throwable> void sneakyThrow(Throwable e) throws E {
+            throw (E) e;
+        }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalBean.java
@@ -62,6 +62,13 @@ public class TestTransactionalBean {
         throw throwable.newInstance();
     }
 
+    @Transactional(dontRollbackOn = Error.class)
+    public void invokeWithRequiresAndDontRollbackOnError(Class<? extends Throwable> throwable) throws Throwable {
+
+        AssertionParticipant.enlist();
+        throw throwable.newInstance();
+    }
+
     @Transactional(dontRollbackOn = TestException.class, rollbackOn = TestException.class)
     public void invokeWithDefaultAndDoAndDontRollbackOn(Class<? extends Throwable> throwable) throws Throwable {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3454

MAIN AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA
