### PR TITLE
JBTM-3734 Replace synchronized with JUCL

### DIFF
--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/ParticipantRecord.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/ParticipantRecord.java
@@ -645,9 +645,15 @@ public class ParticipantRecord extends
     /**
      * record the fact that this participant has completed
      */
-    public final synchronized void completed ()
+    public final void completed ()
     {
-        _completed = true;
+		synchronizationLock.lock();
+
+		try {
+			_completed = true;
+		} finally {
+			synchronizationLock.unlock();
+		}
     }
 
     /**
@@ -656,9 +662,15 @@ public class ParticipantRecord extends
      * @caveat it is only appropriate to call this if this is a CoordinatorCompletion participant
      * @return true if the participant is still able to be sent a complete request otherwise false
      */
-    public final synchronized boolean isActive ()
+    public final boolean isActive ()
     {
-        return !_completed && !_exited;
+		synchronizationLock.lock();
+
+		try {
+			return !_completed && !_exited;
+		} finally {
+			synchronizationLock.unlock();
+		}
     }
 
     /**

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ATCoordinator.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ATCoordinator.java
@@ -225,34 +225,47 @@ public class ATCoordinator extends TwoPhaseCoordinator
 		return _theId;
 	}
 
-	public synchronized void participantRolledBack (String participantId)
+	public void participantRolledBack (String participantId)
 			throws InvalidParticipantException, WrongStateException,
 			SystemException
 	{
-		if (participantId == null)
-			throw new SystemException(
-                    wscfLogger.i18NLogger.get_model_twophase_arjunacore_ATCoordinator_2());
+		synchronizationLock.lock();
 
-		if (status() == ActionStatus.RUNNING)
-			changeParticipantStatus(participantId, ROLLEDBACK);
-		else
-			throw new WrongStateException();
+		try {
+			if (participantId == null)
+				throw new SystemException(
+						wscfLogger.i18NLogger.get_model_twophase_arjunacore_ATCoordinator_2());
+
+			if (status() == ActionStatus.RUNNING)
+				changeParticipantStatus(participantId, ROLLEDBACK);
+			else
+				throw new WrongStateException();
+		} finally {
+			synchronizationLock.unlock();
+		}
+
 	}
 
-	public synchronized void participantReadOnly (String participantId)
+	public void participantReadOnly (String participantId)
 			throws InvalidParticipantException, SystemException
 	{
-		if (participantId == null)
-			throw new SystemException(
-                    wscfLogger.i18NLogger.get_model_twophase_arjunacore_ATCoordinator_2());
+		synchronizationLock.lock();
 
-		if (status() == ActionStatus.RUNNING)
-		{
-			changeParticipantStatus(participantId, READONLY);
+		try {
+			if (participantId == null)
+				throw new SystemException(
+						wscfLogger.i18NLogger.get_model_twophase_arjunacore_ATCoordinator_2());
+
+			if (status() == ActionStatus.RUNNING)
+			{
+				changeParticipantStatus(participantId, READONLY);
+			}
+			else
+				throw new SystemException(
+						wscfLogger.i18NLogger.get_model_twophase_arjunacore_ATCoordinator_3());
+		} finally {
+			synchronizationLock.unlock();
 		}
-		else
-			throw new SystemException(
-                    wscfLogger.i18NLogger.get_model_twophase_arjunacore_ATCoordinator_3());
 	}
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3734
Replaced synchronized blocks with reentrantlocks as advised in JEP 425 to support virtual threads.

CORE

Edit:
The synchronized parts were replaced that caused thread pinnings in my own limited tests. These events occured at transaction start and end. To make locking consistent, all synchronized(this) and non-static synchronized methods were replaced in all subclasses of `StateManager`.  Additionally, I changed the `_syncLock` to be a `ReentrantLock` in `TwoPhaseCoordinator`. 

This should be enough for basic virtual thread work, although many other subclasses of `StateManager` contain different `synchronized(someCustomLock)` synchronizations, which will need to be investigated if someone hits thread pinnings on hot paths again. 

