### PR TITLE
[FIX_DEPENDENCY] replaced hamcrest-core with hamcrest in QA

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -27,7 +27,6 @@
   <properties>
     <version.com.sun.messaging.mq.fscontext>4.6-b01</version.com.sun.messaging.mq.fscontext>
     <version.jboss.profiler.jvmti>1.0.0.CR5</version.jboss.profiler.jvmti>
-    <version.log4j-core>2.19.0</version.log4j-core>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -74,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This PR is a quick fix to replace `hamcrest-core` to `hamcrest`. I haven't raised a JIRA but let me know if you think one is needed. Thanks

JDK17 CORE QA_JTA QA_JTS_OPENJDKORB JACOCO

!TOMCAT !AS_TESTS !RTS !XTS !PERF !LRA !DB_TESTS !mysql !db2 !postgres !oracle

Note: I have used @moulalis' changes from #2097 to compile QA. As a consequence, if my PR passes all test axis, #2097 can be merged