### PR TITLE
Backport Updates to Oracle (and other DBs) to Narayana 5.11

### DIFF
--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -274,8 +274,7 @@
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
 				<version>${version.com.oracle}</version>
-				<scope>system</scope>
-				<systemPath>${orson.jar.location}/../qa/dbdrivers/ojdbc8.jar</systemPath>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 		<build>

--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -239,6 +239,7 @@
             </plugins>
         </build>
     </profile>
+    <!--
 	<profile>
 		<id>sybase-jdbc-store</id>
 		<dependencies>
@@ -267,6 +268,7 @@
 			</plugins>
 		</build>
 	</profile>
+	-->
 	<profile>
 		<id>oracle-jdbc-store</id>
 		<dependencies>
@@ -325,7 +327,7 @@
 		<id>postgres-jdbc-store</id>
 		<dependencies>
 			<dependency>
-				<groupId>postgresql</groupId>
+				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
 				<version>${version.postgresql}</version>
 				<scope>test</scope>
@@ -402,7 +404,7 @@
 			</plugins>
 		</build>
 	</profile>
-
+    <!--
 	<profile>
 		<id>mssql-jdbc-store</id>
 		<dependencies>
@@ -431,6 +433,7 @@
 			</plugins>
 		</build>
 	</profile>
+	-->
   <profile>
     <id>community</id>
     <dependencies>

--- a/ArjunaCore/arjuna/src/test/resources/mysqljbossts-properties.xml
+++ b/ArjunaCore/arjuna/src/test/resources/mysqljbossts-properties.xml
@@ -1,15 +1,15 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
 	<entry key="ObjectStoreEnvironmentBean.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
-	<entry key="ObjectStoreEnvironmentBean.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource;DatabaseName=jbossts;ServerName=narayanaci1.eng.hst.ams2.redhat.com;PortNumber=3306;User=dtf11;Password=dtf11</entry>
+	<entry key="ObjectStoreEnvironmentBean.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=com.mysql.cj.jdbc.MysqlDataSource;DatabaseName=jbossts;ServerName=narayanaci1.eng.hst.ams2.redhat.com;PortNumber=3306;User=dtf11;Password=dtf11</entry>
 	<entry key="ObjectStoreEnvironmentBean.tablePrefix">Action</entry>
 	<entry key="ObjectStoreEnvironmentBean.dropTable">true</entry>
 	<entry key="ObjectStoreEnvironmentBean.stateStore.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
-	<entry key="ObjectStoreEnvironmentBean.stateStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource;DatabaseName=jbossts;ServerName=narayanaci1.eng.hst.ams2.redhat.com;PortNumber=3306;User=dtf11;Password=dtf11</entry>
+	<entry key="ObjectStoreEnvironmentBean.stateStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=com.mysql.cj.jdbc.MysqlDataSource;DatabaseName=jbossts;ServerName=narayanaci1.eng.hst.ams2.redhat.com;PortNumber=3306;User=dtf11;Password=dtf11</entry>
 	<entry key="ObjectStoreEnvironmentBean.stateStore.tablePrefix">stateStore</entry>
 	<entry key="ObjectStoreEnvironmentBean.stateStore.dropTable">true</entry>
 	<entry key="ObjectStoreEnvironmentBean.communicationStore.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
-	<entry key="ObjectStoreEnvironmentBean.communicationStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource;DatabaseName=jbossts;ServerName=narayanaci1.eng.hst.ams2.redhat.com;PortNumber=3306;User=dtf11;Password=dtf11</entry>
+	<entry key="ObjectStoreEnvironmentBean.communicationStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.DynamicDataSourceJDBCAccess;ClassName=com.mysql.cj.jdbc.MysqlDataSource;DatabaseName=jbossts;ServerName=narayanaci1.eng.hst.ams2.redhat.com;PortNumber=3306;User=dtf11;Password=dtf11</entry>
 	<entry key="ObjectStoreEnvironmentBean.communicationStore.tablePrefix">Communication</entry>
 	<entry key="ObjectStoreEnvironmentBean.communicationStore.dropTable">true</entry>
     <entry key="CoreEnvironmentBean.nodeIdentifier">1</entry>

--- a/ArjunaCore/arjuna/src/test/resources/oraclejbossts-properties.xml
+++ b/ArjunaCore/arjuna/src/test/resources/oraclejbossts-properties.xml
@@ -1,15 +1,15 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
 	<entry key="ObjectStoreEnvironmentBean.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
-	<entry key="ObjectStoreEnvironmentBean.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;ClassName=oracle.jdbc.pool.OracleDataSource;DriverType=thin;ServerName=narayanaci1.eng.hst.ams2.redhat.com;NetworkProtocol=tcp;DatabaseName=XE;PortNumber=1521;User=dtf11;Password=dtf11</entry>
+	<entry key="ObjectStoreEnvironmentBean.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;ClassName=oracle.jdbc.pool.OracleDataSource;DriverType=thin;ServerName=narayanaci1.eng.hst.ams2.redhat.com;NetworkProtocol=tcp;ServiceName=XEPDB1;PortNumber=1521;User=dtf11;Password=dtf11</entry>
 	<entry key="ObjectStoreEnvironmentBean.tablePrefix">Action</entry>
 	<entry key="ObjectStoreEnvironmentBean.dropTable">true</entry>
 	<entry key="ObjectStoreEnvironmentBean.stateStore.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
-	<entry key="ObjectStoreEnvironmentBean.stateStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;ClassName=oracle.jdbc.pool.OracleDataSource;DriverType=thin;ServerName=narayanaci1.eng.hst.ams2.redhat.com;NetworkProtocol=tcp;DatabaseName=XE;PortNumber=1521;User=dtf11;Password=dtf11</entry>
+	<entry key="ObjectStoreEnvironmentBean.stateStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;ClassName=oracle.jdbc.pool.OracleDataSource;DriverType=thin;ServerName=narayanaci1.eng.hst.ams2.redhat.com;NetworkProtocol=tcp;ServiceName=XEPDB1;PortNumber=1521;User=dtf11;Password=dtf11</entry>
 	<entry key="ObjectStoreEnvironmentBean.stateStore.tablePrefix">stateStore</entry>
 	<entry key="ObjectStoreEnvironmentBean.stateStore.dropTable">true</entry>
 	<entry key="ObjectStoreEnvironmentBean.communicationStore.objectStoreType">com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore</entry>
-	<entry key="ObjectStoreEnvironmentBean.communicationStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;ClassName=oracle.jdbc.pool.OracleDataSource;DriverType=thin;ServerName=narayanaci1.eng.hst.ams2.redhat.com;NetworkProtocol=tcp;DatabaseName=XE;PortNumber=1521;User=dtf11;Password=dtf11</entry>
+	<entry key="ObjectStoreEnvironmentBean.communicationStore.jdbcAccess">com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;ClassName=oracle.jdbc.pool.OracleDataSource;DriverType=thin;ServerName=narayanaci1.eng.hst.ams2.redhat.com;NetworkProtocol=tcp;ServiceName=XEPDB1;PortNumber=1521;User=dtf11;Password=dtf11</entry>
 	<entry key="ObjectStoreEnvironmentBean.communicationStore.tablePrefix">Communication</entry>
 	<entry key="ObjectStoreEnvironmentBean.communicationStore.dropTable">true</entry>
     <entry key="CoreEnvironmentBean.nodeIdentifier">1</entry>

--- a/ArjunaJTA/jdbc/pom.xml
+++ b/ArjunaJTA/jdbc/pom.xml
@@ -179,7 +179,7 @@
 		<id>postgresql</id>
 		<dependencies>
 			<dependency>
-				<groupId>postgresql</groupId>
+				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>
 				<version>${version.postgresql}</version>
 			</dependency>

--- a/ArjunaJTA/jta/pom.xml
+++ b/ArjunaJTA/jta/pom.xml
@@ -412,8 +412,7 @@
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
 				<version>${version.com.oracle}</version>
-				<systemPath>${orson.jar.location}/../qa/dbdrivers/ojdbc8.jar</systemPath>
-				<scope>system</scope>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</profile>

--- a/ArjunaJTA/jta/pom.xml
+++ b/ArjunaJTA/jta/pom.xml
@@ -198,7 +198,7 @@
       <scope>test</scope>
     </dependency>
 	<dependency>
-		<groupId>postgresql</groupId>
+		<groupId>org.postgresql</groupId>
 		<artifactId>postgresql</artifactId>
 		<version>${version.postgresql}</version>
 		<scope>test</scope>
@@ -317,9 +317,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jumpmind.symmetric.jdbc</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.2-1002-jdbc4</version>
+            <version>${version.postgresql}</version>
             <scope>test</scope>
         </dependency>
 
@@ -394,6 +394,7 @@
 				<version>${version.com.ibm}</version>
 				<scope>test</scope>
 			</dependency>
+            <!--
 			<dependency>
 				<groupId>com.microsoft.sqlserver</groupId>
 				<artifactId>sqljdbc4</artifactId>
@@ -408,6 +409,7 @@
 				<systemPath>${orson.jar.location}/../qa/dbdrivers/jConnect-6_0/classes/jconn3.jar</systemPath>
 				<scope>system</scope>
 			</dependency>
+			-->
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/PerformanceTestCommitMarkableResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/PerformanceTestCommitMarkableResource.java
@@ -61,8 +61,8 @@ import com.arjuna.ats.arjuna.recovery.RecoveryModule;
 import com.arjuna.ats.internal.jta.recovery.arjunacore.CommitMarkableResourceRecordRecoveryModule;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
-import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
-import com.mysql.jdbc.jdbc2.optional.MysqlXADataSource;
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlXADataSource;
 
 import org.junit.Assert;
 

--- a/ArjunaJTA/spi/pom.xml
+++ b/ArjunaJTA/spi/pom.xml
@@ -117,9 +117,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jumpmind.symmetric.jdbc</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.2-1002-jdbc4</version>
+            <version>${version.postgresql}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ArjunaJTA/spi/src/test/java/io/narayana/spi/util/XADSWrapperObjectFactory.java
+++ b/ArjunaJTA/spi/src/test/java/io/narayana/spi/util/XADSWrapperObjectFactory.java
@@ -36,7 +36,7 @@ public class XADSWrapperObjectFactory implements ObjectFactory {
         put("org.h2.Driver", "org.h2.jdbcx.JdbcDataSource");
         put("oracle.jdbc.driver.OracleDriver", "oracle.jdbc.xa.client.OracleXADataSource");
         put("com.microsoft.sqlserver.jdbc.SQLServerDriver", "com.microsoft.sqlserver.jdbc.SQLServerXADataSource"); // no setPassword
-        put("com.mysql.jdbc.Driver", "com.mysql.jdbc.jdbc2.optional.MysqlXADataSource");
+        put("com.mysql.cj.jdbc.Driver", "com.mysql.cj.jdbc.MysqlXADataSource");
         put("com.ibm.db2.jcc.DB2Driver", "com.ibm.db2.jcc.DB2XADataSource"); // for DB2 version 8.2      // no setPassword
         put("com.sybase.jdbc3.jdbc.SybDriver", "com.sybase.jdbc3.jdbc.SybXADataSource");  // no setPassword
     }};
@@ -98,7 +98,7 @@ public class XADSWrapperObjectFactory implements ObjectFactory {
             wrapper.setProperty("driverType", "thin");
         } else if( driver.equals("com.microsoft.sqlserver.jdbc.SQLServerDriver")) {
             wrapper.setProperty("sendStringParametersAsUnicode", false);
-        } else if( driver.equals("com.mysql.jdbc.Driver")) {
+        } else if( driver.equals("com.mysql.cj.jdbc.Driver")) {
 
             // Note: MySQL XA only works on InnoDB tables.
             // set 'default-storage-engine=innodb' in e.g. /etc/my.cnf

--- a/ArjunaJTA/spi/src/test/resources/module.xml
+++ b/ArjunaJTA/spi/src/test/resources/module.xml
@@ -9,7 +9,7 @@
         <!-- The next two are test dependencies - TODO remove them -->
         <module name="jnpserver" slot="5.0.3.GA"/>
         <module name="org.h2" slot="1.3.168"/>
-        <module name="org.jumpmind.symmetric.jdbc.postgresql" slot="9.2-1002-jdbc4"/>
+        <module name="org.postgresql" slot="42.2.20"/>
         <module name="jboss.logging" slot="3.1.3.GA"/>
     </dependencies>
 </module>

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ There are three types of tests in the Narayana repository.
   is about running commands:
 
       cd qa/
-      ant -Ddriver.url=file:///home/hudson/dbdrivers get.drivers dist
       ant -f run-tests.xml ci-tests
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -468,8 +468,8 @@
     <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
     <version.com.oracle>18.3.0.0</version.com.oracle>
     <version.com.ibm>11.5.0.0</version.com.ibm>
-    <version.postgresql>9.0-801.jdbc4</version.postgresql>
-    <version.mysql>5.1.28</version.mysql>
+    <version.postgresql>42.2.20</version.postgresql>
+    <version.mysql>8.0.25</version.mysql>
     <version.mariadb>1.2.2</version.mariadb>
     <version.com.microsoft.sqlserver>mssql2005_sqljdbc_2.0</version.com.microsoft.sqlserver>
     <version.sun.jdk>jdk</version.sun.jdk>

--- a/qa/README.txt
+++ b/qa/README.txt
@@ -63,7 +63,7 @@ To debug spawned processes, edit TaskImpl.properties to set debug command line a
 enable a robust debugging mode by setting a system property tasks.remote.debug. This is set in the junit
 process and will set debugging ports up incrementing from port 5000 for the first spawned process.
 
-For jdbc tests, ensure the required drivers are present (see build.xml get.drivers target)
+For jdbc tests, ensure the required drivers are present (cd qa && mvn install)
 and create a suitable config/jdbc_profiles/<name_of_testnode_host>/ file by copying the existing
 config/jdbc_profiles/_template/ directory or rely on the one in config/jdbc_profiles/default
 By convention each test node has two accounts on each database server, with names of '<testnode_hostname>1'

--- a/qa/TaskImpl.properties.template
+++ b/qa/TaskImpl.properties.template
@@ -43,12 +43,10 @@ COMMAND_LINE_2=\
   ${path.separator}ext${file.separator}jboss-profiler-jvmti.jar${path.separator}ext${file.separator}jboss-logging-spi.jar\
   ${path.separator}tests${file.separator}build${file.separator}classes${file.separator}\
   ${path.separator}dbdrivers${file.separator}selected_dbdriver${file.separator}*\
-  ${path.separator}dbdrivers${file.separator}DB2_v9.7${file.separator}db2jcc.jar\
-  ${path.separator}dbdrivers${file.separator}jConnect-6_0${file.separator}classes${file.separator}jconn3.jar\
-  ${path.separator}dbdrivers${file.separator}mssql2005_sqljdbc_2.0${file.separator}enu${file.separator}sqljdbc4.jar\
-  ${path.separator}dbdrivers${file.separator}mysql-connector-java-5.1.8-bin.jar\
+  ${path.separator}dbdrivers${file.separator}jcc.jar\
+  ${path.separator}dbdrivers${file.separator}mysql-connector-java.jar\
   ${path.separator}dbdrivers${file.separator}ojdbc8.jar\
-  ${path.separator}dbdrivers${file.separator}postgresql-8.3-605.jdbc4.jar\
+  ${path.separator}dbdrivers${file.separator}postgresql.jar\
   ${path.separator}ext${file.separator}log4j.jar\
   ${path.separator}ext${file.separator}netty.jar
 

--- a/qa/build.xml
+++ b/qa/build.xml
@@ -21,7 +21,6 @@
 -->
 <project name="JBossTS QA Suite Distribution" default="dist">
   <property environment="env"/>
-  <property name="driver.home" value="dbdrivers"/>
   <property name="orbtype" value="idlj"/>
   <!-- set this property to the location of a JBossTS JTA/JTS build or installation -->
   <property name="org.jboss.jbossts.qa.ts.home" location="dist"/>
@@ -37,28 +36,6 @@
   <property name="org.jboss.jbossts.qa.server_manager_location" location="ext/jboss-server-manager-0.1.1.GA.jar"/>
   <property name="org.jboss.jbossts.qa.dist.buildroot" location="build"/>
 
-  <target name="get.drivers">
-    <!--
-        https://docspace.corp.redhat.com/clearspace/docs/DOC-16080
-        http://www.jboss.com/products/platforms/application/supportedconfigurations/
-        Files names below should be matched to those in run-tests.xml
-        https://docspace.corp.redhat.com/clearspace/community/bu/middleware/jboss-qe/lab
-        server connection params in config/jdbc_profiles/
-        -->
-    <mkdir dir="${driver.home}/mssql2005_sqljdbc_2.0/enu"/>
-    <get src="${driver.url}/sqljdbc_2.0/enu/sqljdbc.jar" dest="${driver.home}/mssql2005_sqljdbc_2.0/enu/sqljdbc.jar"/>
-    <get src="${driver.url}/sqljdbc_2.0/enu/sqljdbc4.jar" dest="${driver.home}/mssql2005_sqljdbc_2.0/enu/sqljdbc4.jar"/>
-    <!-- pgsql 8.1.408 is broken, use something more recent. -->
-    <get src="${driver.url}/postgresql-8.3-605.jdbc4.jar" dest="${driver.home}/postgresql-8.3-605.jdbc4.jar"/>
-    <!-- mysql server version 5 is the first with XA support, do use anything less.
-	 		driver versions before 5.0.5 are broken, don't use them either. -->
-    <get src="${driver.url}/mysql-connector-java-5.1.8-bin.jar" dest="${driver.home}/mysql-connector-java-5.1.8-bin.jar"/>
-    <mkdir dir="${driver.home}/DB2_v9.7"/>
-    <get src="${driver.url}/DB2_v9.7/db2jcc.jar" dest="${driver.home}/DB2_v9.7/db2jcc.jar"/>
-    <get src="${driver.url}/DB2_v9.7/db2jcc_license_cu.jar" dest="${driver.home}/DB2_v9.7/db2jcc_license_cu.jar"/>
-    <mkdir dir="${driver.home}/jConnect-6_0/classes"/>
-    <get src="${driver.url}/jConnect-6_0/classes/jconn3.jar" dest="${driver.home}/jConnect-6_0/classes/jconn3.jar"/>
-  </target>
   <target name="buildtype">
     <available file="${org.jboss.jbossts.qa.ts.home}/narayana-full-${narayana.version}/lib/jbossjts.jar" property="buildtype" value="jts"/>
     <available file="${org.jboss.jbossts.qa.ts.home}/narayana-full-${narayana.version}/lib/narayana-jta.jar" property="buildtype" value="jta"/>
@@ -69,7 +46,6 @@
         <isset property="as"/>
       </and>
     </condition>
-    <available file="${driver.home}" property="have.dbdrivers" value="true"/>
   </target>
   <target name="clean" depends="clean-tests"/>
   <target name="clean-tests">

--- a/qa/config/jdbc_profiles/_template/JDBCProfiles
+++ b/qa/config/jdbc_profiles/_template/JDBCProfiles
@@ -231,7 +231,7 @@ DB2_PGSQL_JNDI_Host=localhost
 ##########################################################################
 
 DB_MYSQL_JNDI_NumberOfDrivers=2
-DB_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB_MYSQL_JNDI_Binding=mysql
 DB_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql
@@ -246,7 +246,7 @@ DB_MYSQL_JNDI_Host=localhost
 ######################################################################
 
 DB1_MYSQL_JNDI_NumberOfDrivers=2
-DB1_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB1_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB1_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB1_MYSQL_JNDI_Binding=mysql1
 DB1_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql1
@@ -256,7 +256,7 @@ DB1_MYSQL_JNDI_DatabaseName=test
 DB1_MYSQL_JNDI_Host=localhost
 
 DB2_MYSQL_JNDI_NumberOfDrivers=2
-DB2_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB2_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB2_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB2_MYSQL_JNDI_Binding=mysql2
 DB2_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql2

--- a/qa/config/jdbc_profiles/default/JDBCProfiles
+++ b/qa/config/jdbc_profiles/default/JDBCProfiles
@@ -86,7 +86,7 @@ DB1_THIN_JNDI_Binding=oracle_thin1
 DB1_THIN_JNDI_DatabaseURL=jdbc:arjuna:oracle_thin1
 DB1_THIN_JNDI_DatabaseUser=dtf11
 DB1_THIN_JNDI_DatabasePassword=dtf11
-DB1_THIN_JNDI_DatabaseName=XE
+DB1_THIN_JNDI_ServiceName=XEPDB1
 DB1_THIN_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 DB1_THIN_JNDI_Port=1521
 
@@ -97,6 +97,6 @@ DB2_THIN_JNDI_Binding=oracle_thin2
 DB2_THIN_JNDI_DatabaseURL=jdbc:arjuna:oracle_thin2
 DB2_THIN_JNDI_DatabaseUser=dtf12
 DB2_THIN_JNDI_DatabasePassword=dtf12
-DB2_THIN_JNDI_DatabaseName=XE
+DB2_THIN_JNDI_ServiceName=XEPDB1
 DB2_THIN_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 DB2_THIN_JNDI_Port=1521

--- a/qa/config/jdbc_profiles/default/JDBCProfiles
+++ b/qa/config/jdbc_profiles/default/JDBCProfiles
@@ -104,7 +104,7 @@ DB2_PGSQL_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 # exit
  
 DB1_MYSQL_JNDI_NumberOfDrivers=2
-DB1_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB1_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB1_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB1_MYSQL_JNDI_Binding=mysql1
 DB1_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql1
@@ -114,7 +114,7 @@ DB1_MYSQL_JNDI_DatabaseName=jbossts
 DB1_MYSQL_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 
 DB2_MYSQL_JNDI_NumberOfDrivers=2
-DB2_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB2_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB2_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB2_MYSQL_JNDI_Binding=mysql2
 DB2_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql2

--- a/qa/config/jdbc_profiles/default/JDBCProfiles
+++ b/qa/config/jdbc_profiles/default/JDBCProfiles
@@ -27,46 +27,9 @@
 # be more likely to timeout.
 #########
 
-#DB2
-#https://hub.docker.com/r/ibmcom/db2/
-# docker run -itd --name db2-ci --privileged=true -e DB2INST1_PASSWORD=db2inst1-pwd -e LICENSE=accept -e DBNAME=BTDB1 -p 50000:50000 ibmcom/db2:latest db2start
-# docker exec -it db2-ci bash
-# Edit line 193 of /var/db2_setup/lib/setup_db2_instance.sh to change "${instance_name?}" to "db2inst1" from the line
-#useradd db2
-#passwd db2
-#exit
-#docker stop db2-ci
-#docker start db2-ci
-# Check for BTDB1 to be created
-#docker logs -f db2-ci
-#docker exec -it db2-ci bash
-#su - db2inst1
-#db2
-#CONNECT TO BTDB1
-#GRANT CONNECT ON DATABASE TO USER db2
-#quit
-
 ######################################################################
 # PostgreSQL JNDI Pair
 ######################################################################
-
-# docker run --name postgres-ci -e POSTGRES_USER="postgres" -e POSTGRES_PASSWORD="postgres" -d -p 5432:5432 postgres:9.4
-# docker start postgres-ci
-# docker exec -it postgres-ci bash
-# su - postgres
-# createdb jbossts
-# psql -h narayanaci1.eng.hst.ams2.redhat.com -p 5432 jbossts
-# CREATE USER dtf11 PASSWORD 'dtf11';
-# GRANT ALL ON DATABASE jbossts TO dtf11;
-# CREATE USER dtf12 PASSWORD 'dtf12';
-# GRANT ALL ON DATABASE jbossts TO dtf12;
-# ALTER DATABASE jbossts SET bytea_output TO 'escape';
-# \q
-# exit
-# sed -i "s/#max_prepared_transactions = 0/max_prepared_transactions = 100/g" ./var/lib/postgresql/data/postgresql.conf
-# exit
-# docker stop postgres-ci
-# docker start postgres-ci
 
 DB1_PGSQL_JNDI_NumberOfDrivers=2
 DB1_PGSQL_JNDI_Driver0=org.postgresql.Driver
@@ -91,17 +54,6 @@ DB2_PGSQL_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 ######################################################################
 # MySQL JNDI Pair
 ######################################################################
-
-# docker run --name mariadb-ci -e MYSQL_ROOT_PASSWORD="admin1234" -d -p 3306:3306 mariadb:latest
-# docker exec -it mariadb-ci bash
-# mysql -p
-# create database jbossts;
-# CREATE USER dtf11 IDENTIFIED BY 'dtf11';
-# grant all on jbossts.* to 'dtf11'@'%' identified by 'dtf11';
-# CREATE USER dtf12 IDENTIFIED BY 'dtf12';
-# grant all on jbossts.* to 'dtf12'@'%' identified by 'dtf12';
-# flush privileges;
-# exit
  
 DB1_MYSQL_JNDI_NumberOfDrivers=2
 DB1_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
@@ -126,32 +78,6 @@ DB2_MYSQL_JNDI_Host=narayanaci1.eng.hst.ams2.redhat.com
 ######################################################################
 # Oracle thin JNDI Pair
 ######################################################################
-
-# git clone https://github.com/oracle/docker-images.git
-# cd docker-images/OracleDatabase/SingleInstance/dockerfiles
-# Consider changes after https://github.com/oracle/docker-images/blob/main/OracleDatabase/SingleInstance/dockerfiles/18.4.0/Dockerfile.xe#L61 if https://github.com/fuzziebrain/docker-oracle-xe/issues/15#issuecomment-578452720 is relevant
-# ./buildContainerImage.sh -x -v 18.4.0
-
-# docker run --name oracle-ci -p 1521:1521 -p 5500:5500 -e ORACLE_PWD=oracle oracle/database:18.4.0-xe
-# Leave the docker container running and then in a second shell after waiting for the startup and even a bit longer
-
-# docker run --rm -ti oracle/database:18.4.0-xe sqlplus sys/oracle@narayanaci1.eng.hst.ams2.redhat.com:1521/XE as sysdba
-# If you get a prompt to login, this command is not working as expected. Close this container, wait a bit longer and then retry
-#   
-#   CREATE USER dtf11 IDENTIFIED BY dtf11; 
-#   GRANT CREATE SESSION, RESOURCE TO dtf11;
-#   ALTER USER dtf11 quota unlimited on USERS;
-#
-#   CREATE USER dtf12 IDENTIFIED BY dtf12;
-#   GRANT CREATE SESSION, RESOURCE TO dtf12;
-#   ALTER USER dtf12 quota unlimited on USERS;
-#
-#   alter system set processes=300 scope=spfile;
-#   shut immediate;
-#   exit
-#
-# Exit both shells docker run commands
-# docker start oracle-ci
 
 DB1_THIN_JNDI_NumberOfDrivers=2
 DB1_THIN_JNDI_Driver0=oracle.jdbc.driver.OracleDriver

--- a/qa/config/jdbc_profiles/haverstraw/JDBCProfiles
+++ b/qa/config/jdbc_profiles/haverstraw/JDBCProfiles
@@ -57,7 +57,7 @@ DB2_PGSQL_JNDI_Host=tywin.eng.hst.ams2.redhat.com
 # flush privileges;
  
 DB1_MYSQL_JNDI_NumberOfDrivers=2
-DB1_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB1_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB1_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB1_MYSQL_JNDI_Binding=mysql1
 DB1_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql1
@@ -67,7 +67,7 @@ DB1_MYSQL_JNDI_DatabaseName=jbossts
 DB1_MYSQL_JNDI_Host=tywin.eng.hst.ams2.redhat.com
 
 DB2_MYSQL_JNDI_NumberOfDrivers=2
-DB2_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB2_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB2_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB2_MYSQL_JNDI_Binding=mysql2
 DB2_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql2

--- a/qa/config/jdbc_profiles/jaime/JDBCProfiles
+++ b/qa/config/jdbc_profiles/jaime/JDBCProfiles
@@ -57,7 +57,7 @@ DB2_PGSQL_JNDI_Host=tywin.eng.hst.ams2.redhat.com
 # flush privileges;
  
 DB1_MYSQL_JNDI_NumberOfDrivers=2
-DB1_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB1_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB1_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB1_MYSQL_JNDI_Binding=mysql1
 DB1_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql1
@@ -67,7 +67,7 @@ DB1_MYSQL_JNDI_DatabaseName=jbossts
 DB1_MYSQL_JNDI_Host=tywin.eng.hst.ams2.redhat.com
 
 DB2_MYSQL_JNDI_NumberOfDrivers=2
-DB2_MYSQL_JNDI_Driver0=com.mysql.jdbc.Driver
+DB2_MYSQL_JNDI_Driver0=com.mysql.cj.jdbc.Driver
 DB2_MYSQL_JNDI_Driver1=com.arjuna.ats.jdbc.TransactionalDriver
 DB2_MYSQL_JNDI_Binding=mysql2
 DB2_MYSQL_JNDI_DatabaseURL=jdbc:arjuna:mysql2

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -190,7 +190,10 @@
 						org.apache.ant,
 						javax,
 						org.jboss.narayana,
-						com.oracle.database.jdbc
+						com.oracle.database.jdbc,
+						org.postgresql,
+						mysql,
+						com.ibm.db2
 					</excludeGroupIds>
 					<excludeArtifactIds>jboss-transaction-spi</excludeArtifactIds>
 					<outputDirectory>./ext</outputDirectory>
@@ -201,16 +204,23 @@
 					<stripVersion>true</stripVersion>
 				</configuration>
 
+				<!--
+				 Drivers of the used databases are downloaded directly from Maven repositories.
+				 The consumer of these drivers is the ant script "run-tests.xml", which is also
+				 the main script to run all tests in the QA module. The main reason to use DBs in
+				 the QA module is to test Narayana with different kinds of Object Stores
+				-->
+
 				<executions>
 					<execution>
-						<phase>install</phase>
 						<goals>
 							<goal>copy-dependencies</goal>
 						</goals>
+						<phase>install</phase>
 						<configuration>
 							<excludeGroupIds>*</excludeGroupIds>
 							<outputDirectory>${project.build.directory}/../dbdrivers</outputDirectory>
-							<includeArtifactIds>ojdbc8</includeArtifactIds>
+							<includeArtifactIds>ojdbc8, postgresql, mysql-connector-java, jcc</includeArtifactIds>
 						</configuration>
 					</execution>
 				</executions>
@@ -274,6 +284,21 @@
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc8</artifactId>
 			<version>${version.com.oracle}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${version.postgresql}</version>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>${version.mysql}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.ibm.db2</groupId>
+			<artifactId>jcc</artifactId>
+			<version>${version.com.ibm}</version>
 		</dependency>
 	</dependencies>
   <profiles>

--- a/qa/run-tests.xml
+++ b/qa/run-tests.xml
@@ -29,11 +29,23 @@
 
   For general tests plus JDBC (e.g. use on hudson):
     cd qa
-    ant get.drivers dist
+    mvn install
     ant -f run-tests.xml junit junit-jdbc
 
   Paths are relative to the JVM's working dir - don't expect to be able to execute this from anywhere but 'qa'.
 
+  The Narayana team suggests to run QA tests against the following databases:
+  - Oracle
+  - PostgreSql
+  - IBM DB2
+  - MariaDB
+  Nevertheless, tests for Sybase and Microsoft (MS) SQL are still available.
+  To provide DB drivers for these two databases, you should copy the actual
+  JAR files in the folder specified in the pom.xml for Oracle, PostgreSql,
+  IBM DB2 and MySQL (MariaDB). Please, also check this file (run-tests.xml)
+  to find out what filenames you should use to name those JAR files.
+
+  Server connection params can be found in config/jdbc_profiles/
 -->
 <project name="QA Tests for JBossTS" default="junit" basedir="."
          xmlns:jacoco="antlib:org.jacoco.ant">
@@ -239,7 +251,7 @@
   </target>
 
   <!-- copy the selected db driver out of the available set into the classpath.
-        See also build.xml get.drivers and TaskImpl.properties for classpath
+         See also TaskImpl.properties for classpath
      -->
   <macrodef name="install-dbdriver">
     <attribute name="files"/>
@@ -251,11 +263,13 @@
       </copy>
     </sequential>
   </macrodef>
-  <!--  JDBC tests.
+  <!--
+        JDBC tests.
         You'll need a qa/config/jdbc_profiles/<hostname>/JDBCProfiles file for your machine to run these ones,
-          although using the 'default' one is also an option.
-        Plus copies of the db drivers of course (try 'ant get.drivers' if inside the redhat network).
-        And a set of servers to run against. Did I mention it was complicated :-)
+        although using the 'default' one is also an option.
+        Plus copies of the db drivers of course (try 'mvn install' in the qa folder).
+        And a set of DB containers (MariaDB, PostgreSQL, IBM D2, Oracle) to run against.
+        Did I mention it was complicated :-)
     -->
   <target name="junit-jdbc" depends="junit-jdbc-testsuite">
     <fail if="failed-tests" message="some tests failed"/>
@@ -264,7 +278,17 @@
     <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="jdbcresources01_oracle_thin_jndi"/>
     <junit-tests tests="jdbcresources02_oracle_thin_jndi"/>
+    <install-dbdriver files="postgresql.jar"/>
+    <junit-tests tests="jdbcresources01_pgsql_jndi"/>
+    <junit-tests tests="jdbcresources02_pgsql_jndi"/>
+    <install-dbdriver files="mysql-connector-java.jar"/>
+    <junit-tests tests="jdbcresources01_mysql_jndi"/>
+    <junit-tests tests="jdbcresources02_mysql_jndi"/>
+    <install-dbdriver files="jcc.jar"/>
+    <junit-tests tests="jdbcresources01_ibmdb2_jndi"/>
+    <junit-tests tests="jdbcresources02_ibmdb2_jndi"/>
     <!-- mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
+    <!--
     <condition property="mssql.driver" value="sqljdbc4.jar">
       <equals arg1="${java.specification.version}" arg2="1.6"/>
     </condition>
@@ -272,31 +296,20 @@
     <install-dbdriver files="${mssql.driver}"/>
     <junit-tests tests="jdbcresources01_mssqlserver_jndi"/>
     <junit-tests tests="jdbcresources02_mssqlserver_jndi"/>
-    <install-dbdriver files="postgresql-8.3-605.jdbc4.jar"/>
-    <junit-tests tests="jdbcresources01_pgsql_jndi"/>
-    <junit-tests tests="jdbcresources02_pgsql_jndi"/>
-    <install-dbdriver files="mysql-connector-java-5.1.8-bin.jar"/>
-    <junit-tests tests="jdbcresources01_mysql_jndi"/>
-    <junit-tests tests="jdbcresources02_mysql_jndi"/>
     <install-dbdriver files="jconn3.jar"/>
     <junit-tests tests="jdbcresources01_sybase_jndi"/>
     <junit-tests tests="jdbcresources02_sybase_jndi"/>
-    <install-dbdriver files="db2*"/>
-    <junit-tests tests="jdbcresources01_ibmdb2_jndi"/>
-    <junit-tests tests="jdbcresources02_ibmdb2_jndi"/>
+    -->
   </target>
-  <target name="junit-jdbc-ncl" depends="junit-jdbc-ncl-testsuite">
-    <fail if="failed-tests" message="some tests failed"/>
-  </target>
-  <!-- the ncl office build server is not on vpn and only a subset of the dbs are available locally -->
+<!-- the ncl office build server is not on vpn and only a subset of the dbs are available locally -->
   <target name="junit-jdbc-ncl-testsuite">
     <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="jdbcresources01_oracle_thin_jndi"/>
     <junit-tests tests="jdbcresources02_oracle_thin_jndi"/>
-    <install-dbdriver files="mysql-connector-java-5.1.8-bin.jar"/>
+    <install-dbdriver files="mysql-connector-java.jar"/>
     <junit-tests tests="jdbcresources01_mysql_jndi"/>
     <junit-tests tests="jdbcresources02_mysql_jndi"/>
-    <install-dbdriver files="postgresql-8.3-605.jdbc4.jar"/>
+    <install-dbdriver files="postgresql.jar"/>
     <junit-tests tests="jdbcresources01_pgsql_jndi"/>
     <junit-tests tests="jdbcresources02_pgsql_jndi"/>
   </target>
@@ -305,20 +318,23 @@
     <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="crashrecovery11-oracle_jndi"/>
     <!--mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
+    <install-dbdriver files="jcc.jar"/>
+    <junit-tests tests="crashrecovery11-ibmdb2_jndi"/>
+    <install-dbdriver files="postgresql.jar"/>
+    <junit-tests tests="crashrecovery11-pgsql_jndi"/>
+    <install-dbdriver files="mysql-connector-java.jar"/>
+    <junit-tests tests="crashrecovery11-mysql_jndi"/>
+    <!-- mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
+    <!--
     <condition property="mssql.driver" value="sqljdbc4.jar">
       <equals arg1="${java.specification.version}" arg2="1.6"/>
     </condition>
     <property name="mssql.driver" value="sqljdbc.jar"/>
     <install-dbdriver files="${mssql.driver}"/>
     <junit-tests tests="crashrecovery11-mssqlserver_jndi"/>
-    <install-dbdriver files="db2*"/>
-    <junit-tests tests="crashrecovery11-ibmdb2_jndi"/>
-    <install-dbdriver files="postgresql-8.3-603.jdbc3.jar"/>
-    <junit-tests tests="crashrecovery11-pgsql_jndi"/>
-    <install-dbdriver files="mysql-connector-java-5.1.7-bin.jar"/>
-    <junit-tests tests="crashrecovery11-mysql_jndi"/>
     <install-dbdriver files="jconn3.jar"/>
     <junit-tests tests="crashrecovery11-sybase_jndi"/>
+    -->
     <fail if="failed-tests" message="some tests failed"/>
   </target>
   <target name="jta">
@@ -339,22 +355,24 @@
     <!-- jdbclocals01 : 6 tests, 2 minutes for each db -->
     <install-dbdriver files="ojdbc8.jar"/>
     <junit-tests tests="jdbclocals01_oracle_jndi"/>
+    <install-dbdriver files="postgresql.jar"/>
+    <junit-tests tests="jdbclocals01_pgsql_jndi"/>
+    <install-dbdriver files="mysql-connector-java.jar"/>
+    <junit-tests tests="jdbclocals01_mysql_jndi"/>
+    <install-dbdriver files="jcc.jar"/>
+    <junit-tests tests="jdbclocals01_ibmdb2_jndi"/>
+    <fail if="failed-tests" message="some tests failed"/>
     <!-- mssql needs different .jar for jdk 1.5 vs. 1.6 runtime -->
+    <!--
     <condition property="mssql.driver" value="sqljdbc4.jar">
       <equals arg1="${java.specification.version}" arg2="1.6"/>
     </condition>
     <property name="mssql.driver" value="sqljdbc.jar"/>
     <install-dbdriver files="${mssql.driver}"/>
     <junit-tests tests="jdbclocals01_mssqlserver_jndi"/>
-    <install-dbdriver files="postgresql-8.3-603.jdbc3.jar"/>
-    <junit-tests tests="jdbclocals01_pgsql_jndi"/>
-    <install-dbdriver files="mysql-connector-java-5.1.7-bin.jar"/>
-    <junit-tests tests="jdbclocals01_mysql_jndi"/>
     <install-dbdriver files="jconn3.jar"/>
     <junit-tests tests="jdbclocals01_sybase_jndi"/>
-    <install-dbdriver files="db2*"/>
-    <junit-tests tests="jdbclocals01_ibmdb2_jndi"/>
-    <fail if="failed-tests" message="some tests failed"/>
+    -->
   </target>
   <target name="performance">
     <!-- caution: perf tests are essentially regression tests and are only meaningful
@@ -438,7 +456,7 @@
         <equals arg1="${profile}" arg2="mysql" />
         <then>
           <property name="jdbcstore-profile" value="true" />
-          <property name="jdbc.datasource.class" value="com.mysql.jdbc.jdbc2.optional.MysqlDataSource" />
+          <property name="jdbc.datasource.class" value="com.mysql.cj.jdbc.MysqlDataSource" />
           <property name="jdbc.db.url" value="narayanaci1.eng.hst.ams2.redhat.com" />
           <property name="jdbc.db.name" value="jbossts" />
           <property name="jdbc.db.user" value="dtf11" />
@@ -486,6 +504,7 @@
           <property name="jdbc.db.properties" value=" -DObjectStoreEnvironmentBean.dropTable=false" />        	
         </then>
       </elseif>
+      <!--
       <elseif>
         <equals arg1="${profile}" arg2="mssql" />
         <then>
@@ -499,6 +518,7 @@
           <property name="jdbc.db.properties" value="" />
         </then>
       </elseif>
+      -->
       <elseif>
         <equals arg1="${profile}" arg2="hornetq" />
         <then>

--- a/qa/run-tests.xml
+++ b/qa/run-tests.xml
@@ -471,7 +471,7 @@
           <property name="jdbcstore-profile" value="true" />
           <property name="jdbc.datasource.class" value="oracle.jdbc.pool.OracleDataSource" />
           <property name="jdbc.db.url" value="narayanaci1.eng.hst.ams2.redhat.com" />
-          <property name="jdbc.db.name" value="XE" />
+          <property name="jdbc.db.name" value="XEPDB1" />
           <property name="jdbc.db.user" value="dtf11" />
           <property name="jdbc.db.password" value="dtf11" />
           <property name="jdbc.db.port" value="1521" />

--- a/qa/run-tests.xml
+++ b/qa/run-tests.xml
@@ -530,7 +530,15 @@
       <if>
         <equals arg1="${jdbcstore-profile}" arg2="true" />
         <then>
-          <var name="jdbcstore.database.properties" value="ClassName=${jdbc.datasource.class};DatabaseName=${jdbc.db.name};User=${jdbc.db.user};Password=${jdbc.db.password};ServerName=${jdbc.db.url};PortNumber=${jdbc.db.port}${jdbc.db.properties}" />
+          <if>
+            <equals arg1="${profile}" arg2="oracle" />
+            <then>
+              <var name="jdbcstore.database.properties" value="ClassName=${jdbc.datasource.class};ServiceName=${jdbc.db.name};User=${jdbc.db.user};Password=${jdbc.db.password};ServerName=${jdbc.db.url};PortNumber=${jdbc.db.port}${jdbc.db.properties}" />
+            </then>
+            <else>
+              <var name="jdbcstore.database.properties" value="ClassName=${jdbc.datasource.class};DatabaseName=${jdbc.db.name};User=${jdbc.db.user};Password=${jdbc.db.password};ServerName=${jdbc.db.url};PortNumber=${jdbc.db.port}${jdbc.db.properties}" />
+            </else>
+          </if>
           <var name="objectStoreElements" value="-DObjectStoreEnvironmentBean.objectStoreType=com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore -DObjectStoreEnvironmentBean.communicationStore.tablePrefix=Communication -DObjectStoreEnvironmentBean.communicationStore.objectStoreType=com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore -DObjectStoreEnvironmentBean.stateStore.tablePrefix=stateStore -DObjectStoreEnvironmentBean.stateStore.objectStoreType=com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCStore -DObjectStoreEnvironmentBean.tablePrefix=Action -DObjectStoreEnvironmentBean.jdbcAccess=com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;${jdbcstore.database.properties} -DObjectStoreEnvironmentBean.stateStore.jdbcAccess=com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;${jdbcstore.database.properties} -DObjectStoreEnvironmentBean.communicationStore.jdbcAccess=com.arjuna.ats.internal.arjuna.objectstore.jdbc.accessors.SimplePooledDynamicDataSourceJDBCAccess;${jdbcstore.database.properties} -DObjectStoreEnvironmentBean.createTable=false -DObjectStoreEnvironmentBean.communicationStore.createTable=false -DObjectStoreEnvironmentBean.stateStore.createTable=false" />
           <echo message="Running with JDBC object store settings - DB: ${jdbcstore.database.properties}"/>
           <echo message="MBean settings: ${objectStoreElements}"/>

--- a/qa/tests/src/org/jboss/jbossts/qa/Utils/JDBCProfileStore.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/Utils/JDBCProfileStore.java
@@ -103,6 +103,14 @@ public class JDBCProfileStore
 		return (String) _profile.get(profileName + "_DatabaseName");
 	}
 
+	public static String serviceName(String profileName)
+			throws Exception
+	{
+		loadProfile();
+
+		return (String) _profile.get(profileName + "_ServiceName");
+	}
+
 	public static String host(String profileName)
 			throws Exception
 	{

--- a/qa/tests/src/org/jboss/jbossts/qa/Utils/JNDIManager.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/Utils/JNDIManager.java
@@ -118,7 +118,7 @@ public class JNDIManager
 
                 xaDataSourceToBind = wrapper.getWrappedXADataSource();
 			}
-			else if( driver.equals("com.mysql.jdbc.Driver") || driver.equals("com.mysql.cj.jdbc.Driver")) {
+			else if(driver.equals("com.mysql.cj.jdbc.Driver")) {
 
 				// Note: MySQL XA only works on InnoDB tables.
 				// set 'default-storage-engine=innodb' in e.g. /etc/my.cnf
@@ -126,7 +126,7 @@ public class JNDIManager
 				// doing this config on a per connection basis instead is
 				// possible but would require lots of code changes :-(
 
-                XADataSourceReflectionWrapper wrapper = new XADataSourceReflectionWrapper(driver.equals("com.mysql.jdbc.Driver") ? "com.mysql.jdbc.jdbc2.optional.MysqlXADataSource" : "com.mysql.cj.jdbc.MysqlXADataSource");
+				XADataSourceReflectionWrapper wrapper = new XADataSourceReflectionWrapper("com.mysql.cj.jdbc.MysqlXADataSource");
 
                 wrapper.setProperty("databaseName", databaseName);
                 wrapper.setProperty("serverName", host);

--- a/qa/tests/src/org/jboss/jbossts/qa/Utils/JNDIManager.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/Utils/JNDIManager.java
@@ -32,12 +32,10 @@ package org.jboss.jbossts.qa.Utils;
 
 import com.arjuna.ats.internal.jdbc.DynamicClass;
 
-import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.sql.XADataSource;
-import java.util.Hashtable;
-import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * Uses reflection to configure the datasources to avoid the need for
@@ -53,6 +51,7 @@ public class JNDIManager
 			String driver = JDBCProfileStore.driver(profileName, 0 /*driver number*/);
 			String binding = JDBCProfileStore.binding(profileName);
 			String databaseName = JDBCProfileStore.databaseName(profileName);
+			String serviceName = JDBCProfileStore.serviceName(profileName);
 			String host = JDBCProfileStore.host(profileName);
 			String dynamicClass = JDBCProfileStore.databaseDynamicClass(profileName);
 			String databaseURL = JDBCProfileStore.databaseURL(profileName);
@@ -84,14 +83,17 @@ public class JNDIManager
 			}
 			else if (driver.equals("oracle.jdbc.driver.OracleDriver") || driver.equals("oracle.jdbc.OracleDriver"))
 			{
-				if (databaseName == null)
-				{
-					throw new Exception("DatabaseName was not specified for profile: " + profileName);
+				if (serviceName == null) {
+					if (databaseName != null) {
+						throw new Exception(String.format("DatabaseName cannot be used for profile: %s. Please, use ServiceName instead.", profileName));
+					}
+
+					throw new Exception("ServiceName was not specified for profile: " + profileName);
 				}
 
                 XADataSourceReflectionWrapper wrapper = new XADataSourceReflectionWrapper("oracle.jdbc.xa.client.OracleXADataSource");
 
-                wrapper.setProperty("databaseName", databaseName);
+				wrapper.setProperty("serviceName", serviceName);
                 wrapper.setProperty("serverName", host);
                 wrapper.setProperty("portNumber", Integer.valueOf(port));
                 wrapper.setProperty("driverType", "thin");

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -858,9 +858,6 @@ function qa_tests_once {
     let txtimeout=$MFACTOR*120
     sed -e "s/COMMAND_LINE_13=-DCoordinatorEnvironmentBean.defaultTimeout=[0-9]*/COMMAND_LINE_13=-DCoordinatorEnvironmentBean.defaultTimeout=${txtimeout}/" TaskImpl.properties > "TaskImpl.properties.tmp" && mv "TaskImpl.properties.tmp" "TaskImpl.properties"
   fi
-  # if IPV6_OPTS is not set get the jdbc drivers (we do not run the jdbc tests in IPv6 mode)
-  ant get.drivers
-  [ $? -eq 0 ] || fatal "get drivers failed"
   
   [ -z "${IPV6_OPTS+x}" ] && ant -Dorbtype=$orbtype "$QA_BUILD_ARGS" dist ||
     ant -Dorbtype=$orbtype "$QA_BUILD_ARGS" dist

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -125,7 +125,7 @@ function init_test_options {
         if [[ ! $PULL_DESCRIPTION_BODY == *!QA_JTA* ]]; then
           comment_on_pull "Started testing this pull request with QA_JTA profile: $BUILD_URL"
           export AS_BUILD=0 AS_DOWNLOAD=0 AS_TESTS=0 NARAYANA_BUILD=1 NARAYANA_TESTS=0 BLACKTIE=0 XTS_AS_TESTS=0 XTS_TESTS=0 TXF_TESTS=0 txbridge=0
-          export RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=0 QA_TESTS=1 SUN_ORB=0 JAC_ORB=1 QA_TARGET=ci-tests-nojts JTA_AS_TESTS=0
+          export RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=0 QA_TESTS=1 OPENJDK_ORB=1 SUN_ORB=0 JAC_ORB=0 QA_TARGET=ci-tests-nojts JTA_AS_TESTS=0
           export TOMCAT_TESTS=0 LRA_TESTS=0
         else
           export COMMENT_ON_PULL=""
@@ -188,7 +188,7 @@ function init_test_options {
         if [[ ! $PULL_DESCRIPTION_BODY == *!DB_TESTS* ]]; then
           comment_on_pull "Started testing this pull request with DB_TESTS profile: $BUILD_URL"
           export AS_BUILD=0 AS_DOWNLOAD=0 AS_TESTS=0 NARAYANA_BUILD=1 NARAYANA_TESTS=1 BLACKTIE=0 XTS_AS_TESTS=0 XTS_TESTS=0 TXF_TESTS=0 txbridge=0
-          export RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=0 QA_TESTS=1 SUN_ORB=0 JAC_ORB=0 JTA_AS_TESTS=0
+          export RTS_AS_TESTS=0 RTS_TESTS=0 JTA_CDI_TESTS=0 QA_TESTS=1 OPENJDK_ORB=1 SUN_ORB=0 JAC_ORB=0 JTA_AS_TESTS=0
           export TOMCAT_TESTS=0 LRA_TESTS=0
         else
           export COMMENT_ON_PULL=""


### PR DESCRIPTION
This PR is to backport the following JIRA:
- [JBTM-3486] Uncoupled ArjunaJTA.jta and ArjunaCore.arjuna from the QA module when it comes to the Oracle driver
- [JBTM-3480] Databases drivers are downloaded directly from Maven
- Removed the docker commands for setting up the databases
- [JBTM-3553] Introduced serviceName in JNDIManager to handle Oracle's services
- Change the database name from XE to XEPDB1 for certain database connection details
- [JBTM-3575] Introduced ServiceName when the JDBC object store is tested
- [SCRIPT] Modified both DB_TESTS and QA_TESTS to use OPENJDK_ORB

Passed axes:
!CORE !QA_JTS_JACORB !QA_JTS_OPENJDKORB !DB_TESTS !QA_JTA !QA_JTS_JDKORB !mysql !db2 !postgres !oracle

Skipped axes:
!TOMCAT !AS_TESTS !RTS !JACOCO !XTS !PERF !LRA
