### PR TITLE
Remove fast forward during rebase

### DIFF
--- a/scripts/hudson/narayana-rebase.sh
+++ b/scripts/hudson/narayana-rebase.sh
@@ -56,7 +56,7 @@ function rebase_narayana {
   fi
 
   # Update the pull to head  
-  git pull --rebase --ff-only origin $BRANCHPOINT
+  git pull --rebase origin $BRANCHPOINT
 
   if [ $? -ne 0 ]; then
     #comment_on_pull "Narayana rebase failed. Please rebase it manually."

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -831,7 +831,7 @@ function perf_tests {
       [ $? -eq 0 ] || fatal "git fetch of pulls failed"
       git checkout remotes/origin/pull/$PERF_PR_NUMBER/head
       [ $? -eq 0 ] || fatal "git fetch of pull branch failed"
-      git pull --rebase --ff-only origin main
+      git pull --rebase origin main
       [ $? -eq 0 ] || fatal "git rebase failed"
     fi
   fi

--- a/scripts/rebase-jbossas-branch.sh
+++ b/scripts/rebase-jbossas-branch.sh
@@ -21,7 +21,7 @@ git fetch
 git checkout $ORIGIN_AS_BRANCH || fatal
 
 git remote add upstream $UPSTREAM_GIT_URL
-git pull --rebase --ff-only upstream $UPSTREAM_AS_BRANCH
+git pull --rebase upstream $UPSTREAM_AS_BRANCH
 
 if [ $? != 0 ]; then
   echo "Merge conflict needs manual intervention. Please go to '$TEMPORARY_REBASE_LOCATION/jboss-as' and resolve, then run:"


### PR DESCRIPTION
As discussed on zulip (https://narayana.zulipchat.com/#narrow/stream/323715-developers/topic/Remove.20fast.20forward.20during.20rebase) it would be nice to remove --ff-only when rebasing in order 
to always prevent tests from failing when the rebase does not cause conflicts. In fact now the rebase always fails if there is a new commit on top of the main branch.
However '--ff' or '--ff-only' might very useful when using 'git merge'.

CORE 