### PR TITLE
[SCRIPTS ONLY] added token authentication to call CI jobs

### DIFF
--- a/narayana-release-process.sh
+++ b/narayana-release-process.sh
@@ -108,8 +108,8 @@ then
   # jenkins XSS needs a token
   COOKIE_PATH=/tmp/cookie_jenkins_crumb.txt
   crumb=$(curl -s -c "$COOKIE_PATH" 'http://narayanaci1.eng.hst.ams2.redhat.com/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)')
-  curl -v -b "$COOKIE_PATH" -X POST -H "$crumb" http://narayanaci1.eng.hst.ams2.redhat.com/job/release-narayana/build?delay=0sec --data-urlencode json="$json"
-  curl -v -b "$COOKIE_PATH" -X POST -H "$crumb" http://narayanaci1.eng.hst.ams2.redhat.com/job/release-narayana-catelyn/build?delay=0sec --data-urlencode json="$json"
+  curl -v -b "$COOKIE_PATH" -X POST -H "$crumb" http://narayanaci1.eng.hst.ams2.redhat.com/job/release-narayana/build?token=poller&delay=0sec --data-urlencode json="$json"
+  curl -v -b "$COOKIE_PATH" -X POST -H "$crumb" http://narayanaci1.eng.hst.ams2.redhat.com/job/release-narayana-catelyn/build?token=poller&delay=0sec --data-urlencode json="$json"
   set +e
   git fetch upstream --tags
   #./scripts/release/update_jira.py -k JBTM -t 5.next -n $CURRENT


### PR DESCRIPTION
This PR adds the token authentication to call CI jobs from narayana-release-process.sh

!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
