### PR TITLE
[JBTM-3590] Removed idlj surefire profiles from code-coverage

### DIFF
--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -258,10 +258,8 @@
                       <fileset dir="../tools/target/${surefire.reports.directory}" includes="**/*.xml"/>
 
                       <fileset dir="../ArjunaJTS/jts/target/jacorb-surefire-reports" includes="**/*.xml"/>
-                      <fileset dir="../ArjunaJTS/jts/target/idlj-surefire-reports" includes="**/*.xml"/>
                       <fileset dir="../ArjunaJTS/jts/target/idlj-openjdk-surefire-reports" includes="**/*.xml"/>
                       <fileset dir="../ArjunaJTS/orbportability/target/jacorb-surefire-reports" includes="**/*.xml"/>
-                      <fileset dir="../ArjunaJTS/orbportability/target/idlj-surefire-reports" includes="**/*.xml"/>
                       <fileset dir="../ArjunaJTS/orbportability/target/idlj-openjdk-surefire-reports" includes="**/*.xml"/>
                       <fileset dir="../ArjunaJTS/jtax/target/${surefire.reports.directory}" includes="**/*.xml"/>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3590

!CORE !TOMCAT !AS_TESTS !RTS JACOCO !XTS !QA_JTA !QA_JTS_JACORB !QA_JTS_OPENJDKORB !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle
