### PR TITLE
[JBTM-3751] Upgrade org.jboss.invocation:jboss-invocation to 2.0.0.Final

### DIFF
--- a/ArjunaJTA/cdi/pom.xml
+++ b/ArjunaJTA/cdi/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.invocation</groupId>
-      <artifactId>jboss-invocation-jakarta</artifactId>
+      <artifactId>jboss-invocation</artifactId>
       <version>${version.org.jboss.invocation}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
     <version.org.jboss.arquillian.core>1.7.0.Alpha12</version.org.jboss.arquillian.core>
     <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
     <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
-    <version.org.jboss.invocation>1.7.0.Final</version.org.jboss.invocation>
+    <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
     <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
     <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
     <version.org.jboss.logging.jboss-logging>3.5.0.Final</version.org.jboss.logging.jboss-logging>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3751

Get rid of Jakarta transformation (variant of the artifact with -jakarta suffix) - instead use real Jakarta-namespaces-ready version.

CORE AS_TESTS RTS LRA XTS

!TOMCAT !JACOCO !QA_JTA !QA_JTS_OPENJDKORB !PERF !DB_TESTS !mysql !db2 !postgres !oracle
