### PR TITLE
Re-introduce the vertx/module testing that was disabled for JDK+ in 4e4a477e49feeb3784f3b469387964ff4dd8d29c

### DIFF
--- a/vertx/module/pom.xml
+++ b/vertx/module/pom.xml
@@ -254,14 +254,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${version.maven-failsafe-plugin}</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_JDKORB !QA_JTS_OPENJDKORB !PERF !LRA !DB_TESTS mysql db2 postgres oracle

Here is where it was skipped https://github.com/jbosstm/narayana/pull/1364/files#diff-ab5e55e6fb3251f6c514a7fa77dbe902e1e088cfbc2a8a7dcffd12deab4fa0f7R311
This is the Jira that commit is connected to: https://issues.redhat.com/browse/JBTM-2685