### PR TITLE
JBTM-3588 jakarta migration of OSGi module (JBTM-2777)

### DIFF
--- a/osgi/jta/pom.xml
+++ b/osgi/jta/pom.xml
@@ -30,18 +30,36 @@
 
    <properties>
 	   <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
-           <version.org.jboss.spec.javax.transaction>1.0.0.Final</version.org.jboss.spec.javax.transaction>
 	   <karaf.home>${project.build.directory}/apache-karaf-minimal-${version.apache.karaf}</karaf.home>
    </properties>
 
+  <repositories>
+    <repository>
+      <id>spring</id>
+      <name>spring.io</name>
+      <url>https://repo.spring.io/milestone/</url>
+    </repository>
+  </repositories>
+  <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.karaf</groupId>
+                <artifactId>karaf-bom</artifactId>
+                <version>4.4.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+  
    <dependencies>
 	   <dependency>
 		   <groupId>org.osgi</groupId>
-		   <artifactId>org.osgi.core</artifactId>
+		   <artifactId>osgi.core</artifactId>
 	   </dependency>
 	   <dependency>
 		   <groupId>org.osgi</groupId>
-		   <artifactId>org.osgi.compendium</artifactId>
+		   <artifactId>osgi.cmpn</artifactId>
 	   </dependency>
 	   <dependency>
 		   <groupId>org.jboss.osgi.metadata</groupId>
@@ -51,18 +69,53 @@
 		   <groupId>org.osgi</groupId>
 		   <artifactId>org.osgi.enterprise</artifactId>
 	   </dependency>
-	   <dependency>
-		   <groupId>org.jboss.spec.javax.transaction</groupId>
-		   <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-		   <version>${version.org.jboss.spec.javax.transaction}</version>
-		   <scope>provided</scope>
-	   </dependency>
+<!-- 	   <dependency> -->
+<!-- 		   <groupId>org.jboss.spec.javax.transaction</groupId> -->
+<!-- 		   <artifactId>jboss-transaction-api_1.2_spec</artifactId> -->
+<!-- 		   <version>${version.org.jboss.spec.javax.transaction}</version> -->
+<!-- 		   <scope>provided</scope> -->
+<!-- 	   </dependency> -->
 	   <dependency>
 		   <groupId>org.jboss.narayana.jta</groupId>
 		   <artifactId>jta</artifactId>
 		   <version>${project.version}</version>
 		   <scope>provided</scope>
 	   </dependency>
+     
+           <dependency>
+          <groupId>jakarta.transaction</groupId>
+          <artifactId>jakarta.transaction-api</artifactId>
+          <version>2.0.1</version>
+      </dependency>
+      
+       <dependency>
+    <groupId>jakarta.enterprise</groupId>
+    <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    <version>4.0.1</version>
+</dependency>
+      <dependency>
+    <groupId>jakarta.el</groupId>
+    <artifactId>jakarta.el-api</artifactId>
+    <version>5.0.1</version>
+</dependency>
+
+<dependency>
+    <groupId>jakarta.enterprise</groupId>
+    <artifactId>jakarta.enterprise.lang-model</artifactId>
+    <version>4.0.1</version>
+</dependency>
+
+<dependency>
+    <groupId>jakarta.inject</groupId>
+    <artifactId>jakarta.inject-api</artifactId>
+    <version>2.0.1</version>
+</dependency>
+
+<dependency>
+    <groupId>jakarta.interceptor</groupId>
+    <artifactId>jakarta.interceptor-api</artifactId>
+    <version>2.1.0</version>
+</dependency>
 	   <dependency>
 		   <groupId>org.jboss.narayana</groupId>
 		   <artifactId>common</artifactId>
@@ -111,11 +164,41 @@
 		   <version>${version.apache.karaf}</version>
 		   <scope>provided</scope>
 	   </dependency>
+     
+     
+     <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>standard</artifactId>
+            <version>${version.apache.karaf}</version>
+            <type>xml</type>
+            <classifier>features</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>org.apache.karaf.features.core</artifactId>
+            <version>${version.apache.karaf}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.karaf.system</groupId>
+            <artifactId>org.apache.karaf.system.core</artifactId>
+            <version>${version.apache.karaf}</version>
+            <scope>test</scope>
+        </dependency>
 	   <dependency>
 		   <groupId>org.springframework</groupId>
 		   <artifactId>spring-tx</artifactId>
 		   <optional>true</optional>
-		   <version>3.0.5.RELEASE</version>
+		   <version>6.0.0-M5</version>
 	   </dependency>
 	   <dependency>
 		   <groupId>junit</groupId>
@@ -126,8 +209,81 @@
 	   <dependency>
 		   <groupId>org.jboss.arquillian.junit</groupId>
 		   <artifactId>arquillian-junit-container</artifactId>
+           <version>1.7.0.Alpha13</version>
 		   <scope>test</scope>
 	   </dependency>
+     
+       <dependency>
+           <groupId>org.jboss.arquillian.container</groupId>
+           <artifactId>arquillian-container-karaf-managed</artifactId>
+           <version>${version.org.jboss.arquillian.osgi.karaf}</version>
+           <scope>test</scope>
+       </dependency>
+       <dependency>
+           <groupId>org.jboss.arquillian.osgi</groupId>
+           <artifactId>arquillian-osgi-bundle</artifactId>
+           <version>${version.org.jboss.arquillian.osgi.karaf}</version>
+           <scope>test</scope>
+       </dependency>
+       
+       
+       
+            
+     <!-- Provide the KarafTestSupport -->
+        <dependency>
+            <groupId>org.apache.karaf.itests</groupId>
+            <artifactId>common</artifactId>
+            <version>4.4.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Define the Apache Karaf version to download and use for the test -->
+        <!-- We use a released version here to avoid SNAPSHOT resolution -->
+        <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>apache-karaf</artifactId>
+            <scope>test</scope>
+            <type>tar.gz</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.karaf</groupId>
+                    <artifactId>org.apache.karaf.client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Required to use shell commands in the tests -->
+        <dependency>
+            <groupId>org.apache.karaf.shell</groupId>
+            <artifactId>org.apache.karaf.shell.core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Provide the PaxExam Karaf support -->
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-karaf</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Provide the PaxExam JUnit extension -->
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-atinject_1.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.hamcrest</artifactId>
+            <version>1.3_1</version>
+            <scope>runtime</scope>
+        </dependency>
+       
    </dependencies>
    <build>
 	   <resources>
@@ -160,7 +316,7 @@
 			   <plugin>
 				   <artifactId>maven-surefire-plugin</artifactId>
 				   <configuration>
-					   <skip>true</skip>
+					   <skip>false</skip>
 				   </configuration>
 			   </plugin>
 		   </plugins>
@@ -185,7 +341,7 @@
 						   org.jboss.tm*;version=${version.org.jboss.jboss-transaction-spi},
 						   org.jboss.narayana.osgi.jta;version=${project.version},
 						   org.jboss.narayana.osgi.jta.command;version=${project.version},
-						   jakarta.transaction*;version="1.2.0"
+						   jakarta.transaction*;version="2.0.1"
 					   </Export-Package>
 					   <Private-Package>
 						   org.jboss.narayana.osgi.jta.internal,
@@ -243,6 +399,7 @@
 			   </instructions>
 		   </configuration>
 	   </plugin>
+     
 	   <plugin>
 		   <groupId>org.codehaus.mojo</groupId>
 		   <artifactId>build-helper-maven-plugin</artifactId>
@@ -271,11 +428,26 @@
 		   <configuration combine.self="override">
 			   <forkMode>always</forkMode>
 			   <!-- j9 JBTM-2777 disable the osgi test until KARAF-3518 resolved -->
-			   <excludes>
-				   <exclude>**/OSGiJTATest.java</exclude>
-			   </excludes>
+<!-- 			   <excludes> -->
+<!-- 				   <exclude>**/OSGiJTATest.java</exclude> -->
+<!-- 			   </excludes> -->
 		   </configuration>
 	   </plugin>
+     
+            <!-- Allows for the use of versionAsInProject() in Pax Exam tests -->
+<plugin>
+  <groupId>org.apache.servicemix.tooling</groupId>
+  <artifactId>depends-maven-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>generate-depends-file</id>
+      <goals>
+        <goal>generate-depends-file</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+     
 	   </plugins>
    </build>
    <profiles>

--- a/osgi/jta/src/main/resources/features.xml
+++ b/osgi/jta/src/main/resources/features.xml
@@ -3,6 +3,16 @@
 
     <feature name='${project.artifactId}' version='${project.version}'>
     	<bundle>mvn:org.jboss.narayana.osgi/narayana-osgi-jta/${project.version}</bundle>
+        <bundle start-level='8' start='true'>mvn:org.ops4j.pax.logging/pax-logging-api</bundle>    
+        <bundle start-level='8' start='true'>mvn:org.ops4j.pax.logging/pax-logging-service</bundle>
+        <bundle start-level='10' start='true'>mvn:org.apache.felix/org.apache.felix.configadmin</bundle>
+    
+        <bundle start-level='11' start='true'>mvn:org.apache.felix/org.apache.felix.fileinstall</bundle>
+    	<bundle start-level='20' start='true'>mvn:org.apache.sshd/sshd-core</bundle>
+    	<bundle start-level='5' start='true'>mvn:org.ops4j.pax.url/pax-url-aether</bundle>
+    	<bundle start-level='15' start='true'>mvn:org.apache.karaf.features/org.apache.karaf.features.core</bundle>
+    	<bundle start-level='20' start='true'>mvn:org.jboss.narayana.osgi/narayana-osgi-jta</bundle>
+      
     </feature>
 
 </features>

--- a/osgi/jta/src/test/java/org/jboss/narayana/osgi/jta/OSGiJTATest.java
+++ b/osgi/jta/src/test/java/org/jboss/narayana/osgi/jta/OSGiJTATest.java
@@ -21,60 +21,197 @@
  */
 package org.jboss.narayana.osgi.jta;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.osgi.metadata.OSGiManifestBuilder;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.Asset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.ops4j.pax.exam.Constants.START_LEVEL_SYSTEM_BUNDLES;
+import static org.ops4j.pax.exam.CoreOptions.bootDelegationPackage;
+import static org.ops4j.pax.exam.CoreOptions.frameworkStartLevel;
+import static org.ops4j.pax.exam.CoreOptions.url;
+import static org.ops4j.pax.exam.CoreOptions.when;
+import static org.ops4j.pax.exam.OptionUtils.combine;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Enumeration;
+
+import org.apache.karaf.itests.KarafTestSupport;
+import org.jboss.narayana.osgi.jta.internal.OsgiTransactionManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.ConfigurationManager;
+import org.ops4j.pax.exam.CoreOptions;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.container.remote.RBCRemoteTargetOptions;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.container.internal.JavaVersionUtil;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
+import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.options.extra.VMOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 
+import aQute.bnd.osgi.Constants;
 import jakarta.transaction.TransactionManager;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Dictionary;
-import java.util.Enumeration;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
  */
 
-@RunWith(Arquillian.class)
-public class OSGiJTATest {
-    @ArquillianResource
-    BundleContext context;
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class OSGiJTATest extends KarafTestSupport{
 
-    @Deployment
-    public static JavaArchive createTestArchive() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "test.jar");
-        archive.addClass(OSGiJTATest.class);
-        archive.addPackage("org.osgi.util.tracker");
-        archive.setManifest(new Asset() {
-            public InputStream openStream() {
-                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
-                builder.addBundleSymbolicName(archive.getName());
-                builder.addBundleManifestVersion(2);
-                builder.addImportPackages("jakarta.transaction");
-                return builder.openStream();
-            }
-        });
-        return archive;
+    
+    @Configuration
+    public Option[] config() {
+        String httpPort = Integer.toString(getAvailablePort(Integer.parseInt(MIN_HTTP_PORT), Integer.parseInt(MAX_HTTP_PORT)));
+        String rmiRegistryPort = Integer.toString(getAvailablePort(Integer.parseInt(MIN_RMI_REG_PORT), Integer.parseInt(MAX_RMI_REG_PORT)));
+        String rmiServerPort = Integer.toString(getAvailablePort(Integer.parseInt(MIN_RMI_SERVER_PORT), Integer.parseInt(MAX_RMI_SERVER_PORT)));
+        String sshPort = Integer.toString(getAvailablePort(Integer.parseInt(MIN_SSH_PORT), Integer.parseInt(MAX_SSH_PORT)));
+        String localRepository = System.getProperty("org.ops4j.pax.url.mvn.localRepository");
+        if (localRepository == null) {
+            localRepository = "";
+        }
+
+        // org.ops4j.pax.exam.spi.PaxExamRuntime.defaultTestSystemOptions() does it implicitly when pax.exam.system = test
+        ConfigurationManager cm = new ConfigurationManager();
+        String logging = cm.getProperty(org.ops4j.pax.exam.Constants.EXAM_LOGGING_KEY, org.ops4j.pax.exam.Constants.EXAM_LOGGING_PAX_LOGGING);
+        Option[] examOptions = new Option[] {
+                bootDelegationPackage("sun.*"),
+                frameworkStartLevel(org.ops4j.pax.exam.Constants.START_LEVEL_TEST_BUNDLE),
+                url("link:classpath:META-INF/links/org.ops4j.pax.exam.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.exam.inject.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.extender.service.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+
+                when(logging.equals(org.ops4j.pax.exam.Constants.EXAM_LOGGING_PAX_LOGGING)).useOptions(
+                        url("link:classpath:META-INF/links/org.ops4j.pax.logging.api.link").startLevel(START_LEVEL_SYSTEM_BUNDLES)),
+
+                url("link:classpath:META-INF/links/org.ops4j.base.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.swissbox.core.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.swissbox.extender.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.swissbox.framework.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.swissbox.lifecycle.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                url("link:classpath:META-INF/links/org.ops4j.pax.swissbox.tracker.link").startLevel(START_LEVEL_SYSTEM_BUNDLES),
+                // but we don't want geronimo atinject...
+//                url("link:classpath:META-INF/links/org.apache.geronimo.specs.atinject.link").startLevel(START_LEVEL_SYSTEM_BUNDLES)
+                // we want SMX inject 1_3
+                url("link:classpath:org.apache.servicemix.bundles.javax-inject.link").startLevel(START_LEVEL_SYSTEM_BUNDLES)
+        };
+
+        Option[] testOptions = null;
+        if (JavaVersionUtil.getMajorVersion() >= 9) {
+            testOptions = new Option[] {
+                // debugConfiguration("8889", true),
+                KarafDistributionOption.karafDistributionConfiguration().frameworkUrl(getKarafDistribution()).name("Apache Karaf").unpackDirectory(new File("target/exam")),
+                // enable JMX RBAC security, thanks to the KarafMBeanServerBuilder
+                KarafDistributionOption.configureSecurity().disableKarafMBeanServerBuilder(),
+                KarafDistributionOption.configureConsole().ignoreLocalConsole(),
+                KarafDistributionOption.keepRuntimeFolder(),
+                KarafDistributionOption.logLevel(LogLevel.INFO),
+                CoreOptions.systemTimeout(3600000),
+                RBCRemoteTargetOptions.waitForRBCFor(3600000),
+                CoreOptions.mavenBundle().groupId("org.awaitility").artifactId("awaitility").versionAsInProject(),
+                CoreOptions.mavenBundle().groupId("org.apache.servicemix.bundles").artifactId("org.apache.servicemix.bundles.hamcrest").versionAsInProject(),
+                CoreOptions.mavenBundle().groupId("org.apache.karaf.itests").artifactId("common").versionAsInProject(),
+                CoreOptions.mavenBundle().groupId("javax.annotation").artifactId("javax.annotation-api").versionAsInProject(),
+              CoreOptions.mavenBundle().groupId("jakarta.el").artifactId("jakarta.el-api").versionAsInProject(),
+              CoreOptions.mavenBundle().groupId("jakarta.inject").artifactId("jakarta.inject-api").versionAsInProject(),
+              CoreOptions.mavenBundle().groupId("jakarta.interceptor").artifactId("jakarta.interceptor-api").versionAsInProject(),
+              CoreOptions.mavenBundle().groupId("jakarta.enterprise").artifactId("jakarta.enterprise.cdi-api").versionAsInProject(),
+              CoreOptions.mavenBundle().groupId("jakarta.enterprise").artifactId("jakarta.enterprise.lang-model").versionAsInProject(),
+
+              CoreOptions.mavenBundle().groupId("jakarta.transaction").artifactId("jakarta.transaction-api").versionAsInProject(),
+                KarafDistributionOption.features("src/main/resources/features.xml", "narayana-osgi-jta"),
+                
+                KarafDistributionOption.features(CoreOptions.mavenBundle().groupId("org.apache.karaf.features")
+                                .artifactId("standard").classifier("features")
+                                .version("3.0.1").type("xml"), "scr"),
+
+                //replaceConfigurationFile("etc/host.key", getConfigFile("/etc/host.key")),
+                KarafDistributionOption.replaceConfigurationFile("etc/users.properties", getConfigFile("/etc/users.properties")),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.features.cfg", "updateSnapshots", "none"),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", httpPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort", rmiRegistryPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort", rmiServerPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", sshPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg", "org.ops4j.pax.url.mvn.localRepository", localRepository),
+                KarafDistributionOption.editConfigurationFilePut("etc/branding.properties", "welcome", ""), // No welcome banner
+                KarafDistributionOption.editConfigurationFilePut("etc/branding-ssh.properties", "welcome", ""),
+                new VMOption("--add-reads=java.xml=java.logging"),
+                new VMOption("--add-exports=java.base/org.apache.karaf.specs.locator=java.xml,ALL-UNNAMED"),
+                new VMOption("--patch-module"),
+                new VMOption("java.base=lib/endorsed/org.apache.karaf.specs.locator-"
+                    + System.getProperty("karaf.version") + ".jar"),
+                new VMOption("--patch-module"), new VMOption("java.xml=lib/endorsed/org.apache.karaf.specs.java.xml-"
+                    + System.getProperty("karaf.version") + ".jar"),
+                new VMOption("--add-opens"),
+                new VMOption("java.base/java.security=ALL-UNNAMED"),
+                new VMOption("--add-opens"),
+                new VMOption("java.base/java.net=ALL-UNNAMED"),
+                new VMOption("--add-opens"),
+                new VMOption("java.base/java.lang=ALL-UNNAMED"),
+                new VMOption("--add-opens"),
+                new VMOption("java.base/java.util=ALL-UNNAMED"),
+                new VMOption("--add-opens"),
+                new VMOption("java.naming/javax.naming.spi=ALL-UNNAMED"),
+                new VMOption("--add-opens"),
+                new VMOption("java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.base/sun.net.www.protocol.file=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.base/sun.net.www.protocol.ftp=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.base/sun.net.www.content.text=ALL-UNNAMED"),
+                new VMOption("--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED"),
+                new VMOption("--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED"),
+                new VMOption("-classpath"),
+                new VMOption("lib/jdk9plus/*" + File.pathSeparator + "lib/boot/*"
+                    + File.pathSeparator + "lib/endorsed/*")
+                
+            };
+        } else {
+            testOptions = new Option[] {
+                //debugConfiguration("8889", true),
+                KarafDistributionOption.karafDistributionConfiguration().frameworkUrl(getKarafDistribution()).name("Apache Karaf").unpackDirectory(new File("target/exam")),
+                // enable JMX RBAC security, thanks to the KarafMBeanServerBuilder
+                KarafDistributionOption.configureSecurity().disableKarafMBeanServerBuilder(),
+                KarafDistributionOption.configureConsole().ignoreLocalConsole(),
+                KarafDistributionOption.keepRuntimeFolder(),
+                KarafDistributionOption.logLevel(LogLevel.INFO),
+                CoreOptions.systemTimeout(3600000),
+                RBCRemoteTargetOptions.waitForRBCFor(3600000),
+                CoreOptions.mavenBundle().groupId("org.awaitility").artifactId("awaitility").versionAsInProject(),
+                CoreOptions.mavenBundle().groupId("org.apache.servicemix.bundles").artifactId("org.apache.servicemix.bundles.hamcrest").versionAsInProject(),
+                CoreOptions.mavenBundle().groupId("org.apache.karaf.itests").artifactId("common").versionAsInProject(),
+                //replaceConfigurationFile("etc/host.key", getConfigFile("/etc/host.key")),
+                KarafDistributionOption.replaceConfigurationFile("etc/users.properties", getConfigFile("/etc/users.properties")),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.features.cfg", "updateSnapshots", "none"),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", httpPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort", rmiRegistryPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort", rmiServerPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", sshPort),
+                KarafDistributionOption.editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg", "org.ops4j.pax.url.mvn.localRepository", localRepository),
+                KarafDistributionOption.editConfigurationFilePut("etc/branding.properties", "welcome", ""), // No welcome banner
+                KarafDistributionOption.editConfigurationFilePut("etc/branding-ssh.properties", "welcome", ""),
+            };
+        }
+
+        return combine(examOptions, testOptions);
     }
-
+    
     @Test
-    public  void testTransactionManager(@ArquillianResource Bundle bundle) throws Exception {
-        assertEquals("System Bundle ID", 0, context.getBundle().getBundleId());
+    public  void testTransactionManager() throws Exception {
+//        assertEquals("System Bundle ID", 0, bundleContext.getBundle().getBundleId());
+        
 
+        Bundle bundle = bundleContext.getBundle();
         bundle.start();
         assertEquals("Bundle ACTIVE", Bundle.ACTIVE, bundle.getState());
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -25,26 +25,24 @@
   <name>Narayana: OSGi Transaction Service</name>
   <description>Narayana: OSGi Transaction Service</description>
 
-  <properties>
+    <properties>
     <version.org.jboss.arquillian.osgi.karaf>2.2.2.Final</version.org.jboss.arquillian.osgi.karaf>
-    <version.jboss.osgi.metadata>4.0.0.CR1</version.jboss.osgi.metadata>
-    <version.org.jboss.arquillian.core>1.1.10.Final</version.org.jboss.arquillian.core>
-    <version.shrinkwrap>1.1.2</version.shrinkwrap>
-    <version.apache.karaf>4.0.5</version.apache.karaf>
+    <version.jboss.osgi.metadata>6.0.1.Final</version.jboss.osgi.metadata>
+    <version.apache.karaf>4.4.2</version.apache.karaf>
     <sortpom.skip>true</sortpom.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.core</artifactId>
-        <version>5.0.0</version>
+        <artifactId>osgi.core</artifactId>
+        <version>8.0.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.compendium</artifactId>
-        <version>5.0.0</version>
+        <artifactId>osgi.cmpn</artifactId>
+        <version>7.0.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -52,11 +50,6 @@
          <artifactId>org.osgi.enterprise</artifactId>
          <version>5.0.0</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.junit</groupId>
-        <artifactId>arquillian-junit-container</artifactId>
-        <version>${version.org.jboss.arquillian.core}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.osgi.metadata</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -813,7 +813,7 @@
     </profile>
     <profile>
       <id>community</id>
-      <modules> 
+      <modules>
         <module>narayana-full</module>
       </modules>
       <properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-2777

- Spring migrated to Jakarta requires jdk17 : osgi module will require jdk17 profile

- Spring is not officially migrated to jakarta (there are only milestones in repository https://repo.spring.io/milestone/): this repository will be used until official artifact will be available in maven central

- Karaf doc recommend to use PaxExam for Integration Tests (https://github.com/apache/karaf/tree/main/examples/karaf-itest-example): PaxExam will be used

- Arquillian integration test framework dependency used previously has a known issue for osgi and jdk 9+ (https://issues.apache.org/jira/browse/KARAF-3518, https://issues.redhat.com/browse/ARQ-2201), opened issue https://github.com/arquillian/arquillian-container-osgi/issues/152 : arquillian-osgi-bundle and arquillian-container-karaf-managed deps will not be used anymore.