### PR TITLE
[JBTM-3519] Replaced 'master' with 'main' when the repository github.com/wildfly/wildfly is used

### DIFF
--- a/narayana-release-process.sh
+++ b/narayana-release-process.sh
@@ -122,7 +122,7 @@ if [[ $? != 0 ]]
 then
   git fetch upstream; 
   git checkout -b ${WFLYISSUE}
-  git reset --hard upstream/master
+  git reset --hard upstream/main
   CURRENT_VERSION_IN_WFLY=`grep 'narayana>' pom.xml | cut -d \< -f 2|cut -d \> -f 2`
   if [[ $(uname) == CYGWIN* ]]
   then

--- a/scripts/branch-names.sh
+++ b/scripts/branch-names.sh
@@ -1,2 +1,2 @@
-export UPSTREAM_AS_BRANCH=master
+export UPSTREAM_AS_BRANCH=main
 export ORIGIN_AS_BRANCH=5_BRANCH

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -374,12 +374,12 @@ function clone_as {
 
   git fetch upstream
   echo "This is the JBoss-AS commit"
-  echo $(git rev-parse upstream/master)
+  echo $(git rev-parse upstream/main)
   echo "This is the AS_BRANCH $AS_BRANCH commit"
   echo $(git rev-parse HEAD)
 
-  echo "Rebasing the wildfly upstream/master on top of the AS_BRANCH $AS_BRANCH"
-  git pull --rebase --ff-only upstream master
+  echo "Rebasing the wildfly upstream/main on top of the AS_BRANCH $AS_BRANCH"
+  git pull --rebase --ff-only upstream main
   [ $? -eq 0 ] || fatal "git rebase failed"
   
   if [ $REDUCE_SPACE = 1 ]; then


### PR DESCRIPTION
This PR addresses [JBTM-3519](https://issues.redhat.com/browse/JBTM-3519)

AS_TESTS RTS XTS

!MAIN !CORE !TOMCAT !JACOCO !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
