### PR TITLE
[JBTM-3605] Update jaxws-ri version from 2.3.0 to 2.3.5

### DIFF
--- a/XTS/pom.xml
+++ b/XTS/pom.xml
@@ -80,7 +80,6 @@
              <jvm.args.modular>--add-modules=java.se</jvm.args.modular>
 	     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
 	     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-	     <version.jaxws-ri>2.3.0</version.jaxws-ri>
 	  </properties>
 	  <dependencies>
 	     <dependency>

--- a/compensations/pom.xml
+++ b/compensations/pom.xml
@@ -216,7 +216,6 @@
              <jvm.args.modular>--add-modules=java.se</jvm.args.modular>
 	     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
 	     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-	     <version.jaxws-ri>2.3.0</version.jaxws-ri>
 	  </properties>
 	  <dependencies>
              <dependency>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -468,7 +468,6 @@
       </activation>
       <properties>
         <jvm.args.modular>--add-modules=java.se</jvm.args.modular>
-        <version.jaxws-ri>2.3.0</version.jaxws-ri>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
     <version.javax.inject>1</version.javax.inject>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.javax.ws.rs-api>2.0.1.Final</version.javax.ws.rs-api>
+    <version.jaxws-ri>2.3.5</version.jaxws-ri>
     <version.jfree>1.0.9</version.jfree>
     <version.jnpserver>5.0.3.GA</version.jnpserver>
     <version.junit>4.13.1</version.junit>

--- a/txbridge/pom.xml
+++ b/txbridge/pom.xml
@@ -350,7 +350,6 @@
           <properties>
              <jvm.args.modular>--add-modules=java.se</jvm.args.modular>
 	     <version.jaxb>2.3.0</version.jaxb>
-	     <version.jaxws-ri>2.3.0</version.jaxws-ri>
 	  </properties>
 	  <dependencies>
 		  <dependency>

--- a/txframework/pom.xml
+++ b/txframework/pom.xml
@@ -222,7 +222,6 @@
              <jvm.args.modular>--add-modules=java.se</jvm.args.modular>
 	     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
 	     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-	     <version.jaxws-ri>2.3.0</version.jaxws-ri>
 	  </properties>
 	  <dependencies>
              <dependency>


### PR DESCRIPTION
Update jaxws-ri dependency version from 2.3.0 to 2.3.5 https://issues.redhat.com/browse/JBTM-3605

JDK11 CORE AS_TESTS XTS !TOMCAT !RTS !JACOCO !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle
