### PR TITLE
Update microprofile-lra dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <version.maven.jandex-plugin>3.0.5</version.maven.jandex-plugin>
 
     <!-- Needed forWildflyLRACoordinatorDeployment class -->
-    <version.microprofile.lra>2.0-RC1</version.microprofile.lra>
+    <version.microprofile.lra>2.0</version.microprofile.lra>
     <version.org.codehaus.mojo.jboss-maven-plugin>1.5.0</version.org.codehaus.mojo.jboss-maven-plugin>
 
     <!-- This property is used in WarDeployment (XTS) -->

--- a/rts/lra/test/tck/pom.xml
+++ b/rts/lra/test/tck/pom.xml
@@ -64,19 +64,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <!-- TODO [JBTM-3743] This profile can be removed once MP LRA TCK will use Arquillian version >= 1.7.0.Alpha12 -->
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties>
-        <!-- At least org.eclipse.microprofile.lra.tck.TckUnknownStatusTests needs java.base/java.lang and java.base/java.lang.reflect -->
-        <jvm.args.modular>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED</jvm.args.modular>
-      </properties>
-    </profile>
-  </profiles>
-
 </project>


### PR DESCRIPTION
Update microprofile-lra-api and microprofile-lra-tck from 2.0-RC1 to 2.0

[JBTM-3743] jdk17 profile can be removed now that MP LRA TCK uses jdk17 compatible Arquillian version

CORE  RTS  LRA  JDK17

