### PR TITLE
removing hamcrest-library

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -26,7 +26,6 @@
 
   <properties>
     <version.com.sun.messaging.mq.fscontext>4.6-b01</version.com.sun.messaging.mq.fscontext>
-    <version.hamcrest>1.3</version.hamcrest>
     <version.jboss.profiler.jvmti>1.0.0.CR5</version.jboss.profiler.jvmti>
     <version.log4j-core>2.19.0</version.log4j-core>
   </properties>

--- a/rts/lra/pom.xml
+++ b/rts/lra/pom.xml
@@ -81,12 +81,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>${version.hamcrest}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${version.junit}</version>


### PR DESCRIPTION
removing hamcrest-library, this artifact was moved to:
org.hamcrest » hamcrest 2.2
Using hamcrest version 2.2

CORE !TOMCAT !AS_TESTS RTS !JACOCO !XTS QA_JTA QA_JTS_OPENJDKORB !PERF LRA !DB_TESTS !mysql !db2 !postgres !oracle
