### PR TITLE
Declare no-arg constructor to TMApplication

### DIFF
--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/resource/RESTRecord.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/resource/RESTRecord.java
@@ -150,8 +150,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
     private void check_suspend(Fault f) {
         if (fault.equals(f))
         {
-            try
-            {
+            try {
                 log.infof("%s: for 10 seconds", f);
                 Thread.sleep(10000);
             } catch (InterruptedException e) {
@@ -212,8 +211,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
         if (prepareURI == null || txId == null)
             return TwoPhaseOutcome.PREPARE_READONLY;
 
-        try
-        {
+        try {
             String body = new TxSupport().httpRequest(new int[] {HttpURLConnection.HTTP_OK}, this.prepareURI, "PUT",
                     TxMediaType.TX_STATUS_MEDIA_TYPE, TxSupport.toStatusContent(TxStatus.TransactionPrepared.name()));
 
@@ -308,8 +306,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
         String commitUri = (nextState == TxStatus.TransactionCommittedOnePhase && this.commitOnePhaseURI != null)
             ? this.commitOnePhaseURI : this.commitURI;
 
-        try
-        {
+        try {
             if (log.isTraceEnabled())
                 log.tracef("committing %s", commitUri);
 
@@ -374,8 +371,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
                     return false;
                 }
 
-                try
-                {
+                try {
                     TxSupport.getStatus(new TxSupport().httpRequest(new int[] {HttpURLConnection.HTTP_OK},
                             uri, "PUT", TxMediaType.TX_STATUS_MEDIA_TYPE,
                             TxSupport.toStatusContent(nextState.name())));
@@ -407,8 +403,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
      * @return true if the participant did move
      */
     private boolean hasParticipantMoved() {
-        try
-        {
+        try {
             if (log.isTraceEnabled())
                 log.tracef("seeing if participant has moved: %s  recoveryURI: %s", coordinatorID, recoveryURI);
 
@@ -476,8 +471,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
     }
 
     public boolean save_state(OutputObjectState os, int t) {
-        try
-        {
+        try {
             os.packString(txId);
             os.packBoolean(prepared);
             os.packString(participantURI);
@@ -501,8 +495,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
     }
 
     public boolean restore_state(InputObjectState os, int t) {
-        try
-        {
+        try {
             txId = os.unpackString();
             prepared = os.unpackBoolean();
             participantURI = os.unpackString();

--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
@@ -47,6 +47,16 @@ public class TMApplication extends Application {
     Set<Class<?>> classes = new HashSet<Class<?>> ();
 
     public TMApplication(Class<?> ... extraClasses) {
+        this();
+        
+        try
+        {
+            Collections.addAll(classes, extraClasses);
+        } catch (Throwable e) {
+          RESTATLogger.atI18NLogger.warn_jaxrsTM(e.getMessage(), e);
+        }
+    }
+    public TMApplication() {
 //        singletons.addAll(Arrays.asList(resources));
         try
         {
@@ -68,7 +78,6 @@ public class TMApplication extends Application {
 
             Collections.addAll(classes, resourceClasses);
             Collections.addAll(classes, mappers);
-            Collections.addAll(classes, extraClasses);
         } catch (Throwable e) {
           RESTATLogger.atI18NLogger.warn_jaxrsTM(e.getMessage(), e);
         }

--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
@@ -49,8 +49,7 @@ public class TMApplication extends Application {
     public TMApplication(Class<?> ... extraClasses) {
         this();
         
-        try
-        {
+        try {
             Collections.addAll(classes, extraClasses);
         } catch (Throwable e) {
           RESTATLogger.atI18NLogger.warn_jaxrsTM(e.getMessage(), e);
@@ -58,8 +57,7 @@ public class TMApplication extends Application {
     }
     public TMApplication() {
 //        singletons.addAll(Arrays.asList(resources));
-        try
-        {
+        try {
             // TODO move com/arjuna/ats/jbossatx/jt[as]/TransactionManagerService.isRecoveryManagerRunning
             // to RecoveryManager and change logging
             // by default do not colocate the coordinator and recovery manager


### PR DESCRIPTION
From Jakarta EE cdi specification:
_If a bean class does not explicitly declare a constructor using @Inject, the constructor that accepts
no parameters is the bean constructor_.

This is needed only for bean classes (i.e. annotated as @ApplicationScoped ) and the TMApplication is not annotated. However it is possible that a project uses 'all' as bean-discovery-mode and 'not having a no-arg constructor or a constructor with @Inject annotation' might be a problem. Therefore I recommend having a no-arg constructor  and/or an @Inject constructor. 

related issue is https://github.com/eclipse/lsp4jakarta/issues/191

Note 1: The existing constructor cannot be annotated with @Inject because the parameters must be injectable as well according to the [spec](https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#instantiationl)

Note 2: only recently the default bean-discovery-mode has changed to 'annotated' (CDI 4 https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#_jakarta_contexts_and_dependency_injection_4_0 )

Note 3: I got an error on a quarkus-resteasy quickstart related to this issue:
```
Build step
io.quarkus.resteasy.server.common.deployment.ResteasyServerCommonProcessor#build
threw an exception: java.lang.RuntimeException: Unable to handle class:
org.jboss.jbossts.star.service.TMApplication

[ERROR] Caused by: java.lang.NoSuchMethodException:
org.jboss.jbossts.star.service.TMApplication.<init>()
[ERROR]         at
java.base/java.lang.Class.getConstructor0(Class.java:3585)
[ERROR]         at
java.base/java.lang.Class.getConstructor(Class.java:2271)
[ERROR]         at
io.quarkus.resteasy.server.common.deployment.ResteasyServerCommonProcessor.getAllowedClasses(ResteasyServerCommonProcessor.java:1010)
```

CORE RTS LRA 

