### PR TITLE
Update microprofile lra version to 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
     <version.maven.jandex-plugin>3.0.5</version.maven.jandex-plugin>
     <version.microprofile.config-api>3.0.2</version.microprofile.config-api>
     <version.microprofile.fault-tolerance>4.0.2</version.microprofile.fault-tolerance>
-    <version.microprofile.lra>2.0-RC1</version.microprofile.lra>
+    <version.microprofile.lra>2.0</version.microprofile.lra>
     <version.mysql>8.0.25</version.mysql>
     <version.org.apache.activemq>2.24.0</version.org.apache.activemq>
     <version.org.apache.ant>1.10.12</version.org.apache.ant>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3828 - Backport the upgrade to microprofile lra version to 2.0

The SHA being backported is 86c5d55e3566b994d36c2b80f285be60438b4a70

CORE !TOMCAT AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB PERFORMANCE LRA !DB_TESTS !mysql !db2 !postgres