### PR TITLE
[JBTM-3526] Split failsafe reports based on running arq profile

### DIFF
--- a/rts/lra/test/pom.xml
+++ b/rts/lra/test/pom.xml
@@ -135,6 +135,8 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <skipITs>false</skipITs>
+              <reportsDirectory>${project.build.directory}/failsafe-reports-arq-thorntail</reportsDirectory>
+              <summaryFile>${project.build.directory}/failsafe-reports-arq-thorntail/failsafe-summary.xml</summaryFile>
               <systemProperties>
                 <arquillian.xml>arquillian-thorntail.xml</arquillian.xml>
               </systemProperties>
@@ -308,6 +310,8 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <skipITs>false</skipITs>
+              <reportsDirectory>${project.build.directory}/failsafe-reports-arq</reportsDirectory>
+              <summaryFile>${project.build.directory}/failsafe-reports-arq/failsafe-summary.xml</summaryFile>
               <systemProperties>
                 <arquillian.xml>arquillian-wildfly.xml</arquillian.xml>
                 <!-- qualifier used to identify the Wildfly cluster -->


### PR DESCRIPTION
This PR addresses [JBTM-3526](https://issues.redhat.com/browse/JBTM-3526)

!MAIN !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
