### PR TITLE
Remove jboss-corba-ots-spi dependency

### DIFF
--- a/ArjunaJTA/jms/pom.xml
+++ b/ArjunaJTA/jms/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-jms-server</artifactId>
+            <artifactId>artemis-jakarta-server</artifactId>
             <version>${version.org.apache.activemq}</version>
             <scope>test</scope>
         </dependency>

--- a/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/integration/JMSContextIntegrationTest.java
+++ b/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/integration/JMSContextIntegrationTest.java
@@ -116,7 +116,6 @@ public class JMSContextIntegrationTest {
     }
 
     @Test
-    @Ignore // jakarta TODO version problem: NoClassDefFound javax/jms/ConnectionFactory
     public void testCommit() throws Exception {
         when(xaResourceMock.prepare(any(Xid.class))).thenReturn(XAResource.XA_OK);
 

--- a/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/integration/JmsIntegrationTests.java
+++ b/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/integration/JmsIntegrationTests.java
@@ -69,7 +69,6 @@ public class JmsIntegrationTests extends AbstractIntegrationTests {
     }
 
     @Test
-    @Ignore // jakarta TODO version problem: NoClassDefFound javax/jms/ConnectionFactory
     public void testCommit() throws Exception {
         when(xaResourceMock.prepare(any(Xid.class))).thenReturn(XAResource.XA_OK);
 
@@ -92,7 +91,6 @@ public class JmsIntegrationTests extends AbstractIntegrationTests {
     }
 
     @Test
-    @Ignore // jakarta TODO version problem: NoClassDefFound javax/jms/ConnectionFactory
     public void testRollback() throws Exception {
         TransactionManager.transactionManager().begin();
         TransactionManager.transactionManager().getTransaction().enlistResource(xaResourceMock);

--- a/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/integration/JmsRecoveryIntegrationTests.java
+++ b/ArjunaJTA/jms/src/test/java/org/jboss/narayana/jta/jms/integration/JmsRecoveryIntegrationTests.java
@@ -85,7 +85,6 @@ public class JmsRecoveryIntegrationTests extends AbstractIntegrationTests {
     }
 
     @Test
-    @Ignore // jakarta TODO version problem: NoClassDefFound javax/jms/ConnectionFactory
     @BMRule(name = "Fail before commit", targetClass = "com.arjuna.ats.arjuna.coordinator.BasicAction",
             targetMethod = "phase2Commit", targetLocation = "ENTRY", helper = "org.jboss.narayana.jta.jms.helpers.BytemanHelper",
             action = "incrementCommitsCounter(); failFirstCommit($0.get_uid());")

--- a/ArjunaJTS/integration/pom.xml
+++ b/ArjunaJTS/integration/pom.xml
@@ -59,13 +59,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.integration</groupId>
-      <artifactId>jboss-corba-ots-spi</artifactId>
-      <version>${version.org.jboss.integration}</version>
-      <!-- TODO AS7 -->
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
       <version>${version.org.jboss.logging.jboss-logging}</version>

--- a/ArjunaJTS/integration/src/main/java/com/arjuna/ats/internal/jbossatx/jts/InboundTransactionCurrentImple.java
+++ b/ArjunaJTS/integration/src/main/java/com/arjuna/ats/internal/jbossatx/jts/InboundTransactionCurrentImple.java
@@ -21,11 +21,9 @@
 package com.arjuna.ats.internal.jbossatx.jts;
 
 import org.jboss.iiop.tm.InboundTransactionCurrent;
-import org.jboss.tm.TransactionManagerLocator;
 import org.omg.CORBA.LocalObject;
 
 import jakarta.transaction.Transaction;
-import jakarta.transaction.TransactionManager;
 
 import com.arjuna.ats.jbossatx.logging.jbossatxLogger;
 
@@ -47,11 +45,7 @@ import com.arjuna.ats.jbossatx.logging.jbossatxLogger;
  */
 public class InboundTransactionCurrentImple extends LocalObject implements InboundTransactionCurrent
 {
-    /* jakarta TODO
-    Returns:
-    the javax.transaction.Transaction instance associated with the current incoming request, or null if that request was not issued within the scope of some transaction.
-     */
-    public javax.transaction.Transaction getCurrentTransaction()
+    public Transaction getCurrentTransaction()
     {
         if (jbossatxLogger.logger.isTraceEnabled()) {
             jbossatxLogger.logger.trace("InboundTransactionCurrentImple.getCurrentTransaction() called");

--- a/ArjunaJTS/integration/src/main/java/org/jboss/iiop/tm/InboundTransactionCurrent.java
+++ b/ArjunaJTS/integration/src/main/java/org/jboss/iiop/tm/InboundTransactionCurrent.java
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright The Narayana Authors
+ * 
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ */
+package org.jboss.iiop.tm;
+
+import jakarta.transaction.Transaction;
+
+import org.omg.CORBA.Current;
+
+/**
+ * Interface to be implemented by a CORBA OTS provider for integration with
+ * JBossAS. The CORBA OTS provider must (i) create an object that implements
+ * this interface and (ii) register an initial reference for that object
+ * with the JBossAS ORB, under name "InboundTransactionCurrent".
+ * <p/>
+ * Step (ii) above should be done by a call
+ * <code>orbInitInfo.register_initial_reference</code> within the
+ * <code>pre_init</code> method of an
+ * <code>org.omg.PortableInterceptor.ORBInitializer</code>,
+ * which will probably be also the initializer that registers a server request
+ * interceptor for the OTS provider.
+ *
+ */
+public interface InboundTransactionCurrent extends Current {
+    String NAME = "InboundTransactionCurrent";
+
+    /**
+     * Gets the Transaction instance associated with the current incoming
+     * request. This method should be called only by code that handles incoming
+     * requests; its return value is undefined in the case of a call issued
+     * outside of a request scope.
+     *
+     * @return the jakarta.transaction.Transaction instance associated with the
+     *         current incoming request, or null if that request was not issued
+     *         within the scope of some transaction.
+     */
+    Transaction getCurrentTransaction();
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3698
NO_TEST 
I followed Wildfly implementation https://github.com/wildfly/wildfly/tree/main/transactions/src/main/java/org/jboss/iiop/tm  and I kept the original package (org.jboss.iiop.tm) used in wildfly for the new interface created InboundTransactionCurrent (previously present in dependency jboss-corba-ots-spi).
