### PR TITLE
JBTM 3538 Fix for TCK timeout test failures

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
@@ -554,7 +554,11 @@ public class LongRunningAction extends BasicAction {
             updateState(LRAStatus.Closing);
         } // otherwise status is (cancel ? LRAStatus.Cancelled : LRAStatus.Closed)
 
-        finishTime = LocalDateTime.now(ZoneOffset.UTC);
+        if (isTopLevel()) {
+            // note that we don't update the finish time for nested LRAs since their final state depends on the parent
+            finishTime = LocalDateTime.now(ZoneOffset.UTC);
+        }
+
         trace_progress("doEnd update finishTime");
 
         updateState(); // ensure the record is removed if it finished otherwise persisted the state

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
@@ -402,6 +402,11 @@ public class LongRunningAction extends BasicAction {
     public int finishLRA(boolean cancel) {
         ReentrantLock lock = null;
 
+        // check whether the transaction should cancel due to a timeout:
+        if (finishTime != null && !cancel && ChronoUnit.MILLIS.between(LocalDateTime.now(ZoneOffset.UTC), finishTime) <= 0) {
+            cancel = true;
+        }
+
         try {
             lock = lraService.tryLockTransaction(getId());
 

--- a/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
+++ b/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/spi/NarayanaLRARecovery.java
@@ -57,14 +57,7 @@ public class NarayanaLRARecovery implements LRARecoveryService {
 
     @Override
     public void waitForCallbacks(URI lraId) {
-        // for tests that do not involve timeouts no action is needed,
-        // but there are races on time sensitive tests (depending upon how busy the test system is).
-        // To handle these cases introduce an arbitrary 1000 ms delay (note that since LRA provides
-        // no real-time guarantees, introducing the delay is a valid approach):
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException ignore) {
-        }
+        // no action needed
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3538

This PR is designed to fix timeout test instabilities.
It is in 4 separate, but related, commits. It also reverts the recent change to use the reaper for timeouts since that does not work with WildFly (we can revisit that in a future commit after discussion with the resteasy team).
After fixing the timeout instability I found that 3 of the nested LRA tests failed which I fixed in the last commit.


LRA
!MAIN !CORE !QA_JTA !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !QA_JTS_JACORB !BLACKTIE !XTS !PERF NO_WIN !RTS !AS_TESTS !TOMCAT !JACOCO
