### PR TITLE
[JBTM-3735] Move properties to BOMs

### DIFF
--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -143,7 +143,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${version.junit.jupiter}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -425,7 +424,6 @@
         <dependency>
           <groupId>org.jfree</groupId>
           <artifactId>jfreechart</artifactId>
-          <version>${version.jfree}</version>
         </dependency>
       </dependencies>
       <build>

--- a/ArjunaCore/arjunacore/pom.xml
+++ b/ArjunaCore/arjunacore/pom.xml
@@ -144,7 +144,6 @@
         <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
-        <version>${version.jfree}</version>
       </dependency>
     </dependencies>
   </profile>  

--- a/ArjunaJTA/cdi/pom.xml
+++ b/ArjunaJTA/cdi/pom.xml
@@ -110,7 +110,6 @@
     <dependency>
       <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
       <artifactId>microprofile-reactive-streams-operators-api</artifactId>
-      <version>${version.org.eclipse.microprofile.reactive-streams-operators}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -162,7 +161,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -191,7 +189,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -225,7 +222,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-remote</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/ArjunaJTA/narayana-jta/pom.xml
+++ b/ArjunaJTA/narayana-jta/pom.xml
@@ -228,7 +228,6 @@
         <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
-        <version>${version.jfree}</version>
       <scope>provided</scope>
       </dependency>
     </dependencies>

--- a/ArjunaJTA/spi/pom.xml
+++ b/ArjunaJTA/spi/pom.xml
@@ -158,7 +158,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -190,7 +189,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -223,7 +221,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-remote</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/ArjunaJTS/idl/idlj-openjdk/pom.xml
+++ b/ArjunaJTS/idl/idlj-openjdk/pom.xml
@@ -20,13 +20,11 @@
     <dependency>
       <groupId>org.jboss.openjdk-orb</groupId>
       <artifactId>openjdk-orb</artifactId>
-      <version>${version.org.jboss.openjdk-orb}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.openjdk-orb</groupId>
       <artifactId>openjdk-orb</artifactId>
-      <version>${version.org.jboss.openjdk-orb}</version>
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>

--- a/ArjunaJTS/jtax/pom.xml
+++ b/ArjunaJTS/jtax/pom.xml
@@ -19,8 +19,6 @@
   <properties>
     <idlj.boot.args></idlj.boot.args>
     <modular.jdk.args>--upgrade-module-path ${project.build.directory}/upgrademodulepath</modular.jdk.args>
-    <openjdk-orb.jar>${settings.localRepository}/org/jboss/openjdk-orb/openjdk-orb/${version.org.jboss.openjdk-orb}/openjdk-orb-${version.org.jboss.openjdk-orb}.jar</openjdk-orb.jar>
-
     <surefireArgLine></surefireArgLine>
   </properties>
 
@@ -169,7 +167,6 @@
         <dependency>
           <groupId>org.jboss.openjdk-orb</groupId>
           <artifactId>openjdk-orb</artifactId>
-          <version>${version.org.jboss.openjdk-orb}</version>
         </dependency>
       </dependencies>
 

--- a/ArjunaJTS/jts/pom.xml
+++ b/ArjunaJTS/jts/pom.xml
@@ -19,7 +19,6 @@
     <!-- This module builds a jar holding a set of Sun orb's IDL stubs -->
     <classesDirectoryWithIdlj>${project.build.directory}/jts-idlj</classesDirectoryWithIdlj>
     <idlj.boot.args></idlj.boot.args>
-    <openjdk-orb.jar>${settings.localRepository}/org/jboss/openjdk-orb/openjdk-orb/${version.org.jboss.openjdk-orb}/openjdk-orb-${version.org.jboss.openjdk-orb}.jar</openjdk-orb.jar>
     <surefireArgLine></surefireArgLine>
   </properties>
 

--- a/ArjunaJTS/narayana-jts-idlj/pom.xml
+++ b/ArjunaJTS/narayana-jts-idlj/pom.xml
@@ -288,7 +288,6 @@
         <dependency>
           <groupId>org.jfree</groupId>
           <artifactId>jfreechart</artifactId>
-          <version>${version.jfree}</version>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/ArjunaJTS/orbportability/pom.xml
+++ b/ArjunaJTS/orbportability/pom.xml
@@ -17,7 +17,6 @@
   <description>orb portability harness</description>
   <properties>
     <idlj.boot.args></idlj.boot.args>
-    <openjdk-orb.jar>${settings.localRepository}/org/jboss/openjdk-orb/openjdk-orb/${version.org.jboss.openjdk-orb}/openjdk-orb-${version.org.jboss.openjdk-orb}.jar</openjdk-orb.jar>
     <surefireArgLine></surefireArgLine>
   </properties>
 
@@ -72,7 +71,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>${version.org.slf4j}</version>
       <scope>test</scope>
     </dependency>
 

--- a/XTS/localjunit/pom.xml
+++ b/XTS/localjunit/pom.xml
@@ -81,7 +81,6 @@
     <dependency>
       <groupId>jakarta.inject</groupId>
       <artifactId>jakarta.inject-api</artifactId>
-      <version>${version.jakarta.inject.jakarta.inject-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -158,7 +157,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-remote</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -190,7 +188,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -223,7 +220,6 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/compensations/pom.xml
+++ b/compensations/pom.xml
@@ -166,7 +166,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -203,7 +202,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -240,7 +238,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -278,7 +275,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -333,7 +329,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -347,19 +342,16 @@
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-weld-embedded</artifactId>
-                    <version>${version.org.jboss.arquillian.container.weld}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter</artifactId>
-                    <version>${version.junit.jupiter}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>jakarta.platform</groupId>
                     <artifactId>jakarta.jakartaee-api</artifactId>
-                    <version>${version.jakarta.platform.jakarta.jakartaee-api}</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>

--- a/narayana-bom-test/pom.xml
+++ b/narayana-bom-test/pom.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <!--
+   Copyright The Narayana Authors
+   SPDX short identifier: Apache-2.0
+ -->
+
   <parent>
     <groupId>org.jboss.narayana</groupId>
     <artifactId>narayana-all</artifactId>
@@ -11,6 +16,42 @@
   <packaging>pom</packaging>
   <name>Narayana Bom Test</name>
   <description>Narayana BOM for test dependencies</description>
+
+  <properties>
+    <version.ant-contrib>1.0b3</version.ant-contrib>
+    <version.arquillian.byteman>1.1.0</version.arquillian.byteman>
+    <version.arquillian.weld-embedded>3.0.2.Final</version.arquillian.weld-embedded>
+    <version.com.h2database>2.1.214</version.com.h2database>
+    <version.com.ibm>11.5.0.0</version.com.ibm>
+    <version.com.oracle>18.3.0.0</version.com.oracle>
+    <version.com.sun.messaging.mq.fscontext>4.6-b01</version.com.sun.messaging.mq.fscontext>
+    <version.commons-httpclient>3.1-jbossorg-1</version.commons-httpclient>
+    <version.hamcrest>2.2</version.hamcrest>
+    <version.httpcomponents>4.5.14</version.httpcomponents>
+    <version.io.mashona>1.0.0.Beta1</version.io.mashona>
+    <version.jakartaee-api>10.0.0</version.jakartaee-api>
+    <version.jboss.profiler.jvmti>1.0.0.CR5</version.jboss.profiler.jvmti>
+    <version.junit>4.13.1</version.junit>
+    <version.junit.jupiter>5.9.2</version.junit.jupiter>
+    <version.log4j-core>2.19.0</version.log4j-core>
+    <version.mariadb>1.2.2</version.mariadb>
+    <version.mysql>8.0.25</version.mysql>
+    <version.org.apache.ant>1.10.12</version.org.apache.ant>
+    <version.org.jboss.arquillian.container.weld>3.0.2.Final</version.org.jboss.arquillian.container.weld>
+    <version.org.jboss.arquillian.core>1.7.0.Final</version.org.jboss.arquillian.core>
+    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
+    <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
+    <version.org.jboss.shrinkwrap.resolvers>3.1.4</version.org.jboss.shrinkwrap.resolvers>
+    <version.org.jboss.weld>5.0.1.Final</version.org.jboss.weld>
+    <version.org.mockito>3.8.0</version.org.mockito>
+    <version.org.slf4j>1.7.30</version.org.slf4j>
+    <version.org.springframework>3.2.2.RELEASE</version.org.springframework>
+    <version.org.wildfly.arquillian>5.0.0.Final</version.org.wildfly.arquillian>
+    <version.org.wildfly.core>20.0.0.Final</version.org.wildfly.core>
+    <version.org.wildfly.extras.creaper>2.0.2</version.org.wildfly.extras.creaper>
+    <version.postgresql>42.3.1</version.postgresql>
+    <version.squareup.okhttp>1.5.4</version.squareup.okhttp>
+  </properties>
 
   <dependencyManagement>
     <!-- Arjuna Core -->
@@ -303,6 +344,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${version.junit.jupiter}</version>
+        <scope>test</scope>
+      </dependency>
+      
+      <dependency>
         <groupId>com.squareup.okhttp</groupId>
         <artifactId>okhttp</artifactId>
         <version>${version.squareup.okhttp}</version>
@@ -327,6 +375,18 @@
         <groupId>org.jboss.weld.se</groupId>
         <artifactId>weld-se-shaded</artifactId>
         <version>${version.org.jboss.weld}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.arquillian.container</groupId>
+        <artifactId>arquillian-weld-embedded</artifactId>
+        <version>${version.arquillian.weld-embedded}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.platform</groupId>
+        <artifactId>jakarta.jakartaee-api</artifactId>
+        <version>${version.jakartaee-api}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/narayana-bom/pom.xml
+++ b/narayana-bom/pom.xml
@@ -16,6 +16,58 @@
   <name>Narayana Bom</name>
   <description>Narayana BOM</description>
 
+  <properties>
+    <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
+    <version.glassfish.json>2.0.1</version.glassfish.json>
+    <version.io.narayana.checkstyle-config>1.0.1.Final</version.io.narayana.checkstyle-config>
+    <version.io.smallrye.smallrye-config>3.2.0</version.io.smallrye.smallrye-config>
+    <version.jakarta.activation.jakarta.activation-api>2.1.0</version.jakarta.activation.jakarta.activation-api>
+    <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
+    <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
+    <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
+    <version.jakarta.enterprise.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.jakarta.enterprise.cdi-api>
+    <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
+    <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
+    <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
+    <version.jakarta.json-api>2.0.1</version.jakarta.json-api>
+    <version.jakarta.json.jakarta-json-api>2.0.1</version.jakarta.json.jakarta-json-api>
+    <version.jakarta.persistence.jakarta.persistence-api>3.1.0</version.jakarta.persistence.jakarta.persistence-api>
+    <version.jakarta.platform.jakarta.jakartaee-api>10.0.0</version.jakarta.platform.jakarta.jakartaee-api>
+    <version.jakarta.resource.jakarta-resource-api>2.0.0</version.jakarta.resource.jakarta-resource-api>
+    <version.jakarta.servlet.jakarta-servlet-api>5.0.0</version.jakarta.servlet.jakarta-servlet-api>
+    <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
+    <version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
+    <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.0</version.jakarta.xml.bind.jakarta-xml-bind-api>
+    <version.jakarta.xml.ws.jakarta.xml.ws-api>4.0.0</version.jakarta.xml.ws.jakarta.xml.ws-api>
+    <version.jaxws-ri>4.0.0</version.jaxws-ri>
+    <version.jboss-modules>1.10.2.Final</version.jboss-modules>
+    <version.jboss.jnpserver>4.2.2.GA</version.jboss.jnpserver>
+    <version.jfree>1.5.3</version.jfree>
+    <version.jnpserver>5.0.3.GA</version.jnpserver>
+    <version.microprofile.config-api>3.0.2</version.microprofile.config-api>
+    <version.microprofile.fault-tolerance>4.0.2</version.microprofile.fault-tolerance>
+    <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
+    <version.org.eclipse.microprofile.openapi>3.1</version.org.eclipse.microprofile.openapi>
+    <version.org.eclipse.microprofile.reactive-streams-operators>3.0</version.org.eclipse.microprofile.reactive-streams-operators>
+    <version.org.jboss.arquillian.container.weld>3.0.2.Final</version.org.jboss.arquillian.container.weld>
+    <version.org.jboss.arquillian.core>1.7.0.Final</version.org.jboss.arquillian.core>
+    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
+    <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
+    <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
+    <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
+    <version.org.jboss.logging.jboss-logging>3.5.0.Final</version.org.jboss.logging.jboss-logging>
+    <version.org.jboss.logging.jboss-logging-processor>2.2.1.Final</version.org.jboss.logging.jboss-logging-processor>
+    <version.org.jboss.logmanager>1.5.1.Final</version.org.jboss.logmanager>
+    <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
+    <version.org.jboss.ws>2.0.0.Final</version.org.jboss.ws>
+    <version.quarkus>3.0.1.Final</version.quarkus>
+    <version.smallrye-converter-api>2.7.0</version.smallrye-converter-api>
+    <version.sortpom>3.0.0</version.sortpom>
+    <version.squareup.okhttp>1.5.4</version.squareup.okhttp>
+    <version.sun.jdk>jdk</version.sun.jdk>
+    <version.tanukisoft>3.2.3</version.tanukisoft>
+  </properties>
+
   <dependencyManagement>
     <!-- Arjuna Core -->
     <dependencies>
@@ -251,6 +303,11 @@
         <groupId>org.jboss.narayana.xts</groupId>
         <artifactId>jbossxts</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jfree</groupId>
+        <artifactId>jfreechart</artifactId>
+        <version>${version.jfree}</version>
       </dependency>
 
       <!-- This dependency should be removed in JBTM-3056 -->
@@ -596,6 +653,11 @@
         <version>${version.microprofile.config-api}</version>
       </dependency>
       <dependency>
+        <groupId>org.eclipse.microprofile.reactive-streams-operators</groupId>
+        <artifactId>microprofile-reactive-streams-operators-api</artifactId>
+        <version>${version.org.eclipse.microprofile.reactive-streams-operators}</version>
+      </dependency>
+      <dependency>
         <groupId>io.smallrye.config</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>${version.io.smallrye.smallrye-config}</version>
@@ -636,11 +698,6 @@
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
       <dependency>
-        <groupId>org.wildfly.arquillian</groupId>
-        <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>${version.org.wildfly.arquillian}</version>
-      </dependency>
-      <dependency>
         <groupId>asm</groupId>
         <artifactId>asm-all</artifactId>
         <version>${version.asm}</version>
@@ -649,6 +706,12 @@
         <groupId>org.jboss.openjdk-orb</groupId>
         <artifactId>openjdk-orb</artifactId>
         <version>${version.org.jboss.openjdk-orb}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.openjdk-orb</groupId>
+        <artifactId>openjdk-orb</artifactId>
+        <version>${version.org.jboss.openjdk-orb}</version>
+        <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.jboss</groupId>

--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -119,7 +119,6 @@
     <dependency>
       <groupId>org.jboss.ws</groupId>
       <artifactId>jbossws-api</artifactId>
-      <version>${version.org.jboss.ws}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -297,7 +296,6 @@
         <dependency>
           <groupId>io.mashona</groupId>
           <artifactId>mashona-logwriting</artifactId>
-          <version>${version.io.mashona}</version>
           <scope>compile</scope>
         </dependency>
       </dependencies>
@@ -410,7 +408,6 @@
         <dependency>
           <groupId>org.jfree</groupId>
           <artifactId>jfreechart</artifactId>
-          <version>${version.jfree}</version>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -178,101 +178,38 @@
     <sortpom.skip>false</sortpom.skip>
     <!-- The surefire/failsafe test execution logs goes to a file by default -->
     <testLogToFile>true</testLogToFile>
-
-    <version.ant-contrib>1.0b3</version.ant-contrib>
-    <version.arquillian.byteman>1.1.0</version.arquillian.byteman>
     <version.com.github.spotbugs.spotbugs-maven-plugin>4.5.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
-    <version.com.h2database>2.1.214</version.com.h2database>
-    <version.com.ibm>11.5.0.0</version.com.ibm>
-    <version.com.microsoft.sqlserver>mssql2005_sqljdbc_2.0</version.com.microsoft.sqlserver>
-    <version.com.oracle>18.3.0.0</version.com.oracle>
-    <version.com.sun.messaging.mq.fscontext>4.6-b01</version.com.sun.messaging.mq.fscontext>
-    <version.com.sybase.jConnect>6.0</version.com.sybase.jConnect>
-    <version.commons-httpclient>3.1-jbossorg-1</version.commons-httpclient>
     <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
-    <version.doxia>1.8.1</version.doxia>
-    <version.glassfish.json>2.0.1</version.glassfish.json>
-    <version.hamcrest>2.2</version.hamcrest>
-    <version.httpcomponents>4.5.14</version.httpcomponents>
-    <version.io.mashona>1.0.0.Beta1</version.io.mashona>
     <version.io.narayana.checkstyle-config>1.0.1.Final</version.io.narayana.checkstyle-config>
-    <version.io.smallrye.smallrye-config>3.2.0</version.io.smallrye.smallrye-config>
-    <version.jakarta.activation.jakarta.activation-api>2.1.0</version.jakarta.activation.jakarta.activation-api>
-    <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
-    <version.jakarta.ejb.jakarta-ejb-api>4.0.1</version.jakarta.ejb.jakarta-ejb-api>
-    <version.jakarta.enterprise>4.0.0</version.jakarta.enterprise>
-    <version.jakarta.enterprise.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.jakarta.enterprise.cdi-api>
-    <version.jakarta.inject.jakarta.inject-api>2.0.1</version.jakarta.inject.jakarta.inject-api>
-    <version.jakarta.interceptor.jakarta-interceptors-api>2.1.0</version.jakarta.interceptor.jakarta-interceptors-api>
-    <version.jakarta.jms.jakarta-jms-api>3.1.0</version.jakarta.jms.jakarta-jms-api>
-    <version.jakarta.json-api>2.0.1</version.jakarta.json-api>
-    <version.jakarta.json.jakarta-json-api>2.0.1</version.jakarta.json.jakarta-json-api>
-    <version.jakarta.persistence.jakarta.persistence-api>3.1.0</version.jakarta.persistence.jakarta.persistence-api>
-    <version.jakarta.platform.jakarta.jakartaee-api>10.0.0</version.jakarta.platform.jakarta.jakartaee-api>
-    <version.jakarta.resource.jakarta-resource-api>2.0.0</version.jakarta.resource.jakarta-resource-api>
-    <version.jakarta.servlet.jakarta-servlet-api>5.0.0</version.jakarta.servlet.jakarta-servlet-api>
-    <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
-    <version.jakarta.ws.rs.jakarta-ws-rs-api>3.1.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
-    <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.0</version.jakarta.xml.bind.jakarta-xml-bind-api>
-    <version.jakarta.xml.ws.jakarta.xml.ws-api>4.0.0</version.jakarta.xml.ws.jakarta.xml.ws-api>
     <version.javadoc.plugin>3.5.0</version.javadoc.plugin>
-    <version.jaxws-ri>4.0.0</version.jaxws-ri>
-    <version.jboss-modules>1.10.2.Final</version.jboss-modules>
-    <version.jboss.jnpserver>4.2.2.GA</version.jboss.jnpserver>
-    <version.jboss.profiler.jvmti>1.0.0.CR5</version.jboss.profiler.jvmti>
-    <version.jfree>1.5.3</version.jfree>
-    <version.jnpserver>5.0.3.GA</version.jnpserver>
-    <version.junit>4.13.1</version.junit>
-    <version.junit.jupiter>5.9.2</version.junit.jupiter>
-    <version.log4j-core>2.19.0</version.log4j-core>
-    <version.mariadb>1.2.2</version.mariadb>
     <version.maven-failsafe-plugin>3.0.0-M7</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>3.0.0-M7</version.maven-surefire-plugin>
     <version.maven.checkstyle-plugin>3.1.2</version.maven.checkstyle-plugin>
     <version.maven.jandex-plugin>3.0.5</version.maven.jandex-plugin>
-    <version.microprofile.config-api>3.0.2</version.microprofile.config-api>
-    <version.microprofile.fault-tolerance>4.0.2</version.microprofile.fault-tolerance>
-    <version.microprofile.lra>2.0-RC1</version.microprofile.lra>
-    <version.mysql>8.0.25</version.mysql>
-    <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
-    <version.org.apache.ant>1.10.12</version.org.apache.ant>
-    <version.org.apache.httpcomponents>4.2.1</version.org.apache.httpcomponents>
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>
-    <version.org.dom4j>2.1.3</version.org.dom4j>
-    <version.org.eclipse.microprofile.openapi>3.1</version.org.eclipse.microprofile.openapi>
-    <version.org.eclipse.microprofile.reactive-streams-operators>3.0</version.org.eclipse.microprofile.reactive-streams-operators>
-    <version.org.jacoco>0.8.8</version.org.jacoco>
-    <version.org.jboss.arquillian.container.weld>3.0.2.Final</version.org.jboss.arquillian.container.weld>
-    <version.org.jboss.arquillian.core>1.7.0.Final</version.org.jboss.arquillian.core>
     <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
     <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
-    <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
-    <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
-    <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
-    <version.org.jboss.logging.jboss-logging>3.5.0.Final</version.org.jboss.logging.jboss-logging>
-    <version.org.jboss.logging.jboss-logging-processor>2.2.1.Final</version.org.jboss.logging.jboss-logging-processor>
-    <version.org.jboss.logmanager>1.5.1.Final</version.org.jboss.logmanager>
-    <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
-    <version.org.jboss.resteasy>6.2.2.Final</version.org.jboss.resteasy>
-    <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
-    <version.org.jboss.shrinkwrap.resolvers>3.1.4</version.org.jboss.shrinkwrap.resolvers>
-    <version.org.jboss.weld>5.0.1.Final</version.org.jboss.weld>
-    <version.org.jboss.ws>2.0.0.Final</version.org.jboss.ws>
-    <version.org.mockito>3.8.0</version.org.mockito>
-    <version.org.slf4j>1.7.30</version.org.slf4j>
     <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
-    <version.org.springframework>3.2.2.RELEASE</version.org.springframework>
-    <version.org.wildfly.arquillian>5.0.0.Final</version.org.wildfly.arquillian>
-    <version.org.wildfly.core>20.0.0.Final</version.org.wildfly.core>
-    <version.org.wildfly.extras.creaper>2.0.2</version.org.wildfly.extras.creaper>
-    <version.postgresql>42.3.1</version.postgresql>
-    <version.quarkus>3.0.1.Final</version.quarkus>
-    <version.smallrye-converter-api>2.7.0</version.smallrye-converter-api>
+    <version.quarkus-bom>3.0.1.Final</version.quarkus-bom>
+    <version.quarkus-maven-plugin>3.0.1.Final</version.quarkus-maven-plugin>
     <version.sortpom>3.0.0</version.sortpom>
-    <version.squareup.okhttp>1.5.4</version.squareup.okhttp>
-    <version.sun.jdk>jdk</version.sun.jdk>
-    <version.tanukisoft>3.2.3</version.tanukisoft>
+    <version.wildfly-maven-plugin>4.1.0.Final</version.wildfly-maven-plugin>
 
+    <!--     These properties are needed here because they are used in WildflyLRACoordinatorDeployment class -->
+    <version.microprofile.lra>2.0-RC1</version.microprofile.lra>
+    <version.org.jboss.resteasy>6.2.2.Final</version.org.jboss.resteasy>
+     <!-- end of needed properties -->
+
+    <!-- profiles' properties -->
+    <version.org.jacoco>0.8.8</version.org.jacoco>
+    <version.doxia>1.8.1</version.doxia>
+    <!-- end of profiles' properties -->
+    
+
+    <!-- This property is used in WarDeployment (XTS) -->
+    <version.org.dom4j>2.1.3</version.org.dom4j>
+    <!-- end of needed properties -->
+    
   </properties>
 
   <repositories>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -17,10 +17,6 @@
   <packaging>jar</packaging>
   <name>Narayana: qa</name>
 
-  <properties>
-    <version.com.sun.messaging.mq.fscontext>4.6-b01</version.com.sun.messaging.mq.fscontext>
-    <version.jboss.profiler.jvmti>1.0.0.CR5</version.jboss.profiler.jvmti>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -55,12 +51,10 @@
     <dependency>
       <groupId>org.jboss.openjdk-orb</groupId>
       <artifactId>openjdk-orb</artifactId>
-      <version>${version.org.jboss.openjdk-orb}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.openjdk-orb</groupId>
       <artifactId>openjdk-orb</artifactId>
-      <version>${version.org.jboss.openjdk-orb}</version>
       <classifier>sources</classifier>
     </dependency>
     <dependency>

--- a/rts/at/bridge/pom.xml
+++ b/rts/at/bridge/pom.xml
@@ -25,6 +25,18 @@
     <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.narayana</groupId>
+        <artifactId>narayana-bom-test</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jboss</groupId>
@@ -47,13 +59,11 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-core-spi</artifactId>
-      <version>${version.org.jboss.resteasy}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>${version.org.jboss.resteasy}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -67,27 +77,23 @@
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <version>${version.org.jboss.arquillian.core}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
-      <version>${version.jakarta.json-api}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
-      <version>${version.glassfish.json}</version>
       <scope>test</scope>
     </dependency>
 
@@ -170,13 +176,11 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-          <version>${version.org.jboss.arquillian.core}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -204,13 +208,11 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-          <version>${version.org.jboss.arquillian.core}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/rts/at/integration/pom.xml
+++ b/rts/at/integration/pom.xml
@@ -26,12 +26,23 @@
     <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.modular}</server.jvm.args>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.narayana</groupId>
+        <artifactId>narayana-bom-test</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
-      <version>${version.org.jboss.resteasy}</version>
     </dependency>
 
     <dependency>
@@ -51,7 +62,6 @@
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <version>${version.org.jboss.logging.jboss-logging}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -79,13 +89,11 @@
     <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
-      <version>${version.jakarta.json-api}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
-      <version>${version.glassfish.json}</version>
       <scope>test</scope>
     </dependency>
 
@@ -106,27 +114,23 @@
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
-      <version>${version.org.jboss.resteasy}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-netty4</artifactId>
-      <version>${version.org.jboss.resteasy}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-core-spi</artifactId>
-      <version>${version.org.jboss.resteasy}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
-      <version>${version.commons-httpclient}</version>
       <scope>test</scope>
     </dependency>
 
@@ -139,14 +143,12 @@
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <version>${version.org.jboss.arquillian.core}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
 
@@ -189,13 +191,11 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-          <version>${version.org.jboss.arquillian.core}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -251,13 +251,11 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.org.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-          <version>${version.org.jboss.arquillian.core}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/rts/lra/proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/jandex/JandexAnnotationResolver.java
+++ b/rts/lra/proxy/api/src/main/java/io/narayana/lra/client/internal/proxy/nonjaxrs/jandex/JandexAnnotationResolver.java
@@ -26,7 +26,7 @@ public class JandexAnnotationResolver {
         ClassInfo classInfo = index.getClassByName(name);
 
         if (classInfo != null) {
-            annotations.putAll(classInfo.annotations());
+            annotations.putAll(classInfo.annotationsMap());
             annotations.putAll(getInterfaceAnnotations(classInfo.interfaceNames(), index));
             annotations.putAll(getAllAnnotationsFromClassInfoHierarchy(classInfo.superName(), index));
         }
@@ -40,7 +40,7 @@ public class JandexAnnotationResolver {
 
         for (DotName interfaceName : interfaceNames) {
             interfaceClassInfo = index.getClassByName(interfaceName);
-            Map<DotName, List<AnnotationInstance>> interfaceAnnotations = interfaceClassInfo.annotations();
+            Map<DotName, List<AnnotationInstance>> interfaceAnnotations = interfaceClassInfo.annotationsMap();
             annotations.forEach((k, v) -> interfaceAnnotations.merge(k, v, (v1, v2) -> {
                 v1.addAll(v2);
                 return v1;

--- a/rts/lra/test/basic/pom.xml
+++ b/rts/lra/test/basic/pom.xml
@@ -55,7 +55,12 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson2-provider</artifactId>
     </dependency>
-
+    <!--     jboss-threads version 2.x needed for Junit4 -->
+    <dependency>
+      <groupId>org.jboss.threads</groupId>
+      <artifactId>jboss-threads</artifactId>
+      <version>2.4.0.Final</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/rts/lra/test/pom.xml
+++ b/rts/lra/test/pom.xml
@@ -19,9 +19,9 @@
   <description>LRA tests running LRA TCKs and Narayana LRA internal testsuite</description>
 
   <modules>
+    <module>arquillian-extension</module>
     <module>tck</module>
     <module>basic</module>
-    <module>arquillian-extension</module>
   </modules>
 
   <properties>
@@ -123,7 +123,6 @@
         <skip.wildfly.plugin>true</skip.wildfly.plugin>
         <!-- where the WFLY test application will be started at (the coordinator is war deployed for the same app server at the same port) -->
         <test.application.port>8080</test.application.port>
-        <version.wildfly-maven-plugin>4.0.0.Final</version.wildfly-maven-plugin>
         <!-- this property is only used in direct submodules, if used outside this scope it needs to be redefined -->
         <wildfly.trace.logging.cli.script>${project.basedir}/../wildfly-trace-logging.cli</wildfly.trace.logging.cli.script>
       </properties>

--- a/rts/lra/test/tck/pom.xml
+++ b/rts/lra/test/tck/pom.xml
@@ -36,6 +36,12 @@
       <groupId>org.jboss.narayana.rts</groupId>
       <artifactId>lra-test-arquillian-extension</artifactId>
     </dependency>
+    <!--     jboss-threads version 2.x needed for Junit4 -->
+    <dependency>
+      <groupId>org.jboss.threads</groupId>
+      <artifactId>jboss-threads</artifactId>
+      <version>2.4.0.Final</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -20,19 +20,10 @@
 
   <properties>
     <version.resteasy-client>${version.org.jboss.resteasy}</version.resteasy-client>
-
-    <version.json.api>1.1</version.json.api>
-    <version.jaxrs.api>1.0.0.Final</version.jaxrs.api>
-
-    <version.jboss-interceptors>1.0.1.Final</version.jboss-interceptors>
-    <version.cdi-api>1.0-SP1</version.cdi-api>
-
     <version.narayana>${project.version}</version.narayana>
-
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     <sortpom.skip>true</sortpom.skip>
   </properties>
+  
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/rts/sra/pom.xml
+++ b/rts/sra/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bom</artifactId>
-                <version>${version.quarkus}</version>
+                <version>${version.quarkus-bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${version.quarkus}</version>
+                <version>${version.quarkus-maven-plugin}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/txbridge/pom.xml
+++ b/txbridge/pom.xml
@@ -361,21 +361,7 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
-                    <!-- exclude logmanager because an incompatible version is pulled in -->
-                    <exclusions>
-                        <exclusion>
-                            <artifactId>org.jboss.logmanager</artifactId>
-                            <groupId>jboss-logmanager</groupId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.logmanager</groupId>
-                    <artifactId>jboss-logmanager</artifactId>
-                    <version>${version.org.jboss.logmanager}</version>
-                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>
@@ -432,23 +418,7 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${version.org.wildfly.arquillian}</version>
                     <scope>test</scope>
-
-                    <!-- exclude logmanager because an incompatible version is pulled in
-                      -->
-                    <exclusions>
-                        <exclusion>
-                            <artifactId>org.jboss.logmanager</artifactId>
-                            <groupId>jboss-logmanager</groupId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.logmanager</groupId>
-                    <artifactId>jboss-logmanager</artifactId>
-                    <version>${version.org.jboss.logmanager}</version>
-                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/vertx/module/pom.xml
+++ b/vertx/module/pom.xml
@@ -208,7 +208,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${version.maven-failsafe-plugin}</version>
         <configuration>
           <systemProperties>
             <property>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3735

As discussed on Zulip (https://narayana.zulipchat.com/#narrow/stream/323715-developers/topic/JBTM-3735.20Create.20narayana.20boms/near/359649317)

Properties specified in BOMs are not inherited as properties in root pom. So all occurrences of properties in submodules were deleted except the followings:
- plugin properties (these properties are still in root pom)
- root pom profile properties  (these properties are still in root pom)
- properties read in Java files with the Maven resolver (i.e. https://github.com/jbosstm/narayana/blob/7369ddc132d0b52162de23f64e89fe6952693a93/XTS/localjunit/WSTX11-interop/src/test/java/com/jboss/transaction/txinterop/interop/WarDeployment.java#L75 and https://github.com/jbosstm/narayana/blob/7369ddc132d0b52162de23f64e89fe6952693a93/rts/lra/test/arquillian-extension/src/main/java/io/narayana/lra/arquillian/deployment/WildflyLRACoordinatorDeployment.java#L52)

CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_OPENJDKORB PERFORMANCE LRA DB_TESTS mysql db2 postgres oracle
