### PR TITLE
remove reference to MAIN

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ Please refer to our [guidelines for making contributions](https://github.com/jbo
 
 The build axis can be controlled by prefixing a ! on the following as appropriate:
 
-MAIN CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB PERF LRA !NO_WIN DB_TESTS mysql db2 postgres oracle
+CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB PERF LRA !NO_WIN DB_TESTS mysql db2 postgres oracle


### PR DESCRIPTION
script only change. I've removed `MAIN` from the PR comment since `MAIN` does not do anything.

@tomjenkinson will you review this. I removed MAIN but there is a reference to in a test in `scripts/hudson/narayana.sh` that you added (sha 49d61042c51113e72a277c844902edad93c62e82) that I don't understand so I left it in there (but with my change the test definitely has no effect).
