### PR TITLE
[JBTM-3719] Deprecate OSGi module

### DIFF
--- a/osgi/README.md
+++ b/osgi/README.md
@@ -1,0 +1,15 @@
+### DEPRECATION NOTICE : this module will not be part of Narayana project since release 6.0.0
+
+# Narayana-OSGi-JTA
+
+## Integrate with Karaf
+
+The Narayana has been introduced in the Karaf 4.1.0-SNAPSHOT. You need to build from https://github.com/apache/karaf.
+
+The narayana configuration file could be found in <karaf-4.1.0-SNAPSHOT>/etc/org.jboss.nararayana.cfg
+
+
+## More Information
+
+Narayana Osgi documentation: https://www.narayana.io/docs/project/#d0e16703
+For more information see the OSGi Specification Project pages at Eclipse: https://projects.eclipse.org/projects/technology.osgi

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/ObjStoreBrowserService.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/ObjStoreBrowserService.java
@@ -26,8 +26,16 @@ import java.util.List;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ * 
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 public interface ObjStoreBrowserService {
     void probe() throws MBeanException;
     List<String> types();

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/AttachCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/AttachCommand.java
@@ -30,8 +30,16 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "attach", description = "Attach to a transaction log")
 @Service
 public class AttachCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/DeleteCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/DeleteCommand.java
@@ -30,8 +30,15 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
-
+@Deprecated
 @Command(scope = "narayana", name = "delete", description = "Delete the specified heuristic participant")
 @Service
 public class DeleteCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/DetachCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/DetachCommand.java
@@ -29,8 +29,16 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "detach", description = "Detach to a transaction log")
 @Service
 public class DetachCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/ForgetCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/ForgetCommand.java
@@ -30,8 +30,16 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "forget", description = "Move the specified heuristic participant back to the prepared list")
 @Service
 public class ForgetCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/ListCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/ListCommand.java
@@ -30,8 +30,16 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "ls", description = "List the transactions")
 @Service
 public class ListCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/ProbeCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/ProbeCommand.java
@@ -29,8 +29,16 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "refresh", description = "Refresh the view of the object store")
 @Service
 public class ProbeCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/SelectCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/SelectCommand.java
@@ -30,8 +30,16 @@ import org.jboss.narayana.osgi.jta.ObjStoreBrowserService;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "select", description = "Select a particular transaction type")
 @Service
 public class SelectCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/TypesCommand.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/command/TypesCommand.java
@@ -31,8 +31,16 @@ import java.util.List;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 @Command(scope = "narayana", name = "types", description = "List record types")
 @Service
 public class TypesCommand implements Action {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/Activator.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/Activator.java
@@ -44,6 +44,15 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.log.LogService;
 
+/**
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta.
+ * <p/>
+ */
+@Deprecated
 public class Activator implements BundleActivator, ManagedService, Runnable {
 
     public static final String PID = "org.jboss.narayana";

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/ObjStoreBrowserImpl.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/ObjStoreBrowserImpl.java
@@ -52,8 +52,16 @@ import java.util.Set;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
+@Deprecated
 public class ObjStoreBrowserImpl implements ObjStoreBrowserService{
     private ObjStoreBrowser osb;
     private PrintStream printStream;

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/OsgiServer.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/OsgiServer.java
@@ -50,6 +50,16 @@ import org.osgi.service.log.LogService;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
+/**
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
+ */
+
+@Deprecated
 public class OsgiServer implements ServiceTrackerCustomizer<XAResourceRecovery, XAResourceRecovery> {
 
     private final BundleContext bundleContext;

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/OsgiTransactionManager.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/OsgiTransactionManager.java
@@ -28,6 +28,15 @@ import javax.transaction.UserTransaction;
 
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
 
+/**
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
+ */
+@Deprecated
 public class OsgiTransactionManager extends TransactionManagerImple implements UserTransaction {
 
     public interface Listener {

--- a/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/PlatformTransactionManagerImple.java
+++ b/osgi/jta/src/main/java/org/jboss/narayana/osgi/jta/internal/PlatformTransactionManagerImple.java
@@ -31,7 +31,14 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
+@Deprecated
 public class PlatformTransactionManagerImple extends JtaTransactionManager {
 
     private final Map<Transaction, SuspendedResourcesHolder> suspendedResources = new ConcurrentHashMap<>();

--- a/osgi/jta/src/test/java/org/jboss/narayana/osgi/jta/OSGiJTATest.java
+++ b/osgi/jta/src/test/java/org/jboss/narayana/osgi/jta/OSGiJTATest.java
@@ -47,9 +47,17 @@ import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:zfeng@redhat.com">Amos Feng</a>
+ *
+ * @deprecated The OSGi module will be removed. Other OSGi Transaction Manager implementations can be used.
+ * Release 6.x (Jakarta) will not include OSGi module because:
+ * <p/>
+ * i) The OSGi compendium fully Jakarta release has not been released yet;
+ * ii) Product(s) using Narayana and supporting OSGi has not yet moved to Jakarta;
+ * <p/>
  */
 
 @RunWith(Arquillian.class)
+@Deprecated
 public class OSGiJTATest {
     @ArquillianResource
     BundleContext context;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3719

Deprecated OSGi module in Narayana project. Release 6.x will not include this module.

NO_TESTS

