### PR TITLE
[Jbtm 3736] Upgrade h2 dependency

### DIFF
--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/FailAfterPrepareBase.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/FailAfterPrepareBase.java
@@ -53,7 +53,7 @@ public class FailAfterPrepareBase extends TestCommitMarkableResourceBase {
     protected Uid generateCMRRecord(final DataSource dataSource) throws Exception {
 
         ((JdbcDataSource) dataSource)
-                .setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+                .setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
         // Test code
         Utils.createTables(dataSource.getConnection());

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/PerformanceTestCommitMarkableResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/PerformanceTestCommitMarkableResource.java
@@ -273,7 +273,7 @@ public class PerformanceTestCommitMarkableResource extends
 					.setCommitMarkableResourceRecordDeleteBatchSize(100);
 			dataSource = new JdbcDataSource();
 			((JdbcDataSource) dataSource)
-					.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+					.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 			recoveryDataSource = ((JdbcDataSource) dataSource);
 		} else if (dbType.equals("postgres")) {
 
@@ -409,7 +409,7 @@ public class PerformanceTestCommitMarkableResource extends
 		} else if (dbType.equals("h2")) {
 			dataSource = new org.h2.jdbcx.JdbcDataSource();
 			((JdbcDataSource) dataSource)
-					.setURL("jdbc:h2:mem:JBTMDB2;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+					.setURL("jdbc:h2:mem:JBTMDB2;DB_CLOSE_DELAY=-1");
 		} else if (dbType.equals("postgres")) {
 
 			dataSource = new PGXADataSource();

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResource.java
@@ -45,7 +45,7 @@ public class TestCommitMarkableResource extends TestCommitMarkableResourceBase {
 	@Test
 	public void testH2() throws Exception {
 		JdbcDataSource dataSource = new JdbcDataSource();
-		dataSource.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+		dataSource.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
 		doTest(dataSource);
 	}

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailActivate.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailActivate.java
@@ -58,7 +58,7 @@ public class TestCommitMarkableResourceFailActivate extends
 	public void testFailAfterPrepare() throws Exception {
 		final DataSource dataSource = new JdbcDataSource();
 		((JdbcDataSource) dataSource)
-				.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+				.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
 		// Test code
 		Utils.createTables(dataSource.getConnection());

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterCommit.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterCommit.java
@@ -33,7 +33,7 @@ public class TestCommitMarkableResourceFailAfterCommit extends
 	@BMScript("commitMarkableResourceFailAfterCommit")
 	public void testFailAfterCommitH2() throws Exception {
 		final JdbcDataSource dataSource = new JdbcDataSource();
-		dataSource.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+		dataSource.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
 		doTest(dataSource);
 	}

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterCommitOrphan.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterCommitOrphan.java
@@ -112,7 +112,7 @@ public class TestCommitMarkableResourceFailAfterCommitOrphan extends TestCommitM
     @BMScript("commitMarkableResourceFailAfterCommit")
     public void test() throws Exception {
         final JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+        dataSource.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
         // Test code
         Utils.createTables(dataSource.getConnection());

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterPrepareTwoXAResources.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceFailAfterPrepareTwoXAResources.java
@@ -60,7 +60,7 @@ public class TestCommitMarkableResourceFailAfterPrepareTwoXAResources extends
 	public void testFailAfterPrepare() throws Exception {
 		final DataSource dataSource = new JdbcDataSource();
 		((JdbcDataSource) dataSource)
-				.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+				.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
 		// Test code
 		Utils.createTables(dataSource.getConnection());

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceGCFromCrashAfterCommit.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceGCFromCrashAfterCommit.java
@@ -47,7 +47,7 @@ public class TestCommitMarkableResourceGCFromCrashAfterCommit extends
 	public void testFailAfterCommitH2() throws Exception {
 		final DataSource dataSource = new JdbcDataSource();
 		((JdbcDataSource) dataSource)
-				.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+				.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
 
 		// Test code
 		Utils.createTables(dataSource.getConnection());

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceMultiEnlist.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceMultiEnlist.java
@@ -65,7 +65,7 @@ public class TestCommitMarkableResourceMultiEnlist {
 			SystemException, IllegalStateException, RollbackException,
 			SQLException {
 		JdbcDataSource dataSource = new JdbcDataSource();
-		dataSource.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE");
+		dataSource.setURL("jdbc:h2:mem:JBTMDB");
 
 		jakarta.transaction.TransactionManager tm = com.arjuna.ats.jta.TransactionManager
 				.transactionManager();

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceReturnUnknownOutcomeFrom1PCCommit.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/TestCommitMarkableResourceReturnUnknownOutcomeFrom1PCCommit.java
@@ -100,7 +100,7 @@ public class TestCommitMarkableResourceReturnUnknownOutcomeFrom1PCCommit {
     public void testRMFAILAfterCommit() throws Exception {
         jtaPropertyManager.getJTAEnvironmentBean().setNotifyCommitMarkableResourceRecoveryModuleOfCompleteBranches(false);
         final JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+        dataSource.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
         // Test code
         Utils.createTables(dataSource.getConnection());
 
@@ -193,7 +193,7 @@ public class TestCommitMarkableResourceReturnUnknownOutcomeFrom1PCCommit {
     public void testRMFAILAfterNoCommit() throws Exception {
         jtaPropertyManager.getJTAEnvironmentBean().setNotifyCommitMarkableResourceRecoveryModuleOfCompleteBranches(false);
         final JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setURL("jdbc:h2:mem:JBTMDB;MVCC=TRUE;DB_CLOSE_DELAY=-1");
+        dataSource.setURL("jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1");
         // Test code
         Utils.createTables(dataSource.getConnection());
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <version.ant-contrib>1.0b3</version.ant-contrib>
     <version.arquillian.byteman>1.1.0</version.arquillian.byteman>
     <version.com.github.spotbugs.spotbugs-maven-plugin>4.5.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
-    <version.com.h2database>1.4.195</version.com.h2database>
+    <version.com.h2database>2.1.214</version.com.h2database>
     <version.com.ibm>11.5.0.0</version.com.ibm>
     <version.com.microsoft.sqlserver>mssql2005_sqljdbc_2.0</version.com.microsoft.sqlserver>
     <version.com.oracle>18.3.0.0</version.com.oracle>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3736
Update from 1.4.* to 2.* h2 dependency

From h2 version 1.4.198 MVCC setting is removed, MVStore uses row-level locks and PageStore uses table-level locks unconditionally.

for more details see https://github.com/h2database/h2database/releases/tag/version-1.4.198


CORE QA_JTA DB_TESTS 