### PR TITLE
upgrade smallrye-converter-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
     <version.org.wildfly.arquillian>5.0.0.Alpha5</version.org.wildfly.arquillian>
     <version.postgresql>42.3.1</version.postgresql>
     <version.quarkus>2.12.1.Final</version.quarkus>
-    <version.smallrye-converter-api>1.0.10</version.smallrye-converter-api>
+    <version.smallrye-converter-api>2.7.0</version.smallrye-converter-api>
     <version.sortpom>3.0.0</version.sortpom>
     <version.sun.jdk>jdk</version.sun.jdk>
   </properties>


### PR DESCRIPTION
Our smallrye dependency is way out of date. I have upgraded it to match what quarkus use but note that we only use it in the `cdi` module and even there the code path that could potentially use it is never exercised

CORE
!TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle
