### PR TITLE
RELEASE SCRIPT: Allow the list of REPOS to be tagged to be overridden

### DIFF
--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -40,7 +40,7 @@ TEMP_WORKING_DIR=~/tmp/narayana/$CURRENT/sources/
 mkdir -p $TEMP_WORKING_DIR
 cd $TEMP_WORKING_DIR || fatal
 
-for REPO in documentation quickstart performance narayana 'git@github.com:jboss-dockerfiles/narayana.git jboss-dockerfiles'
+for REPO in ${REPOS:-documentation quickstart performance narayana 'git@github.com:jboss-dockerfiles/narayana.git jboss-dockerfiles'}
 do
     echo ""
     echo "=== TAGGING AND UPDATING $REPO ==="


### PR DESCRIPTION
NO_TEST

Unfortunately it is not fully complete (I think) as I haven't work out how to pass a REPO that needs to be renamed in the clone to the REPOS variable.

E.g. `REPOS='a "b c"' ./scripts/pre-release.sh` would assume three variables, 'a' '"b' and 'c"' rather than two: 'a' and 'b c'

That said, if you just want to tag say narayana on it's own or along with something like document or quickstarts this approach should work.