### PR TITLE
[JBTM-3950] removed idlj orb compiler

### DIFF
--- a/ArjunaJTS/orbportability/config/idl-compiler-definitions.xml
+++ b/ArjunaJTS/orbportability/config/idl-compiler-definitions.xml
@@ -48,37 +48,6 @@
 
     </orb>
 
-    <orb name="idlj">
-
-	<in-parameters>
-	    <param name="destdir" required="false"/>
-	    <param name="include" required="false" delimiter=";"/>
-	    <param name="package" required="false"/>
-	    <param name="mapping" required="false" delimiter=";"/>
-	    <param name="filename" required="true"/>
-	    <param name="classpath" required="true" delimiter=";" classpath="true"/>
-	</in-parameters>
-
-	<idl-executable>idlj</idl-executable>
-
-	<out-parameters>
-	    <param>-td</param>
-	    <param>${destdir}</param>
-	    <param>-fallTIE</param>
-	    <param foreach="include">
-		<sub-param>-i</sub-param>
-		<sub-param>${include}</sub-param>
-	    </param>
-	    <param foreach="mapping">
-		<sub-param>-pkgPrefix</sub-param>
-		<sub-param>${mapping-name}</sub-param>
-		<sub-param>${mapping-value}</sub-param>
-	    </param>
-	    <param>${filename}</param>
-	</out-parameters>
-
-    </orb>
-
     <orb name="openjdk">
 
 	<in-parameters>


### PR DESCRIPTION
JBTM-3950 leftover

Passed
!CORE !QA_JTS_JACORB !QA_JTS_OPENJDKORB

Failed:
QA_JTA 

!TOMCAT !AS_TESTS !RTS !JACOCO !XTS !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle
