### PR TITLE
5.11 updates

### DIFF
--- a/narayana-full/src/main/assembly/bin.xml
+++ b/narayana-full/src/main/assembly/bin.xml
@@ -212,26 +212,6 @@
 			<outputDirectory>lib/ext</outputDirectory>
 			<destName>xts_third_party_licenses.txt</destName>
 		</file>
-		<file>
-			<source>../rts/lra/coordinator-quarkus/target/lra-coordinator-runner.jar</source>
-			<fileMode>0755</fileMode>
-			<outputDirectory>rts/lra/</outputDirectory>
-		</file>
-		<file>
-			<source>../rts/lra/coordinator/target/lra-coordinator.jar</source>
-			<fileMode>0644</fileMode>
-			<outputDirectory>rts/lra/</outputDirectory>
-		</file>
-		<file>
-			<source>../rts/lra/coordinator-war/target/lra-coordinator.war</source>
-			<fileMode>0644</fileMode>
-			<outputDirectory>rts/lra/</outputDirectory>
-		</file>
-		<file>
-			<source>../rts/lra/coordinator-thorntail/target/lra-coordinator-thorntail.jar</source>
-			<fileMode>0644</fileMode>
-			<outputDirectory>rts/lra/</outputDirectory>
-		</file>
 	</files>
 	<fileSets>
 		<fileSet>
@@ -335,10 +315,6 @@
 			<directory>../rest-tx/quickstarts
 			</directory>
 			<outputDirectory>quickstarts/rest-tx</outputDirectory>
-		</fileSet>
-		<fileSet>
-			<directory>../rts/lra/coordinator-quarkus/target/lib</directory>
-			<outputDirectory>rts/lra/lib</outputDirectory>
 		</fileSet>
 	</fileSets>
 </assembly> 

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
     <version.com.sun.grizzly>1.9.59</version.com.sun.grizzly>
     <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
     <version.junit>4.13.1</version.junit>
-    <version.org.jboss.byteman>4.0.13</version.org.jboss.byteman>
+    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
     <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
     <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
     <version.org.jboss.arquillian.container.weld>1.0.0.CR9</version.org.jboss.arquillian.container.weld>

--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -204,18 +204,6 @@
         <version>${version.org.jboss.resteasy}</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-servlet</artifactId>
-        <version>[2.0.21,)</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.undertow</groupId>
-        <artifactId>undertow-core</artifactId>
-        <version>[2.0.21,)</version>
-        <scope>test</scope>
-    </dependency>
     <!-- end undertow with RestEasy -->
   </dependencies>
   <build>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -106,6 +106,7 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
           </dependency>
 	    </dependencies>
       </profile>
+      <!--
       <profile>
         <id>community</id>
         <modules>
@@ -113,6 +114,7 @@ Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
           <module>sra</module>
         </modules>
       </profile>
+      -->
     </profiles>
   <modules>
     <module>at</module>


### PR DESCRIPTION
Given that sra and lra use an old version of Quarkus on this branch, they are being disabled from the build.

A later version of Byteman is used.

The Undertow dependencies and not directly added (`master` does not add them either - https://github.com/jbosstm/narayana/blob/master/rts/at/tx/pom.xml)

!JACOCO !AS_TESTS !XTS !RTS (these should use the app server but WildFly 23.x (https://github.com/jbosstm/narayana/blob/5.11/scripts/hudson/narayana.sh#L393) is no longer maintained. !LRA (it downloads the latest nightly)