### PR TITLE
JBTM-3544 fix previous commit by removing two unwanted dependencies

### DIFF
--- a/XTS/pom.xml
+++ b/XTS/pom.xml
@@ -89,19 +89,6 @@
                 <version>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec}</version>
 		<scope>provided</scope>
              </dependency>
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>3.0.1</version>
-                <scope>runtime</scope>
-            </dependency>
-
-	     <dependency>
-                <groupId>jakarta.xml.ws</groupId>
-                <artifactId>jakarta.xml.ws-api</artifactId>
-                <version>3.0.1</version>
-		<scope>provided</scope>
-             </dependency>
 	     <dependency>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-ri</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3544

The previous PR added two unwanted jakarta dependencies to the XTS parent pom  I added these inadvertently.

CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !LRA !NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle
