### PR TITLE
JBTM-3481 Upgrade MicroProfile LRA to 1.0

### DIFF
--- a/rts/lra/annotation-checker/pom.xml
+++ b/rts/lra/annotation-checker/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
-            <version>${version.microprofile.lra.api}</version>
+            <version>${version.microprofile.lra}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/rts/lra/client/pom.xml
+++ b/rts/lra/client/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
-            <version>${version.microprofile.lra.api}</version>
+            <version>${version.microprofile.lra}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>

--- a/rts/lra/coordinator-thorntail/pom.xml
+++ b/rts/lra/coordinator-thorntail/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
           <groupId>org.eclipse.microprofile.lra</groupId>
           <artifactId>microprofile-lra-api</artifactId>
-          <version>${version.microprofile.lra.api}</version>
+          <version>${version.microprofile.lra}</version>
         </dependency>
     </dependencies>
 

--- a/rts/lra/coordinator/pom.xml
+++ b/rts/lra/coordinator/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
-            <version>${version.microprofile.lra.api}</version>
+            <version>${version.microprofile.lra}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>

--- a/rts/lra/jaxrs/pom.xml
+++ b/rts/lra/jaxrs/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
-            <version>${version.microprofile.lra.api}</version>
+            <version>${version.microprofile.lra}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -27,8 +27,7 @@
         <version.jboss-modules>1.10.2.Final</version.jboss-modules>
         <version.org.jboss.servlet.api>1.0.0.Final</version.org.jboss.servlet.api>
 
-        <version.microprofile.lra.api>1.0-RC3</version.microprofile.lra.api>
-        <version.microprofile.lra.tck>1.0-RC3</version.microprofile.lra.tck>
+        <version.microprofile.lra>1.0</version.microprofile.lra>
         <version.microprofile.fault-tolerance>2.1.1</version.microprofile.fault-tolerance>
 
         <version.org.jboss.weld.se>3.1.1.Final</version.org.jboss.weld.se>

--- a/rts/lra/proxy/api/pom.xml
+++ b/rts/lra/proxy/api/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
-            <version>${version.microprofile.lra.api}</version>
+            <version>${version.microprofile.lra}</version>
         </dependency>
 	    <!-- testing -->
         <dependency>

--- a/rts/lra/proxy/test/pom.xml
+++ b/rts/lra/proxy/test/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-api</artifactId>
-            <version>${version.microprofile.lra.api}</version>
+            <version>${version.microprofile.lra}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.rts</groupId>

--- a/rts/lra/service-base/pom.xml
+++ b/rts/lra/service-base/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>org.eclipse.microprofile.lra</groupId>
       <artifactId>microprofile-lra-api</artifactId>
-      <version>${version.microprofile.lra.api}</version>
+      <version>${version.microprofile.lra}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/rts/lra/test/arquillian-extension/pom.xml
+++ b/rts/lra/test/arquillian-extension/pom.xml
@@ -17,13 +17,13 @@
     <dependency>
       <groupId>org.eclipse.microprofile.lra</groupId>
       <artifactId>microprofile-lra-api</artifactId>
-      <version>${version.microprofile.lra.api}</version>
+      <version>${version.microprofile.lra}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.microprofile.lra</groupId>
       <artifactId>microprofile-lra-tck</artifactId>
-      <version>${version.microprofile.lra.tck}</version>
+      <version>${version.microprofile.lra}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.narayana.rts</groupId>

--- a/rts/lra/test/tck/pom.xml
+++ b/rts/lra/test/tck/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.lra</groupId>
             <artifactId>microprofile-lra-tck</artifactId>
-            <version>${version.microprofile.lra.tck}</version>
+            <version>${version.microprofile.lra}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3481

I also changed the mp.lra version property to be the same for API and TCK. I don't remember why we needed this distinction, but it hasn't been used long.

!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
