### PR TITLE
[JBTM-3611] Add a jakarta-direct.properties for text strings that nee…

### DIFF
--- a/XTS/jbossxts-jakarta/pom.xml
+++ b/XTS/jbossxts-jakarta/pom.xml
@@ -39,6 +39,8 @@
                   <arg value="-o"/>
                   <arg value="-tr"/>
                   <arg value="${project.basedir}/../../jakarta-rules/jakarta-renames.properties"/>
+                  <arg value="-td"/>
+                  <arg value="${project.basedir}/../../jakarta-rules/jakarta-direct.properties"/>
                   <classpath>
                     <pathelement path="${plugin_classpath}"/>
                   </classpath>
@@ -62,6 +64,8 @@
                   <arg value="-o"/>
                   <arg value="-tr"/>
                   <arg value="${project.basedir}/../../jakarta-rules/jakarta-renames.properties"/>
+                  <arg value="-td"/>
+                  <arg value="${project.basedir}/../../jakarta-rules/jakarta-direct.properties"/>
                   <classpath>
                     <pathelement path="${plugin_classpath}"/>
                   </classpath>

--- a/jakarta-rules/jakarta-direct.properties
+++ b/jakarta-rules/jakarta-direct.properties
@@ -1,0 +1,4 @@
+javax.xml.ws.servlet.request=jakarta.xml.ws.servlet.request
+javax.xml.ws.handler.message.outbound=jakarta.xml.ws.handler.message.outbound
+javax.xml.ws.service.endpoint.address=jakarta.xml.ws.service.endpoint.address
+javax.xml.ws.soap.http.soapaction.uri=jakarta.xml.ws.soap.http.soapaction.uri

--- a/txbridge-jakarta/pom.xml
+++ b/txbridge-jakarta/pom.xml
@@ -76,6 +76,8 @@
                   <arg value="-o"></arg>
                   <arg value="-tr"></arg>
                   <arg value="${project.basedir}/../jakarta-rules/jakarta-renames.properties"></arg>
+                  <arg value="-td"></arg>
+                  <arg value="${project.basedir}/../jakarta-rules/jakarta-direct.properties"></arg>
                   <classpath>
                     <pathelement path="${plugin_classpath}"></pathelement>
                   </classpath>
@@ -100,6 +102,8 @@
                   <arg value="-o"></arg>
                   <arg value="-tr"></arg>
                   <arg value="${project.basedir}/../jakarta-rules/jakarta-renames.properties"></arg>
+                  <arg value="-td"></arg>
+                  <arg value="${project.basedir}/../jakarta-rules/jakarta-direct.properties"></arg>
                   <classpath>
                     <pathelement path="${plugin_classpath}"></pathelement>
                   </classpath>
@@ -124,6 +128,8 @@
                   <arg value="-o"></arg>
                   <arg value="-tr"></arg>
                   <arg value="${project.basedir}/../jakarta-rules/jakarta-renames.properties"></arg>
+                  <arg value="-td"></arg>
+                  <arg value="${project.basedir}/../jakarta-rules/jakarta-direct.properties"></arg>
                   <classpath>
                     <pathelement path="${plugin_classpath}"></pathelement>
                   </classpath>


### PR DESCRIPTION
…d to be transformed.

https://issues.redhat.com/browse/JBTM-3611

Note that there are other modules that transform byte code. However, in WildFly these were the only ones that were causing issues. If we feel these changes should go into all the transformed modules please let me know and I'll make the changes.
