### PR TITLE
[JBTM-3537] using CDI.current().select() to get LRAParticipantRegistry

### DIFF
--- a/rts/lra/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.lra.annotation.Status;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 import org.eclipse.microprofile.lra.annotation.ws.rs.Leave;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ProcessingException;
@@ -385,6 +386,13 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
             String timeLimitStr = terminateURIs.get(TIMELIMIT_PARAM_NAME);
             long timeLimit = timeLimitStr == null ? DEFAULT_TIMEOUT_MILLIS : Long.parseLong(timeLimitStr);
 
+            if (lraParticipantRegistry == null) {
+                try {
+                    lraParticipantRegistry = CDI.current().select(LRAParticipantRegistry.class).get();
+                } catch (IllegalStateException ise) {
+                    // ok, can be null
+                }
+            }
             LRAParticipant participant = lraParticipantRegistry != null ?
                 lraParticipantRegistry.getParticipant(resourceInfo.getResourceClass().getName()) : null;
 

--- a/rts/lra/proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRAParticipantResource.java
+++ b/rts/lra/proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/LRAParticipantResource.java
@@ -29,6 +29,7 @@ import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.Status;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -110,6 +111,13 @@ public class LRAParticipantResource {
     }
 
     private LRAParticipant getParticipant(String participantId) {
+        if (lraParticipantRegistry == null) {
+            try {
+                lraParticipantRegistry = CDI.current().select(LRAParticipantRegistry.class).get();
+            } catch (IllegalStateException ise) {
+                // ok, can be null
+            }
+        }
         LRAParticipant participant = lraParticipantRegistry.getParticipant(participantId);
         if (participant == null) {
             throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).


### PR DESCRIPTION
as a workaround for WildFly integration (WFLY-14869)

https://issues.redhat.com/browse/JBTM-3537

LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
