### PR TITLE
JBTM-3522: Unable to load "ServerLRAFilter" class as part of WildFly LRA extension

### DIFF
--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -358,7 +358,7 @@ public class LRATest {
         // start a new LRA
         Response r2 = client.target(coordinatorPath + "/start").request().post(null);
         assertEquals("Expected 201", Response.Status.CREATED.getStatusCode(), r2.getStatus());
-        String lraId = r2.getHeaderString(LRA_HTTP_CONTEXT_HEADER);
+        String lraId = r2.readEntity(String.class);
         Assert.assertNotNull("missing context header", lraId);
         // RestEasy adds brackets and , to delimit multiple values for a particular header key
         lraId = new StringTokenizer(lraId, "[,]").nextToken();

--- a/rts/lra/jaxrs/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
+++ b/rts/lra/jaxrs/src/main/resources/META-INF/services/javax.ws.rs.ext.Providers
@@ -1,3 +1,3 @@
 io.narayana.lra.filter.ClientLRAResponseFilter
 io.narayana.lra.filter.ClientLRARequestFilter
-
+io.narayana.lra.filter.ServerLRAFilter


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3522

CORE
LRA
!MAIN
!AS_TESTS

!TOMCAT !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
