### PR TITLE
[JBTM-3604] Remove explicit dependencies on undertow

### DIFF
--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -37,7 +37,6 @@
     <spdy.args>-Xbootclasspath/p:${basedir}/src/test/resources/grizzly-npn-bootstrap-1.0.jar -Drts.usespdy=true -Djavax.net.ssl.trustStore=keystore.jks -Djavax.net.ssl.trustStorePassword=123456</spdy.args>
     <ssl.args>-Drts.usessl=true -Djavax.net.ssl.trustStore=keystore.jks -Djavax.net.ssl.trustStorePassword=123456</ssl.args>
 
-    <version.org.jboss.resteasy-cdi>4.5.5.Final</version.org.jboss.resteasy-cdi>
   </properties>
 
   <dependencies>
@@ -47,42 +46,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${version.log4j}</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.jmx</groupId>
-          <artifactId>jmxri</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jdmk</groupId>
-          <artifactId>jmxtools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.jms</groupId>
-          <artifactId>jms</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.mail</groupId>
-          <artifactId>mail</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
       <version>${version.org.jboss.spec.javax.servlet}</version>
       <scope>provided</scope>
     </dependency>
     <!-- Jersey -->
-    <dependency>
-      <groupId>asm</groupId>
-      <artifactId>asm-all</artifactId>
-      <version>${version.asm}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.sun.grizzly</groupId>
       <artifactId>grizzly-servlet-webserver</artifactId>
@@ -133,19 +102,8 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-cdi</artifactId>
-      <version>${version.org.jboss.resteasy-cdi}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
       <version>${version.org.jboss.resteasy}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>${version.commons-httpclient}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -153,12 +111,6 @@
       <artifactId>jboss-logging</artifactId>
       <version>${version.org.jboss.logging.jboss-logging}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>${version.com.h2database}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -210,18 +210,6 @@
       <version>${version.org.jboss.resteasy}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.undertow</groupId>
-      <artifactId>undertow-servlet</artifactId>
-      <version>[2.0.21,)</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.undertow</groupId>
-      <artifactId>undertow-core</artifactId>
-      <version>[2.0.21,)</version>
-      <scope>test</scope>
-    </dependency>
     <!-- end undertow with RestEasy -->
     <dependency>
       <groupId>org.jboss.spec.javax.interceptor</groupId>


### PR DESCRIPTION
Remove defined explicit dependencies on undertow, using instead the version that is transitively provided by org.jboss.resteasy:resteasy-undertow   https://issues.redhat.com/browse/JBTM-3604

Resolve following errors:
JDK8, compilation error:
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0-jboss-2:testCompile (default-testCompile) on project restat-api: Compilation failure
[ERROR] /narayana/rts/at/tx/src/test/java/org/jboss/jbossts/star/test/BaseTest.java:[59,19] cannot access io.undertow.Undertow
[ERROR]   bad class file: /root/.m2/repository/io/undertow/undertow-core/2.3.0.Alpha1/undertow-core-2.3.0.Alpha1.jar(io/undertow/Undertow.class)
[ERROR]     class file has wrong version 55.0, should be 52.0`
JDK11, test errors:
`java.lang.IllegalArgumentException: UT010009: Servlet ResteasyServlet of type class org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher does not implement jakarta.servlet.Servlet`

JDK11 CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_JACORB QA_JTS_JDKORB QA_JTS_OPENJDKORB PERF LRA DB_TESTS mysql db2 postgres oracle
