### PR TITLE
[JBTM-3588] make the javadoc-maven-plugin work with jakarta

### DIFF
--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -422,7 +422,7 @@
           <systemPath>${orson.jar.location}/orson-0.5.0.jar</systemPath>
         </dependency>
         <dependency>
-          <groupId>jfree</groupId>
+          <groupId>org.jfree</groupId>
           <artifactId>jfreechart</artifactId>
           <version>${version.jfree}</version>
         </dependency>

--- a/ArjunaCore/arjunacore/pom.xml
+++ b/ArjunaCore/arjunacore/pom.xml
@@ -154,7 +154,7 @@
         <systemPath>${orson.jar.location}/orson-0.5.0.jar</systemPath>
       </dependency>
         <dependency>
-        <groupId>jfree</groupId>
+        <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${version.jfree}</version>
       </dependency>

--- a/ArjunaJTA/narayana-jta/pom.xml
+++ b/ArjunaJTA/narayana-jta/pom.xml
@@ -244,7 +244,7 @@
         <systemPath>${orson.jar.location}/orson-0.5.0.jar</systemPath>
       </dependency>
         <dependency>
-        <groupId>jfree</groupId>
+        <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${version.jfree}</version>
       <scope>provided</scope>

--- a/ArjunaJTS/narayana-jts-idlj/pom.xml
+++ b/ArjunaJTS/narayana-jts-idlj/pom.xml
@@ -384,7 +384,7 @@
         <systemPath>${orson.jar.location}/orson-0.5.0.jar</systemPath>
       </dependency>
         <dependency>
-        <groupId>jfree</groupId>
+        <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${version.jfree}</version>
       <scope>provided</scope>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -130,12 +130,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
-      <version>${version.javax.enterprise}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
       <version>${version.jakarta.annotation.jakarta-annotation-api}</version>
@@ -169,10 +163,6 @@
         <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jakarta.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -217,11 +207,6 @@
       <version>${version.org.jboss.logging.jboss-logging-processor}</version>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.transaction</groupId>
-      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-      <version>${version.org.jboss.spec.javax.transaction}</version>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
       <artifactId>ironjacamar-spec-api</artifactId>
       <version>${version.org.jboss.ironjacamar}</version>
@@ -244,23 +229,24 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <!-- jakarta TODO
-      <groupId>org.jboss.spec.jakarta.xml.bind</groupId>
-      <version>${version.org.jboss.spec.jakarta.xml.bind.jboss-jaxb-api_2.3_spec}</version>
-      -->
-      <groupId>org.jboss.spec.javax.xml.bind</groupId>
-      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-      <version>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec}</version>
-      <scope>provided</scope>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <version>${version.jakarta.json-api}</version>
     </dependency>
     <dependency>
-      <!-- jakarta TODO
-      <groupId>org.jboss.spec.jakarta.xml.ws</groupId>
-      <version>${version.org.jboss.spec.jakarta.xml.ws.jboss-jaxws-api_2.3_spec}</version>
-      -->
-      <groupId>org.jboss.spec.javax.xml.ws</groupId>
-      <artifactId>jboss-jaxws-api_2.3_spec</artifactId>
-      <version>${version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec}</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>${version.jakarta.xml.bind.jakarta-xml-bind-api}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
+      <version>${version.jakarta.xml.ws.jakarta.xml.ws-api}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${version.jakarta.servlet.jakarta-servlet-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -365,6 +351,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.4.1</version>
             <executions>
               <execution>
                 <id>javadoc</id>
@@ -417,8 +404,20 @@
                     <additionalJOption>${jvm.args.modular}</additionalJOption>
                   </additionalJOptions>
                   <dependencySourceExcludes>
-                    <dependencySourceExclude>javax.enterprise:cdi-api</dependencySourceExclude>
-                    <dependencySourceExclude>org.jboss.spec.jakarta.xml.bind:jboss-jaxb-api_2.3_spec</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.annotation:jakarta.annotation-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.json:jakarta.json-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.servlet:jakarta.servlet-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.interceptor:jakarta.interceptor-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.ejb:jakarta.ejb-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.inject:jakarta.inject-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.xml.bind:jakarta.xml.bind-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.xml.soap:jakarta.xml.soap-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.xml.ws:jakarta.xml.ws-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.ws.rs:jakarta.ws.rs-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.jms:jakarta.jms-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.enterprise:jakarta.enterprise.cdi-api</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.enterprise:jakarta.enterprise.lang-model</dependencySourceExclude>
+                    <dependencySourceExclude>jakarta.el:jakarta.el-api</dependencySourceExclude>
                   </dependencySourceExcludes>
                 </configuration>
               </execution>
@@ -455,7 +454,7 @@
           <systemPath>${orson.jar.location}/orson-0.5.0.jar</systemPath>
         </dependency>
         <dependency>
-          <groupId>jfree</groupId>
+          <groupId>org.jfree</groupId>
           <artifactId>jfreechart</artifactId>
           <version>${version.jfree}</version>
           <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
     <version.javax.ws.rs-api>2.0.1.Final</version.javax.ws.rs-api>
     <version.jaxb>2.3.0</version.jaxb>
     <version.jaxws-ri>2.3.5</version.jaxws-ri>
-    <version.jfree>1.0.9</version.jfree>
+    <version.jfree>1.5.3</version.jfree>
     <version.jnpserver>5.0.3.GA</version.jnpserver>
     <version.junit>4.13.1</version.junit>
     <version.junit.jupiter>5.7.1</version.junit.jupiter>
@@ -813,11 +813,9 @@
     </profile>
     <profile>
       <id>community</id>
-      <!-- jakarta TODO package javax.swing is declared in module java.desktop, but module jakarta.annotation does not read it etc
-      <modules>
+      <modules> 
         <module>narayana-full</module>
       </modules>
-      -->
       <properties>
         <version.orson>0.5.0</version.orson>
         <version.tanukisoft>3.2.3</version.tanukisoft>


### PR DESCRIPTION
make the javadoc-maven-plugin work with jakarta
some jakarta dependencies need to be excluded from javadoc because jdk modularity:

      `[ERROR] Exit code: 1 - ~/narayana/narayana-full/target/distro-javadoc-sources/jakarta.xml.bind-api-4.0.0-sources/module-info.java:18: error: module not found: jakarta.activation
      [ERROR]     requires transitive jakarta.activation;
      [ERROR]                                ^
      [ERROR] error: cannot access module-info
      [ERROR]   cannot resolve modules`

jfree dependency update