### PR TITLE
JBTM-3591 Fix warnings from deprecated method Assert.assertThat

### DIFF
--- a/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/ConnectionFactoryProxyTests.java
+++ b/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/ConnectionFactoryProxyTests.java
@@ -33,7 +33,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/ConnectionProxyTests.java
+++ b/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/ConnectionProxyTests.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;

--- a/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/JmsXAResourceRecoveryHelperTests.java
+++ b/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/JmsXAResourceRecoveryHelperTests.java
@@ -31,8 +31,8 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doThrow;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3591 