### PR TITLE
[JBTM-3450] Back ported JBTM-3450 to Narayana 5.9

### DIFF
--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -283,11 +283,10 @@
 		<id>oracle-jdbc-store</id>
 		<dependencies>
 			<dependency>
-				<groupId>com.oracle</groupId>
-				<artifactId>ojdbc</artifactId>
+				<groupId>com.oracle.database.jdbc</groupId>
+				<artifactId>ojdbc8</artifactId>
 				<version>${version.com.oracle}</version>
-				<scope>system</scope>
-				<systemPath>${orson.jar.location}/../qa/dbdrivers/oracle_10_2_0_4/ojdbc14.jar</systemPath>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 		<build>

--- a/ArjunaJTA/jta/pom.xml
+++ b/ArjunaJTA/jta/pom.xml
@@ -410,11 +410,10 @@
 				<scope>system</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.oracle</groupId>
-				<artifactId>ojdbc</artifactId>
+				<groupId>com.oracle.database.jdbc</groupId>
+				<artifactId>ojdbc8</artifactId>
 				<version>${version.com.oracle}</version>
-				<systemPath>${orson.jar.location}/../qa/dbdrivers/oracle_10_2_0_4/ojdbc14.jar</systemPath>
-				<scope>system</scope>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,7 @@
     <version.org.apache.ant>1.8.2</version.org.apache.ant>
     <version.org.apache.httpcomponents>4.2.1</version.org.apache.httpcomponents>
     <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
-    <version.com.oracle>10.2.0.4</version.com.oracle>
+    <version.com.oracle>18.3.0.0</version.com.oracle>
     <version.com.ibm>9.7</version.com.ibm>
     <version.postgresql>9.0-801.jdbc4</version.postgresql>
     <version.mysql>5.1.28</version.mysql>

--- a/qa/TaskImpl.properties.template
+++ b/qa/TaskImpl.properties.template
@@ -47,7 +47,7 @@ COMMAND_LINE_2=\
   ${path.separator}dbdrivers${file.separator}jConnect-6_0${file.separator}classes${file.separator}jconn3.jar\
   ${path.separator}dbdrivers${file.separator}mssql2005_sqljdbc_2.0${file.separator}enu${file.separator}sqljdbc4.jar\
   ${path.separator}dbdrivers${file.separator}mysql-connector-java-5.1.8-bin.jar\
-  ${path.separator}dbdrivers${file.separator}oracle_10_2_0_4${file.separator}ojdbc14.jar\
+  ${path.separator}dbdrivers${file.separator}ojdbc8.jar\
   ${path.separator}dbdrivers${file.separator}postgresql-8.3-605.jdbc4.jar\
   ${path.separator}ext${file.separator}log4j.jar\
   ${path.separator}ext${file.separator}netty.jar

--- a/qa/build.xml
+++ b/qa/build.xml
@@ -37,7 +37,7 @@
   <property name="org.jboss.jbossts.qa.server_manager_location" location="ext/jboss-server-manager-0.1.1.GA.jar"/>
   <property name="org.jboss.jbossts.qa.dist.buildroot" location="build"/>
 
-  <target name="get.drivers" depends="clean-dbdrivers">
+  <target name="get.drivers">
     <!--
         https://docspace.corp.redhat.com/clearspace/docs/DOC-16080
         http://www.jboss.com/products/platforms/application/supportedconfigurations/
@@ -45,8 +45,6 @@
         https://docspace.corp.redhat.com/clearspace/community/bu/middleware/jboss-qe/lab
         server connection params in config/jdbc_profiles/
         -->
-    <mkdir dir="${driver.home}/oracle_10_2_0_4"/>
-    <get src="${driver.url}/ojdbc14.jar" dest="${driver.home}/oracle_10_2_0_4/ojdbc14.jar"/>
     <mkdir dir="${driver.home}/mssql2005_sqljdbc_2.0/enu"/>
     <get src="${driver.url}/sqljdbc_2.0/enu/sqljdbc.jar" dest="${driver.home}/mssql2005_sqljdbc_2.0/enu/sqljdbc.jar"/>
     <get src="${driver.url}/sqljdbc_2.0/enu/sqljdbc4.jar" dest="${driver.home}/mssql2005_sqljdbc_2.0/enu/sqljdbc4.jar"/>
@@ -72,10 +70,6 @@
       </and>
     </condition>
     <available file="${driver.home}" property="have.dbdrivers" value="true"/>
-  </target>
-  <target name="clean-dbdrivers" unless="dbdrivers.cleaned">
-    <delete dir="${driver.home}"/>
-    <property name="dbdrivers.cleaned" value="true"/>
   </target>
   <target name="clean" depends="clean-tests"/>
   <target name="clean-tests">

--- a/qa/config/jdbc_profiles/default/JDBCProfiles
+++ b/qa/config/jdbc_profiles/default/JDBCProfiles
@@ -121,17 +121,29 @@ DB2_MYSQL_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 # Oracle thin JNDI Pair
 ######################################################################
 
-# https://github.com/oracle/docker-images/tree/master/OracleDatabase
-# docker run --name oracle-ci --shm-size=1g -p 1521:1521 -p 8080:8080 -e ORACLE_PWD=oracle oracle/database:11.2.0.2-xe
-# docker run --rm -ti oracle/database:11.2.0.2-xe sqlplus sys/oracle@narayanaci1.eng.hst.ams2.redhat.com:1521/XE as sysdba
-# CREATE USER dtf11 IDENTIFIED BY dtf11; 
-# GRANT CONNECT, RESOURCE TO dtf11;
+# git clone https://github.com/oracle/docker-images.git
+# cd docker-images/OracleDatabase/SingleInstance/dockerfiles
+# Consider changes after https://github.com/oracle/docker-images/blob/main/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe#L61 if https://github.com/fuzziebrain/docker-oracle-xe/issues/15#issuecomment-578452720 is relevant
+# ./buildContainerImage.sh -x -v 18.4.0
+# docker run --name oracle-ci -p 1521:1521 -p 5500:5500 -e ORACLE_PWD=oracle oracle/database:18.4.0-xe
+# Leave the docker container running and then in a second shell after waiting for the startup and even a bit longer
+
+# docker run --rm -ti oracle/database:18.4.0-xe sqlplus sys/oracle@narayanaci1.eng.hst.ams2.redhat.com:1521/XE as sysdba
+# If you get a prompt to login, this command is not working as expected. Close this container, wait a bit longer and then retry
+
+# CREATE USER dtf11 IDENTIFIED BY dtf11;
+# GRANT CREATE SESSION, RESOURCE TO dtf11;
+# ALTER USER dtf11 quota unlimited on USERS;
+#
 # CREATE USER dtf12 IDENTIFIED BY dtf12;
-# GRANT CONNECT, RESOURCE TO dtf12;
-# docker start oracle-ci
-#sqlplus / as sysdba
-#sqlplus>alter system set processes=300 scope=spfile;
-#sqlplus>shut immediate;
+# GRANT CREATE SESSION, RESOURCE TO dtf12;
+# ALTER USER dtf12 quota unlimited on USERS;
+#
+# alter system set processes=300 scope=spfile;
+# shut immediate;
+# exit
+#
+# Exit both shells docker run commands
 # docker start oracle-ci
 
 DB1_THIN_JNDI_NumberOfDrivers=2

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -170,8 +170,8 @@
 					<target>1.7</target>
 					<excludes>
 						<exclude>**/astests/**</exclude>
-            <exclude>org/jboss/jbossts/qa/junit/testgroup/TestGroup_perfprofile01_i.java</exclude>
-            <exclude>org/jboss/jbossts/qa/junit/testgroup/TestGroup_jtsremote.java</exclude>
+						<exclude>org/jboss/jbossts/qa/junit/testgroup/TestGroup_perfprofile01_i.java</exclude>
+						<exclude>org/jboss/jbossts/qa/junit/testgroup/TestGroup_jtsremote.java</exclude>
 					</excludes>
 				</configuration>
 			</plugin>
@@ -183,8 +183,16 @@
 				<artifactId>maven-dependency-plugin</artifactId>
 
 				<configuration>
-          <excludeGroupIds>org.jboss.spec.javax.transaction,junit,jboss.profiler.jvmti,org.apache.ant,javax,org.jboss.narayana</excludeGroupIds>
-          <excludeArtifactIds>jboss-transaction-spi</excludeArtifactIds>
+					<excludeGroupIds>
+						org.jboss.spec.javax.transaction,
+						junit,
+						jboss.profiler.jvmti,
+						org.apache.ant,
+						javax,
+						org.jboss.narayana,
+						com.oracle.database.jdbc
+					</excludeGroupIds>
+					<excludeArtifactIds>jboss-transaction-spi</excludeArtifactIds>
 					<outputDirectory>./ext</outputDirectory>
 					<overWriteReleases>false</overWriteReleases>
 					<overWriteSnapshots>false</overWriteSnapshots>
@@ -192,6 +200,20 @@
 					<excludeTransitive>true</excludeTransitive>
 					<stripVersion>true</stripVersion>
 				</configuration>
+
+				<executions>
+					<execution>
+						<phase>install</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<excludeGroupIds>*</excludeGroupIds>
+							<outputDirectory>${project.build.directory}/../dbdrivers</outputDirectory>
+							<includeArtifactIds>ojdbc8</includeArtifactIds>
+						</configuration>
+					</execution>
+				</executions>
 
 			</plugin>
 		</plugins>
@@ -243,11 +265,16 @@
 			<artifactId>jboss-transaction-spi</artifactId>
 			<version>${version.org.jboss.jboss-transaction-spi}</version>
 		</dependency>
-        <dependency>
-          <groupId>org.jboss.narayana.jts</groupId>
-          <artifactId>narayana-jts-idlj</artifactId>
-          <version>${project.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.jboss.narayana.jts</groupId>
+			<artifactId>narayana-jts-idlj</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.database.jdbc</groupId>
+			<artifactId>ojdbc8</artifactId>
+			<version>${version.com.oracle}</version>
+		</dependency>
 
 	</dependencies>
   <profiles>

--- a/qa/run-tests.xml
+++ b/qa/run-tests.xml
@@ -82,7 +82,7 @@
   </target>
   <!-- handy utility space where you can copy one or more test groups if you want to run something ad-hoc -->
   <target name="test">
-    <property name="driver" value="ojdbc14.jar"/>
+    <property name="driver" value="ojdbc8.jar"/>
     <fail unless="test" message="you need to specify the name of a test"/>
     <install-dbdriver files="${driver}"/>
     <junit-tests tests="${test}"/>
@@ -261,7 +261,7 @@
     <fail if="failed-tests" message="some tests failed"/>
   </target>
   <target name="junit-jdbc-testsuite">
-    <install-dbdriver files="ojdbc14.jar"/>
+    <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="jdbcresources01_oracle_thin_jndi"/>
     <junit-tests tests="jdbcresources02_oracle_thin_jndi"/>
     <!-- mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
@@ -290,7 +290,7 @@
   </target>
   <!-- the ncl office build server is not on vpn and only a subset of the dbs are available locally -->
   <target name="junit-jdbc-ncl-testsuite">
-    <install-dbdriver files="ojdbc14.jar"/>
+    <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="jdbcresources01_oracle_thin_jndi"/>
     <junit-tests tests="jdbcresources02_oracle_thin_jndi"/>
     <install-dbdriver files="mysql-connector-java-5.1.8-bin.jar"/>
@@ -302,7 +302,7 @@
   </target>
   <target name="junit-jdbc-crachrec">
     <!-- crashrecovery11 : jdbc resource crash recovery tests. 4 tests, 4 minutes per db -->
-    <install-dbdriver files="ojdbc14.jar"/>
+    <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="crashrecovery11-oracle_jndi"/>
     <!--mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
     <condition property="mssql.driver" value="sqljdbc4.jar">
@@ -337,7 +337,7 @@
     <!-- jtatest01 : 6 tests, minute-->
     <junit-tests tests="jtatests01"/>
     <!-- jdbclocals01 : 6 tests, 2 minutes for each db -->
-    <install-dbdriver files="ojdbc14.jar"/>
+    <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="jdbclocals01_oracle_jndi"/>
     <!-- mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
     <condition property="mssql.driver" value="sqljdbc4.jar">


### PR DESCRIPTION
This PR is for back porting to Narayana 5.9 the new oracle driver in [QA](https://github.com/jbosstm/narayana/pull/1829) and in [ArjunaCore.arjuna](https://github.com/jbosstm/narayana/pull/1844)

This PR backports JIRAs:
[JBTM-3486](https://issues.redhat.com/browse/JBTM-3486)
[JBTM-3450](https://issues.redhat.com/browse/JBTM-3450)

QA_JTA DB_TESTS oracle

Test to exclude:
!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF !LRA NO_WIN !mysql !db2 !postgres
