### PR TITLE
Update to same jboss-parent as in WildFly 26.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
     <version.com.sun.jersey>1.9.1</version.com.sun.jersey>
     <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
     <version.commons-httpclient>3.1-jbossorg-1</version.commons-httpclient>
+    <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
     <version.dom4j>1.6.1</version.dom4j>
     <version.doxia>1.8.1</version.doxia>
     <version.fasterxml.jackson>2.12.3</version.fasterxml.jackson>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>35</version>
+    <version>39</version>
   </parent>
   <groupId>org.jboss.narayana</groupId>
   <artifactId>narayana-all</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
     <version.io.narayana.checkstyle-config>1.0.1.Final</version.io.narayana.checkstyle-config>
     <version.jacorb>2.3.1jboss.patch01-brew</version.jacorb>
     <version.jakarta.json-api>1.1.6</version.jakarta.json-api>
+    <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
     <version.javax.annotation>1.2</version.javax.annotation>
     <version.javax.enterprise>2.0</version.javax.enterprise>
     <version.javax.inject>1</version.javax.inject>


### PR DESCRIPTION
WildFly 26.1.1 is using jboss-parent 39: https://github.com/wildfly/wildfly/blob/26.1.1.Final/pom.xml#L29

!JDK8 JDK11

CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB PERF LRA DB_TESTS mysql db2 postgres oracle
