### PR TITLE
[JBTM-3374] afterLRA method is repeatedly called with simple LRA reso…

### DIFF
--- a/rts/lra/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
+++ b/rts/lra/jaxrs/src/main/java/io/narayana/lra/filter/ServerLRAFilter.java
@@ -27,6 +27,8 @@ import io.narayana.lra.client.NarayanaLRAClient;
 import io.narayana.lra.client.internal.proxy.nonjaxrs.LRAParticipant;
 import io.narayana.lra.client.internal.proxy.nonjaxrs.LRAParticipantRegistry;
 import io.narayana.lra.logging.LRALogger;
+
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
 import org.eclipse.microprofile.lra.annotation.Compensate;
 import org.eclipse.microprofile.lra.annotation.Complete;
 import org.eclipse.microprofile.lra.annotation.Forget;
@@ -158,7 +160,8 @@ public class ServerLRAFilter implements ContainerRequestFilter, ContainerRespons
                 || AnnotationResolver.isAnnotationPresent(Compensate.class, method)
                 || AnnotationResolver.isAnnotationPresent(Leave.class, method)
                 || AnnotationResolver.isAnnotationPresent(Status.class, method)
-                || AnnotationResolver.isAnnotationPresent(Forget.class, method);
+                || AnnotationResolver.isAnnotationPresent(Forget.class, method)
+                || AnnotationResolver.isAnnotationPresent(AfterLRA.class, method);
 
         if (headers.containsKey(LRA_HTTP_CONTEXT_HEADER)) {
             try {

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/LRAParticipantAfterLRAIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/LRAParticipantAfterLRAIT.java
@@ -1,0 +1,81 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package io.narayana.lra.arquillian;
+
+import io.narayana.lra.arquillian.resource.LRAParticipantAfterLRA;
+import org.eclipse.microprofile.lra.tck.service.spi.LRACallbackException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URL;
+
+public class LRAParticipantAfterLRAIT extends TestBase {
+
+    private static final Logger log = Logger.getLogger(LRAParticipantAfterLRAIT.class);
+
+    @ArquillianResource
+    public URL baseURL;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Override
+    public void before() {
+        super.before();
+        log.info("Running test " + testName.getMethodName());
+    }
+
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(LRAParticipantAfterLRAIT.class.getSimpleName(), LRAParticipantAfterLRA.class);
+    }
+
+    @Test
+    public void testAfterLRACount() throws LRACallbackException {
+        Client client = ClientBuilder.newClient();
+        Response response = null;
+        try {
+            response = client.target(UriBuilder.fromUri(baseURL.toExternalForm())
+                    .path(LRAParticipantAfterLRA.SIMPLE_PARTICIPANT_RESOURCE_PATH)
+                    .path(LRAParticipantAfterLRA.DO_LRA_PATH).build()).request().put(null);
+
+            Assert.assertEquals(200, response.getStatus());
+            Assert.assertTrue(response.hasEntity());
+
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+
+        try {
+            response = client.target(UriBuilder.fromUri(baseURL.toExternalForm())
+                    .path(LRAParticipantAfterLRA.SIMPLE_PARTICIPANT_RESOURCE_PATH)
+                    .path(LRAParticipantAfterLRA.COUNTER_LRA_PATH).build()).request().get();
+
+            Assert.assertEquals(2, Integer.parseInt(response.readEntity(String.class)));
+        } finally {
+            if (response != null) {
+                response.close();
+            }
+        }
+
+    }
+
+}

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAParticipantAfterLRA.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/resource/LRAParticipantAfterLRA.java
@@ -1,0 +1,94 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ *
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+
+package io.narayana.lra.arquillian.resource;
+
+import org.eclipse.microprofile.lra.LRAResponse;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+
+@ApplicationScoped
+@Path(LRAParticipantAfterLRA.SIMPLE_PARTICIPANT_RESOURCE_PATH)
+@LRA(value = LRA.Type.REQUIRED)
+public class LRAParticipantAfterLRA {
+    public static final String SIMPLE_PARTICIPANT_RESOURCE_PATH = "lra-participant-type-required";
+    public static final String START_LRA_PATH = "start-lra";
+    public static final String DO_LRA_PATH = "/do";
+    public static final String COMPLETE_LRA_PATH = "/complete";
+    public static final String AFTER_LRA_PATH = "/after";
+    public static final String COUNTER_LRA_PATH = "/counter";
+    public static final String RESET_ACCEPTED_PATH = "reset-accepted";
+
+    private static final AtomicInteger afterLRACounter = new AtomicInteger(0);
+    private static Logger log = Logger.getLogger(LRAParticipantAfterLRA.class);
+
+    @Context
+    private UriInfo context;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello participant";
+    }
+
+    @PUT
+    @Path(DO_LRA_PATH)
+    @LRA(value = LRA.Type.REQUIRES_NEW)
+    public Response doLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.debug("doing " + lraId);
+        // pretend to do some work
+        return Response.ok().entity(lraId + "\n").build();
+    }
+
+    @Complete
+    @Path(COMPLETE_LRA_PATH)
+    @PUT
+    public Response complete(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        log.debug("completing " + lraId);
+        return LRAResponse.completed();
+    }
+
+    @PUT
+    @Path(AFTER_LRA_PATH)
+    @AfterLRA
+    public Response afterLRA(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI endedLRAId, LRAStatus status) {
+        log.debug("after " + endedLRAId + " status " + status + " for path " + context.getPath());
+
+        if (afterLRACounter.getAndIncrement() < 1) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+        return Response.ok("ok").build();
+    }
+
+    @GET
+    @Path(COUNTER_LRA_PATH)
+    public Response getCounterValue() {
+        return Response.ok(afterLRACounter.get()).build();
+    }
+
+}


### PR DESCRIPTION
[[JBTM-3374]](https://issues.redhat.com/browse/JBTM-3374)  afterLRA method is repeatedly called with simple LRA resource

adding AfterLRA in filter check.
adding test.

CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB PERF LRA !DB_TESTS !mysql !db2 !postgres !oracle
