### PR TITLE
[JBTM-3673] Removed maven profile jdk17 and updated Arquillian dependencies

### DIFF
--- a/ArjunaJTA/jta/pom.xml
+++ b/ArjunaJTA/jta/pom.xml
@@ -486,19 +486,5 @@
         <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.jacoco} ${jvm.args.modular}</server.jvm.args>
       </properties>
     </profile>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-        <!-- The add-opens is only needed for something in test(s?) that are in ran with "arq" profile so limit to that -->
-        <property>
-          <name>arqProfileActivated</name>
-        </property>
-      </activation>
-      <properties>
-        <!-- CMRIntegrationTest needs this -->
-        <jvm.args.modular>--add-opens=java.base/java.util=ALL-UNNAMED</jvm.args.modular>
-      </properties>
-    </profile>
   </profiles>
 </project>

--- a/rts/lra/test/pom.xml
+++ b/rts/lra/test/pom.xml
@@ -127,7 +127,7 @@
         <skip.wildfly.plugin>true</skip.wildfly.plugin>
         <!-- where the WFLY test application will be started at (the coordinator is war deployed for the same app server at the same port) -->
         <test.application.port>8080</test.application.port>
-        <version.wildfly-maven-plugin>2.1.0.Beta1</version.wildfly-maven-plugin>
+        <version.wildfly-maven-plugin>4.0.0.Final</version.wildfly-maven-plugin>
         <!-- this property is only used in direct submodules, if used outside this scope it needs to be redefined -->
         <wildfly.trace.logging.cli.script>${project.basedir}/../wildfly-trace-logging.cli</wildfly.trace.logging.cli.script>
       </properties>
@@ -364,17 +364,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties>
-        <!-- At least org.eclipse.microprofile.lra.tck.TckUnknownStatusTests needs java.base/java.lang and java.base/java.lang.reflect -->
-        <jvm.args.modular>--add-opens=java.base/java.lang=ALL-UNNAMED
-          --add-opens=java.base/java.lang.reflect=ALL-UNNAMED</jvm.args.modular>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/rts/lra/test/tck/pom.xml
+++ b/rts/lra/test/tck/pom.xml
@@ -58,4 +58,18 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- TODO [JBTM-3743] This profile can be removed once MP LRA TCK will use Arquillian version >= 1.7.0.Alpha12 -->
+      <id>jdk17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <!-- At least org.eclipse.microprofile.lra.tck.TckUnknownStatusTests needs java.base/java.lang and java.base/java.lang.reflect -->
+        <jvm.args.modular>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED</jvm.args.modular>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Addresses [JBTM-3673](https://issues.redhat.com/browse/JBTM-3673)

To test:
JDK17 LRA AS_TESTS RTS 

Passed
!XTS !JACOCO !JDK11 !CORE !TOMCAT !QA_JTA !QA_JTS_OPENJDKORB PERF !DB_TESTS !mysql !db2 !postgres !oracle