### PR TITLE
JBTM-3768 Keep logs for both runs of emptyObjectStore

### DIFF
--- a/qa/tests/src/org/jboss/jbossts/qa/junit/TestGroupBase.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/junit/TestGroupBase.java
@@ -60,7 +60,7 @@ public class TestGroupBase
         // no need to do this here as it gets done in tearDown
         // TaskImpl.cleanupTasks();
 
-        Task emptyObjectStore = createTask("emptyObjectStore", org.jboss.jbossts.qa.Utils.EmptyObjectStore.class, Task.TaskType.EXPECT_PASS_FAIL, 480);
+        Task emptyObjectStore = createTask("emptyObjectStore0", org.jboss.jbossts.qa.Utils.EmptyObjectStore.class, Task.TaskType.EXPECT_PASS_FAIL, 480);
         emptyObjectStore.perform();
 
         if(isRecoveryManagerNeeded) {
@@ -82,7 +82,7 @@ public class TestGroupBase
         servers.clear();
         objectStoreNamesToTaskIds.clear();
 
-        Task emptyObjectStore = createTask("emptyObjectStore", org.jboss.jbossts.qa.Utils.EmptyObjectStore.class, Task.TaskType.EXPECT_PASS_FAIL, 480);
+        Task emptyObjectStore = createTask("emptyObjectStore1", org.jboss.jbossts.qa.Utils.EmptyObjectStore.class, Task.TaskType.EXPECT_PASS_FAIL, 480);
         emptyObjectStore.perform();
 
         try {


### PR DESCRIPTION
!CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS mysql db2 postgres oracle