### PR TITLE
SRA and quarkus

### DIFF
--- a/narayana-bom/pom.xml
+++ b/narayana-bom/pom.xml
@@ -876,7 +876,7 @@
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
         <version>${version.microprofile.config-api}</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>io.smallrye.config</groupId>
@@ -898,7 +898,7 @@
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-api</artifactId>
         <version>${version.microprofile.fault-tolerance}</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.lra</groupId>
@@ -909,7 +909,7 @@
         <groupId>org.eclipse.microprofile.openapi</groupId>
         <artifactId>microprofile-openapi-api</artifactId>
         <version>${version.org.eclipse.microprofile.openapi}</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.lra</groupId>

--- a/rts/at/tx/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
+++ b/rts/at/tx/src/main/resources/META-INF/services/jakarta.ws.rs.ext.Providers
@@ -1,0 +1,1 @@
+org.jboss.jbossts.star.client.ServerSRAFilter


### PR DESCRIPTION
Related to Jira issue: https://issues.redhat.com/browse/JBTM-3462
Quarkus does not inject providers from external library by default (https://quarkus.io/guides/cdi-reference). In order to inject them the validation service provider is needed: https://docs.jboss.org/resteasy/docs/6.2.2.Final/userguide/html_single/index.html#d5e4828

CORE RTS LRA 

