### PR TITLE
JBTM-3597: Upgrading quarkus dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
     <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
     <version.sortpom>3.0.0</version.sortpom>
     <version.sun.jdk>jdk</version.sun.jdk>
+    <version.quarkus>2.9.0.Final</version.quarkus>
   </properties>
 
   <dependencies>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -31,7 +31,6 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
   <url>http://www.jboss.org/jbosstm</url>
 
   <properties>
-    <version.quarkus>1.8.3.Final</version.quarkus>
     <version.resteasy-client>${version.org.jboss.resteasy}</version.resteasy-client>
 
     <version.json.api>1.1</version.json.api>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3597

JDK11 !JDK8

!CORE !TOMCAT !AS_TESTS RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF LRA !DB_TESTS !mysql !db2 !postgres !oracle
