### PR TITLE
[JBTM-3602] Compatibility issues with other Java vendors in WS-AT (on Hold)

### DIFF
--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/ContextFactoryImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/ContextFactoryImple.java
@@ -350,13 +350,9 @@ public class ContextFactoryImple implements ContextFactory, LocalFactory
 
     private W3CEndpointReference getParticipant(final String id, final boolean isSecure)
     {
-        final QName serviceName = AtomicTransactionConstants.PARTICIPANT_SERVICE_QNAME;
-        final QName endpointName = AtomicTransactionConstants.PARTICIPANT_PORT_QNAME;
         final ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
         final String address = serviceRegistry.getServiceURI(AtomicTransactionConstants.PARTICIPANT_SERVICE_NAME, isSecure);
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(serviceName);
-        builder.endpointName(endpointName);
         builder.address(address);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id);
         return builder.build();
@@ -371,8 +367,6 @@ public class ContextFactoryImple implements ContextFactory, LocalFactory
     private static W3CEndpointReference getRegistrationCoordinator(String registrationCoordinatorURI, String identifier)
     {
         final W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(CoordinationConstants.REGISTRATION_SERVICE_QNAME);
-        builder.endpointName(CoordinationConstants.REGISTRATION_ENDPOINT_QNAME);
         // strictly we shouldn't need to set the address because we are in the same web app as the
         // coordinator but we have to as the W3CEndpointReference implementation is incomplete
         builder.address(registrationCoordinatorURI);

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/RegistrarImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/RegistrarImple.java
@@ -293,8 +293,6 @@ public class RegistrarImple implements Registrar
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
 		ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
         String address = serviceRegistry.getServiceURI(AtomicTransactionConstants.COMPLETION_COORDINATOR_SERVICE_NAME, isSecure);
-        builder.serviceName(AtomicTransactionConstants.COMPLETION_COORDINATOR_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.COMPLETION_COORDINATOR_PORT_QNAME);
         builder.address(address);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, instanceIdentifier);
         return builder.build();
@@ -305,8 +303,6 @@ public class RegistrarImple implements Registrar
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
 		ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
         String address = serviceRegistry.getServiceURI(AtomicTransactionConstants.COMPLETION_COORDINATOR_RPC_SERVICE_NAME, isSecure);
-        builder.serviceName(AtomicTransactionConstants.COMPLETION_COORDINATOR_RPC_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.COMPLETION_COORDINATOR_RPC_PORT_QNAME);
         builder.address(address);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, instanceIdentifier);
         return builder.build();
@@ -317,8 +313,6 @@ public class RegistrarImple implements Registrar
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
 		ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
         String address = serviceRegistry.getServiceURI(AtomicTransactionConstants.COORDINATOR_SERVICE_NAME, isSecure);
-        builder.serviceName(AtomicTransactionConstants.COORDINATOR_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.COORDINATOR_PORT_QNAME);
         builder.address(address);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, participantId);
         return builder.build();

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/TransactionManagerImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/TransactionManagerImple.java
@@ -128,13 +128,9 @@ public class TransactionManagerImple extends TransactionManager
 
     final W3CEndpointReference getParticipant(final String id, final boolean isSecure)
     {
-        final QName serviceName = AtomicTransactionConstants.PARTICIPANT_SERVICE_QNAME;
-        final QName endpointName = AtomicTransactionConstants.PARTICIPANT_PORT_QNAME;
-		final ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
+        final ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
         final String address = serviceRegistry.getServiceURI(AtomicTransactionConstants.PARTICIPANT_SERVICE_NAME, isSecure);
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(serviceName);
-        builder.endpointName(endpointName);
         builder.address(address);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id);
         return builder.build();

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserTransactionImple.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst11/at/remote/UserTransactionImple.java
@@ -472,13 +472,9 @@ public class UserTransactionImple extends UserTransaction
      */
     private W3CEndpointReference getCompletionParticipant(final String id, final boolean isSecure)
     {
-        final QName serviceName = AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_QNAME;
-        final QName endpointName = AtomicTransactionConstants.COMPLETION_INITIATOR_PORT_QNAME;
-		final ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
+        final ServiceRegistry serviceRegistry = PrivilegedServiceRegistryFactory.getInstance().getServiceRegistry();
         final String address = serviceRegistry.getServiceURI(AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_NAME, isSecure);
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(serviceName);
-        builder.endpointName(endpointName);
         builder.address(address);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id);
         return builder.build();

--- a/XTS/localjunit/WSTFSC07-interop/src/main/java/com/jboss/transaction/wstf/webservices/sc007/InteropUtil.java
+++ b/XTS/localjunit/WSTFSC07-interop/src/main/java/com/jboss/transaction/wstf/webservices/sc007/InteropUtil.java
@@ -139,8 +139,6 @@ public class InteropUtil
         final ServiceRegistry serviceRegistry = ServiceRegistry.getRegistry() ;
         final String serviceURI = serviceRegistry.getServiceURI(AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_NAME) ;
         final W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.COMPLETION_INITIATOR_PORT_QNAME);
         builder.address(serviceURI);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id) ;
         return builder.build();
@@ -156,8 +154,6 @@ public class InteropUtil
         final ServiceRegistry serviceRegistry = ServiceRegistry.getRegistry() ;
         final String serviceURI = serviceRegistry.getServiceURI(AtomicTransactionConstants.PARTICIPANT_SERVICE_NAME) ;
         final W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(AtomicTransactionConstants.PARTICIPANT_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.PARTICIPANT_PORT_QNAME);
         builder.address(serviceURI);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id) ;
         return builder.build();

--- a/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/webservices/atinterop/ATInteropUtil.java
+++ b/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/webservices/atinterop/ATInteropUtil.java
@@ -139,8 +139,6 @@ public class ATInteropUtil
         final ServiceRegistry serviceRegistry = ServiceRegistry.getRegistry() ;
         final String serviceURI = serviceRegistry.getServiceURI(AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_NAME) ;
         final W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.COMPLETION_INITIATOR_PORT_QNAME);
         builder.address(serviceURI);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id) ;
         return builder.build();
@@ -156,8 +154,6 @@ public class ATInteropUtil
         final ServiceRegistry serviceRegistry = ServiceRegistry.getRegistry() ;
         final String serviceURI = serviceRegistry.getServiceURI(AtomicTransactionConstants.PARTICIPANT_SERVICE_NAME) ;
         final W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(AtomicTransactionConstants.PARTICIPANT_SERVICE_QNAME);
-        builder.endpointName(AtomicTransactionConstants.PARTICIPANT_PORT_QNAME);
         builder.address(serviceURI);
         InstanceIdentifier.setEndpointInstanceIdentifier(builder, id) ;
         return builder.build();

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/TestContextFactory.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/TestContextFactory.java
@@ -63,8 +63,6 @@ public class TestContextFactory implements ContextFactory
         final ServiceRegistry serviceRegistry = ServiceRegistry.getRegistry() ;
         final String registrationURI = serviceRegistry.getServiceURI(CoordinationConstants.REGISTRATION_SERVICE_NAME) ;
         final W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(CoordinationConstants.REGISTRATION_SERVICE_QNAME);
-        builder.endpointName(CoordinationConstants.REGISTRATION_ENDPOINT_QNAME);
         builder.address(registrationURI);
         W3CEndpointReference registrationService = builder.build();
 

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/TestUtil11.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/TestUtil11.java
@@ -26,7 +26,6 @@
 
 package com.arjuna.wsc.tests;
 
-import com.arjuna.webservices11.wscoor.CoordinationConstants;
 import com.arjuna.webservices11.wsarj.InstanceIdentifier;
 import org.jboss.jbossts.xts.environment.XTSPropertyManager;
 
@@ -55,16 +54,12 @@ public class TestUtil11
 
     public static W3CEndpointReference getActivationEndpoint() {
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(CoordinationConstants.ACTIVATION_SERVICE_QNAME);
-        builder.endpointName(CoordinationConstants.ACTIVATION_ENDPOINT_QNAME);
         builder.address(activationCoordinatorService);
         return builder.build();
     }
 
     public static W3CEndpointReference getRegistrationEndpoint(String identifier) {
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(CoordinationConstants.REGISTRATION_SERVICE_QNAME);
-        builder.endpointName(CoordinationConstants.REGISTRATION_ENDPOINT_QNAME);
         builder.address(registrationCoordinatorService);
         if (identifier != null) {
             InstanceIdentifier.setEndpointInstanceIdentifier(builder, identifier);
@@ -74,8 +69,6 @@ public class TestUtil11
 
     public static W3CEndpointReference getProtocolCoordinatorEndpoint(String identifier) {
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(PROTOCOL_COORDINATOR_SERVICE_QNAME);
-        builder.endpointName(PROTOCOL_COORDINATOR_ENDPOINT_QNAME);
         builder.address(TestUtil.PROTOCOL_COORDINATOR_SERVICE);
         if (identifier != null) {
             InstanceIdentifier.setEndpointInstanceIdentifier(builder, identifier);
@@ -85,8 +78,6 @@ public class TestUtil11
 
     public static W3CEndpointReference getProtocolParticipantEndpoint(String identifier) {
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(PROTOCOL_PARTICIPANT_SERVICE_QNAME);
-        builder.endpointName(PROTOCOL_PARTICIPANT_ENDPOINT_QNAME);
         builder.address(TestUtil.PROTOCOL_PARTICIPANT_SERVICE);
         if (identifier != null) {
             InstanceIdentifier.setEndpointInstanceIdentifier(builder, identifier);

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/arq/TestActivationCoordinatorProcessor.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/arq/TestActivationCoordinatorProcessor.java
@@ -78,8 +78,6 @@ public class TestActivationCoordinatorProcessor extends
         identifierInstance.setValue(identifier);
         coordinationContext.setIdentifier(identifierInstance);
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-        builder.serviceName(CoordinationConstants.REGISTRATION_SERVICE_QNAME);
-        builder.endpointName(CoordinationConstants.REGISTRATION_ENDPOINT_QNAME);
         builder.address(TestUtil.PROTOCOL_COORDINATOR_SERVICE);
         builder.build();
         coordinationContext.setRegistrationService(TestUtil11.getRegistrationEndpoint(identifier));

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/TestInitialisation.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/TestInitialisation.java
@@ -22,8 +22,6 @@
 
 package com.arjuna.wst.tests;
 
-import javax.servlet.ServletContextListener;
-import javax.servlet.ServletContextEvent;
 import javax.xml.ws.wsaddressing.W3CEndpointReference;
 import javax.xml.ws.wsaddressing.W3CEndpointReferenceBuilder;
 import javax.xml.namespace.QName;
@@ -271,11 +269,7 @@ public void teardownTest() {
     {
         try {
             W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-            final QName serviceName = AtomicTransactionConstants.COORDINATOR_SERVICE_QNAME;
-            final QName endpointName = AtomicTransactionConstants.COORDINATOR_PORT_QNAME;
             final String address = ServiceRegistry.getRegistry().getServiceURI(AtomicTransactionConstants.COORDINATOR_SERVICE_NAME);
-            builder.serviceName(serviceName);
-            builder.endpointName(endpointName);
             builder.address(address);
             InstanceIdentifier.setEndpointInstanceIdentifier(builder, id);
             return builder.build();

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/TestUtil.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wst/tests/TestUtil.java
@@ -28,7 +28,6 @@ package com.arjuna.wst.tests;
 
 import com.arjuna.webservices11.wsba.BusinessActivityConstants;
 import com.arjuna.webservices11.wsarj.InstanceIdentifier;
-import com.arjuna.webservices11.wsat.AtomicTransactionConstants;
 import org.jboss.jbossts.xts.environment.XTSPropertyManager;
 
 import javax.xml.ws.wsaddressing.W3CEndpointReference;
@@ -84,32 +83,28 @@ public class TestUtil
 
     public static W3CEndpointReference getParticipantEndpoint(String id)
     {
-        return getEndpoint(AtomicTransactionConstants.PARTICIPANT_SERVICE_QNAME,
-                AtomicTransactionConstants.PARTICIPANT_PORT_QNAME,
+        return getEndpoint(null, null,
                 participantServiceURI,
                 id);
     }
 
     public static W3CEndpointReference getCoordinatorEndpoint(String id)
     {
-        return getEndpoint(AtomicTransactionConstants.COORDINATOR_SERVICE_QNAME,
-                AtomicTransactionConstants.COORDINATOR_PORT_QNAME,
+        return getEndpoint(null, null,
                 coordinatorServiceURI,
                 id);
     }
 
     public static W3CEndpointReference getCompletionInitiatorEndpoint(String id)
     {
-        return getEndpoint(AtomicTransactionConstants.COMPLETION_INITIATOR_SERVICE_QNAME,
-                AtomicTransactionConstants.COMPLETION_INITIATOR_PORT_QNAME,
+        return getEndpoint(null, null,
                 completionInitiatorServiceURI,
                 id);
     }
 
     public static W3CEndpointReference getCompletionCoordinatorEndpoint(String id)
     {
-        return getEndpoint(AtomicTransactionConstants.COMPLETION_COORDINATOR_SERVICE_QNAME,
-                AtomicTransactionConstants.COMPLETION_COORDINATOR_PORT_QNAME,
+        return getEndpoint(null, null,
                 completionCoordinatorServiceURI,
                 id);
     }
@@ -150,8 +145,12 @@ public class TestUtil
     {
         try {
             W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-            builder.serviceName(service);
-            builder.endpointName(port);
+            if (service != null) {
+                builder.serviceName(service);
+            }
+            if (port != null) {
+                builder.endpointName(port);
+            }
             builder.address(address);
             if (id != null) {
                 InstanceIdentifier.setEndpointInstanceIdentifier(builder, id);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBTM-3602

The PR removes the service-name and endpoint-name from any reference associated to WS-AT and WS-COOR specs. I tried to not modify anything else. Tests modified because sometimes they also configure the endpoints from the test code (this way we test this in all the possible places).

@mmusgrov I have also prepared the PR for 5.11 (it's the same, no conflicts) if you need it.

JDK11 CORE AS_TESTS XTS !RTS !JACOCO !TOMCAT !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle
