### PR TITLE
[JBTM-3753] Make the concurrency of the LRA coordinator start method

### DIFF
--- a/rts/lra/README.adoc
+++ b/rts/lra/README.adoc
@@ -1,0 +1,18 @@
+= MicroProfile LRA
+
+link:https://github.com/eclipse/microprofile-lra[MicroProfile LRA] is a specification of an annotation based API that enables loosely coupled services to coordinate long running activities in such a way as to guarantee a globally consistent outcome without the need to take long duration locks on data.
+
+== MicroProfile Fault Tolerance
+LRA Coordinator implements Bulkhead Fault Tolerance strategies for dealing with failure:
+
+* Bulkhead: Limit concurrent execution so that failures in that area can't overload the whole system
+
+You can link:https://www.eclipse.org/community/eclipse_newsletter/2017/september/article4.php[configure the Fault Tolerance] variables (Bulkhead value and waitingTaskQueue) by defining the config property as "classname/annotation/parameter" in the link:./coordinator/src/main/resources/META-INF/microprofile-config.properties[microprofile-config.properties] file. 
+
+For more documentation on Narayana LRA:
+
+* link:https://www.narayana.io//docs/project/index.html#d5e7502[Narayana LRA doc]
+
+Documentation on MicroProfile LRA specification:
+
+* link:https://github.com/eclipse/microprofile-lra/blob/master/spec/src/main/asciidoc/microprofile-lra-spec.asciidoc[microprofile-lra-spec]

--- a/rts/lra/coordinator/src/main/resources/META-INF/microprofile-config.properties
+++ b/rts/lra/coordinator/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,7 @@
+#MicroProfile fault-tolerant configuration can be edited in this property file
+
+# max number of parallel calls to the coordinator (default 10)
+#io.narayana.lra.coordinator.api.Coordinator/startLRA/Bulkhead/value=10
+
+# max number of tasks in coordinator's queue (default 10)
+#io.narayana.lra.coordinator.api.Coordinator/startLRA/Bulkhead/waitingTaskQueue=10

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/LRAAsyncIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/LRAAsyncIT.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package io.narayana.lra.arquillian.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import io.narayana.lra.arquillian.Deployer;
+import io.narayana.lra.arquillian.TestBase;
+import io.narayana.lra.arquillian.resource.LRAParticipant;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+
+public class LRAAsyncIT extends TestBase {
+
+    private static final Logger log = Logger.getLogger(LRAAsyncIT.class);
+    private static final String SHOULD_NOT_BE_ASSOCIATED = "The narayana implementation (of the MP-LRA specification) still thinks that there is "
+            + "an active LRA associated with the current thread even though all LRAs should now be finished";
+    //Default maximum number of concurrent calls to LRA coordinator is 10 (see org.eclipse.microprofile.faulttolerance.Bulkhead @interface),
+    //you can change the default number in the microprofile-config.properties file
+    private static final int NUMBER_OF_TASKS = 10;
+    //In order to have calls as much concurrent as possible
+    //the number of threads should be equals or greater to the number of tasks
+    private ExecutorService executorService = Executors.newFixedThreadPool(NUMBER_OF_TASKS);
+
+    @ArquillianResource
+    public URL baseURL;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Override
+    public void before() {
+        super.before();
+        log.info("Running test " + testName.getMethodName());
+    }
+    @Override
+    public void after() {
+        super.after();
+        executorService.shutdown();
+    }
+    @Deployment
+    public static WebArchive deploy() {
+        return Deployer.deploy(LRAAsyncIT.class.getSimpleName(), LRAParticipant.class);
+    }
+
+    /**
+     * Invoke a resource method which in turn invokes other resources. The various
+     * resource invocations are called in new or existing LRAs. Various tests are
+     * performed to verify that the correct LRAs are used and the LRAs have the
+     * expected status (see the resource method for the detail).
+     */
+    @Test
+    public void testChainOfInvocations() {
+        Callable<URI> callableTask = () -> {
+
+                // Invoke a method which starts a transaction
+                // (note that the method LRAParticipant.CREATE_OR_CONTINUE_LRA also invokes
+                // other resource methods)
+                URI lra1 = invokeInTransaction(null, LRAParticipant.CREATE_OR_CONTINUE_LRA);
+                    lrasToAfterFinish.add(lra1);
+                    assertEquals("LRA should still be active. The identifier of the LRA was " + lra1, LRAStatus.Active,
+                            lraClient.getStatus(lra1));
+
+                    // end the LRA
+                    invokeInTransaction(lra1, LRAParticipant.END_EXISTING_LRA);
+
+
+                    return lraClient.getCurrent();
+
+        };
+
+        List<Callable<URI>> callableTasks = new ArrayList<>();
+        for(int i = 0; i< NUMBER_OF_TASKS; i++)
+            callableTasks.add(callableTask);
+
+        try {
+            List<Future<URI>> futures = executorService.invokeAll(callableTasks);
+            for( Future<URI> f : futures)
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, f.get());
+
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            fail("Error in testChainOfInvocations method");
+        }
+    }
+
+    /**
+     * test behavior when multiple LRAs are active
+     */
+    @Test
+    public void testNoCurrent() {
+            URI lra2 = invokeInTransaction(null, LRAParticipant.START_NEW_LRA);
+
+            Callable<URI> callableTask = () -> {
+                URI lra = invokeInTransaction(null, LRAParticipant.START_NEW_LRA);
+                lrasToAfterFinish.add(lra);
+
+                assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+                invokeInTransaction(lra, LRAParticipant.END_EXISTING_LRA);
+                return lra;
+
+            };
+
+
+            List<Callable<URI>> callableTasks = new ArrayList<>();
+            for(int i = 0; i< NUMBER_OF_TASKS; i++)
+                callableTasks.add(callableTask);
+
+            try {
+                List<Future<URI>> futures = executorService.invokeAll(callableTasks);
+                for( Future<URI> f : futures) {
+                    f.get();
+                    assertNull(SHOULD_NOT_BE_ASSOCIATED, lraClient.getCurrent());
+                }
+
+            } catch (InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+                fail("Error in testNoCurrent method");
+            }
+    }
+
+    private URI invokeInTransaction(URI lra, String resourcePath) {
+
+            Response response = null;
+
+            try {
+                Invocation.Builder builder = client.target(UriBuilder.fromUri(baseURL.toExternalForm())
+                        .path(LRAParticipant.RESOURCE_PATH).path(resourcePath).build()).request();
+
+                if (lra != null) {
+                    builder.header(LRA_HTTP_CONTEXT_HEADER, lra.toASCIIString());
+                }
+
+                response = builder.get();
+
+                assertTrue("This test expects that the invoked resource returns the identifier of the LRA "
+                        + "that was active during the invocation or an error message.", response.hasEntity());
+
+                String responseMessage = response.readEntity(String.class);
+
+                assertEquals(responseMessage, 200, response.getStatus());
+
+                return URI.create(responseMessage);
+            } finally {
+                if (response != null) {
+                    response.close();
+                }
+            }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3753
Make the concurrency of the LRA coordinator start method (added the microprofile-config.properties)
Added a test in lra-test-basic
Added a README.md in LRA module

JDK17
CORE !TOMCAT AS_TESTS RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERF LRA !DB_TESTS !mysql !db2 !postgres !oracle
