### PR TITLE
[JBTM-3503] when Weld does not provide @Transactional annotations using prior way of searching it

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
@@ -107,14 +107,16 @@ public abstract class TransactionalInterceptorBase implements Serializable {
      */
     private Transactional getTransactional(InvocationContext ic) {
         // when the CDI implementation is Weld then using the Weld API for accessing the annotated type
-        if (ic.getContextData().containsKey(WELD_INTERCEPTOR_BINDINGS_KEY)) {
+        // when Weld does not provide the annotation we switch to more complicated processing
+        if (interceptedBean != null && ic.getContextData().get(WELD_INTERCEPTOR_BINDINGS_KEY) != null) {
             Set<Annotation> annotationBindings = (Set<Annotation>) ic.getContextData().get(WELD_INTERCEPTOR_BINDINGS_KEY);
             for (Annotation annotation : annotationBindings) {
                 if (annotation.annotationType() == Transactional.class) {
                     return (Transactional) annotation;
                 }
             }
-        } else if (interceptedBean != null) { // not-null for CDI
+        }
+        if (interceptedBean != null) { // not-null for CDI
             // getting annotated type and method corresponding of the intercepted bean and method
             AnnotatedType<?> currentAnnotatedType = extension.getBeanToAnnotatedTypeMapping().get(interceptedBean);
             if (currentAnnotatedType == null) {

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/ejb/CdiWeldFailureWithEjbTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/ejb/CdiWeldFailureWithEjbTest.java
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.ejb;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.transaction.Status;
+
+/**
+ * When using Weld then Narayana switches to use Weld API to access the list of the {@code @Transactional} annotations.
+ * This is done via {@code InvocationContext.getContextData("org.jboss.weld.interceptor.bindings")}.
+ * In some particular cases where EJB is involved it may happen the Weld is not able to provide the {@code @Transactional} annotations.
+ *
+ * This test aims to hit this corner case and check that when Weld does not provide the annotation then
+ * Narayana will use a different way to get the annotation correctly and it intercepts the call.
+ *
+ * @see <a href="https://issues.redhat.com/browse/WFLY-14924">WFLY-14924</a>
+ */
+@RunWith(Arquillian.class)
+public class CdiWeldFailureWithEjbTest {
+
+    @Inject
+    StatelessEjbCaller beanB;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, "weld-failure-wit-ejb.war")
+                .addPackage(CdiWeldFailureWithEjbTest.class.getPackage())
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void workWithTestService() {
+        Assert.assertNotNull("Expecting bean injection from arquillian works fine", beanB);
+        Assert.assertEquals("Expecting the transactional EJB returns that the transaction is active",
+                Status.STATUS_ACTIVE, beanB.doWork());
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/ejb/StatelessEjbCaller.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/ejb/StatelessEjbCaller.java
@@ -1,0 +1,23 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.ejb;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+@Stateless
+public class StatelessEjbCaller {
+
+    @Inject
+    private TransactionalEjbCalled transactionalEjb;
+
+    public int doWork() {
+        return transactionalEjb.inNewTransaction();
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/ejb/TransactionalEjbCalled.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/ejb/TransactionalEjbCalled.java
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.stereotype.ejb;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.transaction.TransactionManager;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+@Stateless
+public class TransactionalEjbCalled {
+    @Resource(lookup = "java:/TransactionManager")
+    TransactionManager tm;
+
+    @Transactional(TxType.REQUIRES_NEW)
+    public int inNewTransaction() {
+        try {
+            return tm.getStatus();
+        } catch (Exception e) {
+            throw new IllegalStateException("Expected transaction is active and fine to get status", e);
+        }
+    }
+
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,15 @@ The DCO text is also included verbatim in the [dco.txt](dco.txt) file in the roo
 
 New files may contain a license header in the following format:
 
-> Copyright The Narayana Authors
-> 
-> SPDX-License-Identifier: LGPL-2.1-only
+```
+/*
+ *
+ * Copyright The Narayana Authors
+ * 
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+```
 
 ## Reporting an issue
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3503

superseding https://github.com/jbosstm/narayana/pull/1866

MAIN AS_TESTS
!QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !TOMCAT !JACOCO !LRA
