### PR TITLE
JBTM-3544 remove ant task that updates jar manifest - it replaces all…

### DIFF
--- a/ArjunaJTS/integration-jakarta/pom.xml
+++ b/ArjunaJTS/integration-jakarta/pom.xml
@@ -125,45 +125,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/ArjunaJTS/narayana-jts-idlj-jakarta/pom.xml
+++ b/ArjunaJTS/narayana-jts-idlj-jakarta/pom.xml
@@ -125,45 +125,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/XTS/bridge-jakarta/pom.xml
+++ b/XTS/bridge-jakarta/pom.xml
@@ -131,45 +131,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/XTS/jbossxts-jakarta/pom.xml
+++ b/XTS/jbossxts-jakarta/pom.xml
@@ -70,29 +70,6 @@
             </configuration>
           </execution>
           <execution>
-            <id>change-manifest</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-api.jar">
-                  <manifest>
-                    <attribute name="Specification-Title" value="${project.name}"/>
-                    <attribute name="Specification-Version" value="2.0"/>
-                    <attribute name="Specification-Vendor" value="Eclipse"/>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"/>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"/>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"/>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"/>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
-          <execution>
             <id>transform-sources-jar</id>
             <phase>package</phase>
             <goals>

--- a/compensations-jakarta/pom.xml
+++ b/compensations-jakarta/pom.xml
@@ -128,45 +128,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/rts/at/bridge-jakarta/pom.xml
+++ b/rts/at/bridge-jakarta/pom.xml
@@ -127,45 +127,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/rts/at/integration-jakarta/pom.xml
+++ b/rts/at/integration-jakarta/pom.xml
@@ -130,45 +130,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/rts/at/tx-jakarta/pom.xml
+++ b/rts/at/tx-jakarta/pom.xml
@@ -125,45 +125,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/rts/at/util-jakarta/pom.xml
+++ b/rts/at/util-jakarta/pom.xml
@@ -126,45 +126,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/txbridge-jakarta/pom.xml
+++ b/txbridge-jakarta/pom.xml
@@ -131,45 +131,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/txframework-jakarta/pom.xml
+++ b/txframework-jakarta/pom.xml
@@ -128,45 +128,6 @@
               </target>
             </configuration>
           </execution>
-          <execution>
-            <id>change-manifest</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <target>
-                <echo>update manifest</echo>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} classes"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-sources.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} sources"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-                <jar jarfile="${project.build.directory}/${project.build.finalName}-javadoc.jar">
-                  <manifest>
-                    <attribute name="Implementation-Title" value="${project.name} javadocs"></attribute>
-                    <attribute name="Implementation-Version" value="${project.version} (revision: ${buildNumber})"></attribute>
-                    <attribute name="arjuna-scm-revision" value="${buildNumber}"></attribute>
-                    <attribute name="arjuna-properties-file" value="jbossts-properties.xml"></attribute>
-                    <attribute name="arjuna-builder" value="JBoss Inc. [${user.name}] ${os.name} ${os.version} ${buildproperty.date}"></attribute>
-                  </manifest>
-                </jar>
-              </target>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3544

This PR follows on from #1920 and removes the ant task that updates the manifest (since it is overwriting the contents of the jar).

CORE !TOMCAT !AS_TESTS RTS !JACOCO XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle