### PR TITLE
JBTM-3716 - The JACOCO axis (i.e. code coverage) fails because of the execution order of maven plugins

### DIFF
--- a/ArjunaJTS/idl/idlj-openjdk/pom.xml
+++ b/ArjunaJTS/idl/idlj-openjdk/pom.xml
@@ -128,11 +128,11 @@
         <version>1.7</version>
         <executions>
           <execution>
-            <id>generate-sources</id>
+            <id>compile-idl-sources</id>
             <goals>
               <goal>run</goal>
             </goals>
-            <phase>generate-sources</phase>
+            <phase>process-sources</phase>
             <configuration>
               <tasks name="Generate idl stubs">
                 <property name="idl.compiler.class" value="com.sun.tools.corba.se.idl.toJavaPortable.Compile"></property>

--- a/ArjunaJTS/idl/idlj-openjdk/pom.xml
+++ b/ArjunaJTS/idl/idlj-openjdk/pom.xml
@@ -100,6 +100,26 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>attach-test-sources</id>
+            <goals>
+              <goal>test-jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
@@ -123,6 +143,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>1.7</version>
@@ -311,24 +332,6 @@
                 </java>
               </tasks>
             </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>attach-test-sources</id>
-            <goals>
-              <goal>test-jar-no-fork</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Addresses [JBTM-3716](https://issues.redhat.com/browse/JBTM-3716)

JDK17 JACOCO

!CORE !TOMCAT !AS_TESTS !RTS !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle