### PR TITLE
[JBTM-3523] print warning with cause when AfterLRA call does not proceed well

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
@@ -448,13 +448,7 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
                 return true;
             }
         } catch (Exception e) {
-            Throwable cause = e.getCause();
-            if (!(e instanceof WebApplicationException) && cause instanceof WebApplicationException) {
-                e = (WebApplicationException) cause;
-            }
-            if (LRALogger.logger.isDebugEnabled()) {
-                LRALogger.logger.debugf("Could not notify URI at %s (%s)", target, e.getMessage());
-            }
+            LRALogger.i18nLogger.warn_cannotNotifyAfterLRAURI(target, e);
         } finally {
             if (client != null) {
                 client.close();

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
@@ -143,6 +143,10 @@ public interface LraI18nLogger {
             "Please, provide the right version for the API.")
     String get_wrongAPIVersionDemanded(String demandedApiVersion, String supportedVersions);
 
+    @LogMessage(level = WARN)
+    @Message(id = 25029, value = "Cannot notify AfterLRA URL at %s")
+    void warn_cannotNotifyAfterLRAURI(URI target, @Cause Throwable t);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.


### PR DESCRIPTION
LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO

https://issues.redhat.com/browse/JBTM-3523

I would like to propose a change in the logging of the error during after lra call from coordinator. Currently it's hidden under `debug` without the whole stacktrace. When an error happens then it's "invisible" without details. When the call goes wrong then it leads to an unrecoverable lra records (`afterLRARequest` returns `false` and the `TwoPhaseOutcome.HEURISTIC_HAZARD` is returned, https://github.com/jbosstm/narayana/blob/b4bd01f695af5fb92bed70fe1502bb606b305579/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java#L512) while the reason for the error is difficult to find.

@mmusgrov @mayankkunwar what do you think about his kind of change? If it's  fine with you I will create a JBTM issue and will remove the `Hold` label from this PR.