### PR TITLE
JBTM-3544 add missing source jars

### DIFF
--- a/rts/at/tx-jakarta/pom.xml
+++ b/rts/at/tx-jakarta/pom.xml
@@ -129,6 +129,7 @@
       </plugin>
     </plugins>
   </build>
+
   <profiles>
     <profile>
       <id>release</id>
@@ -151,19 +152,40 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <source>8</source>
-              <detectOfflineLinks>false</detectOfflineLinks>
-            </configuration>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>create_javadocs</id>
+                <id>sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>attach-artifact</goal>
                 </goals>
-                <phase>prepare-package</phase>
+                <phase>package</phase>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-sources.jar</file>
+                      <type>jar</type>
+                      <classifier>sources</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
+              </execution>
+              <execution>
+                <id>javadoc</id>
+                <goals>
+                  <goal>attach-artifact</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar</file>
+                      <type>jar</type>
+                      <classifier>javadoc</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/rts/at/util-jakarta/pom.xml
+++ b/rts/at/util-jakarta/pom.xml
@@ -152,19 +152,40 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <detectOfflineLinks>false</detectOfflineLinks>
-              <failOnError>false</failOnError>
-            </configuration>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>create_javadocs</id>
+                <id>sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>attach-artifact</goal>
                 </goals>
-                <phase>prepare-package</phase>
+                <phase>package</phase>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-sources.jar</file>
+                      <type>jar</type>
+                      <classifier>sources</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
+              </execution>
+              <execution>
+                <id>javadoc</id>
+                <goals>
+                  <goal>attach-artifact</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar</file>
+                      <type>jar</type>
+                      <classifier>javadoc</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/txbridge-jakarta/pom.xml
+++ b/txbridge-jakarta/pom.xml
@@ -161,32 +161,36 @@
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>add-source</id>
+                <id>sources</id>
                 <goals>
-                  <goal>add-source</goal>
+                  <goal>attach-artifact</goal>
                 </goals>
-                <phase>generate-sources</phase>
+                <phase>package</phase>
                 <configuration>
-                  <sources>
-                    <source>src/main/java</source>
-                  </sources>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-sources.jar</file>
+                      <type>jar</type>
+                      <classifier>sources</classifier>
+                    </artifact>
+                  </artifacts>
                 </configuration>
               </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <source>8</source>
-              <detectOfflineLinks>false</detectOfflineLinks>
-            </configuration>
-            <executions>
               <execution>
-                <id>attach-javadocs</id>
+                <id>javadoc</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>attach-artifact</goal>
                 </goals>
+                <phase>package</phase>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar</file>
+                      <type>jar</type>
+                      <classifier>javadoc</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3544

This PR follows on from #1920 and adds some missing source jars.

CORE !TOMCAT !AS_TESTS RTS !JACOCO XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !LRA NO_WIN !DB_TESTS !mysql !db2 !postgres !oracle