### PR TITLE
[JBTM-3479] Added resteasy-client and resteasy-jackson2-provider dependencies to the lra-client module

### DIFF
--- a/rts/lra/client/pom.xml
+++ b/rts/lra/client/pom.xml
@@ -30,6 +30,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${version.org.jboss.resteasy}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <version>${version.org.jboss.resteasy}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <version>${version.cdi-api}</version>

--- a/rts/lra/client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
+++ b/rts/lra/client/src/main/resources/META-INF/services/javax.ws.rs.client.ClientBuilder
@@ -1,1 +1,2 @@
+org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
 org.jboss.resteasy.microprofile.client.impl.MpClientBuilderImpl


### PR DESCRIPTION
This PR addressed [JBTM-3479](https://issues.redhat.com/browse/JBTM-3479)

LRA
!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !BLACKTIE !PERF NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
