### PR TITLE
Removal of jboss-transaction-spi-jakarta

### DIFF
--- a/narayana-bom/pom.xml
+++ b/narayana-bom/pom.xml
@@ -425,12 +425,6 @@
       <!-- qa -->
 
       <dependency>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-transaction-spi-jakarta</artifactId>
-        <version>${version.org.jboss.jboss-transaction-spi}</version>
-      </dependency>
-
-      <dependency>
         <groupId>jboss.profiler.jvmti</groupId>
         <artifactId>jboss-profiler-jvmti</artifactId>
         <version>${version.jboss.profiler.jvmti}</version>


### PR DESCRIPTION
Removal of jboss-transaction-spi-jakarta (old and not used), the already present and jakarta native dependency is named jboss-transaction-spi

CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_OPENJDKORB PERFORMANCE LRA DB_TESTS mysql db2 postgres oracle

