### PR TITLE
JBTM-3734 Replace synchronized with JUCL in ThreadUtil

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/utils/ThreadUtil.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/utils/ThreadUtil.java
@@ -7,6 +7,8 @@ package com.arjuna.ats.arjuna.utils;
 
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Provides utilities to manage thread ids.
@@ -26,6 +28,11 @@ public class ThreadUtil
      * The thread id counter.
      */
     private static AtomicLong id = new AtomicLong();
+
+    /**
+     * Lock for synchronizing access to the WeakHashMap
+     */
+    private static final Lock lock = new ReentrantLock();
 
     /**
      * Get the string ID for the current thread.
@@ -53,7 +60,8 @@ public class ThreadUtil
 
         }
 
-        synchronized (ThreadUtil.class) {
+        lock.lock();
+        try {
             final String id = THREAD_ID.get(thread);
             if (id != null) {
                 if (thread == Thread.currentThread()) {
@@ -69,6 +77,8 @@ public class ThreadUtil
                 LOCAL_ID.set(newId);
             }
             return newId;
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
A minor additional fix for the ThreadUtil to use a lock instead of synchronized.

After `JtaContextProvider.resumeTransaction`, the `WeakHashMap` sometimes blocks the carrier threads when accessing a queue due to the synchronized block in `ThreadUtil`, see strack trace below (<== monitors:1). I found no places where there is a monitor used on ThreadUtil.class in any other place.

`
Thread[#264,ForkJoinPool-1-worker-16,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:183)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:398)
    java.base/jdk.internal.vm.Continuation.yield0(Continuation.java:390)
    java.base/jdk.internal.vm.Continuation.yield(Continuation.java:357)
    java.base/java.lang.VirtualThread.yieldContinuation(VirtualThread.java:428)
    java.base/java.lang.VirtualThread.park(VirtualThread.java:566)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2630)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:54)
    java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:219)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:754)
    java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:990)
    java.base/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
    java.base/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
    java.base/java.lang.ref.ReferenceQueue.poll(ReferenceQueue.java:182)
    java.base/java.util.WeakHashMap.expungeStaleEntries(WeakHashMap.java:329)
    java.base/java.util.WeakHashMap.getTable(WeakHashMap.java:361)
    java.base/java.util.WeakHashMap.get(WeakHashMap.java:409)
    com.arjuna.ats.arjuna.utils.ThreadUtil.getThreadId(ThreadUtil.java:72) <== monitors:1
    com.arjuna.ats.arjuna.coordinator.BasicAction.addChildThread(BasicAction.java:607)
    com.arjuna.ats.internal.arjuna.thread.ThreadActionData.pushAction(ThreadActionData.java:93)
    com.arjuna.ats.internal.arjuna.thread.ThreadActionData.pushAction(ThreadActionData.java:69)
    com.arjuna.ats.internal.arjuna.thread.ThreadActionData.restoreActions(ThreadActionData.java:130)
    com.arjuna.ats.arjuna.AtomicAction.resume(AtomicAction.java:366)
    com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple.resume(TransactionManagerImple.java:111)
    io.quarkus.narayana.jta.runtime.NotifyingTransactionManager.resume(NotifyingTransactionManager.java:122)
    io.smallrye.context.jta.context.propagation.JtaContextProvider.resumeTransaction(JtaContextProvider.java:86)
    io.smallrye.context.jta.context.propagation.JtaContextProvider.lambda$currentContext$1(JtaContextProvider.java:51)
`
