### PR TITLE
Revert "wildfly-jdk17 use 27.0.0.Alpha1 for WildFly testing"

### DIFF
--- a/rts/lra/test/crash/src/test/java/io/narayana/lra/arquillian/resource/LRAListener.java
+++ b/rts/lra/test/crash/src/test/java/io/narayana/lra/arquillian/resource/LRAListener.java
@@ -31,15 +31,6 @@ import org.eclipse.microprofile.lra.annotation.AfterLRA;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 
-<<<<<<< HEAD
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HeaderParam;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Response;
-=======
->>>>>>> ead7de415 (JBTM-3532 Add LRA support for EE 9)
 import java.net.URI;
 
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;


### PR DESCRIPTION
revert commit 2f453c6c1badf53fbae345d88c9fb9a4c15842b0 "2f453c6c1badf53fbae345d88c9fb9a4c15842b0" because it was  needed in order to produce a release for quarkus. 
This PR's goal is to build again wildfly application server from wildfly main repo 
The wildfly source used is https://github.com/jbosstm/jboss-as/pull/87