### PR TITLE
[JBTM-3531] print warning when exception causes the LRA record cannot be removed from object store

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -196,7 +196,8 @@ public class LRAService {
         try {
             return getRM().removeCommitted(new Uid(uid));
         } catch (Exception e) {
-            return false; // the uid segment is invalid
+            LRALogger.i18nLogger.warn_cannotRemoveUidRecord(lraId, uid, e);
+            return false;
         }
     }
 

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
@@ -157,8 +157,12 @@ public interface LraI18nLogger {
     void warn_saveState(String cause);
 
     @LogMessage(level = WARN)
-    @Message(id = 25033, value = "LRA Record: Cannot restore state (reason: %s")
+    @Message(id = 25033, value = "LRA Record: Cannot restore state (reason: %s)")
     void warn_restoreState(String cause);
+
+    @LogMessage(level = WARN)
+    @Message(id = 25034, value = "LRA Recovery cannot remove LRA id %s from the object store. The uid segment '%s' is probably invalid.")
+    void warn_cannotRemoveUidRecord(String lraId, String uid, @Cause Throwable t);
 
     /*
         Allocate new messages directly above this notice.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3531

LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO