### PR TITLE
New procedure for reporting security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,23 @@
-# Security Policy 
- 
-## Security Contacts and Procedures
+# Reporting of CVEs and Security Issues
 
-The narayana community takes security seriously and will take immediate action to address security-related problems that involve our products or services.
+## The Narayana community and our sponsor, Red Hat, take security bugs very seriously
 
-Our policy is based on the [Red Hat security policy](https://access.redhat.com/security/team/contact).
- 
-Please report any suspected security vulnerability in this project to Red Hat Product Security at secalert@redhat.com. You can use our GPG key to communicate with us securely.
- 
-To report an issue in any Red Hat branded website or online service, please contact Red Hat Information Security at site-security@redhat.com.
-https://access.redhat.com/security/team/contact
+We aim to take immediate action to address serious security-related problems that involve our projects.
+
+Note that we will only fix such issues in the most recent minor release of Narayana.
+
+## Reporting of Security Issues
+
+When reporting a security vulnerability it is important to not accidentally broadcast to the world that the issue exists, as this makes it easier for people to exploit it. The software industry uses the term <a href="https://www.redhat.com/en/blog/security-embargoes-red-hat">embargo</a> to describe the time a security issue is known internally until it is public knowledge.
+
+Our preferred way of reporting security issues in Narayana is listed below.
+
+### Email the mailing list
+
+The list at <a href="mailto:narayana-security@redhat.com">narayana-security@redhat.com</a> is the preferred mechanism for outside users to report security issues. A member of the Narayana team will open the required issues.
+
+### Other considerations
+
+If you would like to work with us on a fix for the security vulnerability, please include your GitHub username in the above email, and we will provide you access to a temporary private fork where we can collaborate on a fix without it being disclosed publicly, **including in your own publicly visible git repository**.
+
+Do not open a public issue, send a pull request, or disclose any information about the suspected vulnerability publicly, **including in your own publicly visible git repository**. If you discover any publicly disclosed security vulnerabilities, please notify us immediately through <a href="mailto:narayana-security@redhat.com">narayana-security@redhat.com</a>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3800

Update to include the email address to the community to use for reporting security related issues.