### PR TITLE
remove unused openjdk-orb-jakarta dependency

### DIFF
--- a/narayana-bom/pom.xml
+++ b/narayana-bom/pom.xml
@@ -254,12 +254,6 @@
         <version>${project.version}</version>
         <classifier>tests</classifier>
       </dependency>
-      <dependency>
-        <groupId>org.jboss.openjdk-orb</groupId>
-        <artifactId>openjdk-orb-jakarta</artifactId>
-        <version>${version.org.jboss.openjdk-orb}</version>
-        <classifier>sources</classifier>
-      </dependency>
 
       <dependency>
         <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
openjdk-orb is already present in BOM and it is the one used in Narayana, which is already jakarta namespaced.

CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle
