### PR TITLE
[JBTM-3468] omit throwing NPE on generating stack trace in reaper worker thread

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -3401,6 +3401,7 @@ public class BasicAction extends StateManager
 
     protected synchronized Map<String,String> createStackTraces() {
         Map<String,String> results = new HashMap<>();
+        if (_childThreads == null) return results;
         for (Thread entry : _childThreads.values()) {
             StackTraceElement[] stackTrace = entry.getStackTrace();
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3468

AS_TESTS
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS  !TOMCAT !JACOCO !LRA
