### PR TITLE
JBTM-3830 ensure that shutdown won't hang due to missed notification

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TransactionReaper.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TransactionReaper.java
@@ -715,22 +715,24 @@ public class TransactionReaper
             _inShutdown = true;
 
             /*
-                * If the caller does not want to wait for the normal transaction timeout
-                * periods to elapse before terminating, then we first start by enabling
-                * our time machine!
-                */
-
-            if (!waitForTransactions) {
-                _reaperElements.setAllTimeoutsToZero();
-            }
-
-            /*
                 * Wait for all of the transactions to
                 * terminate normally.
                 */
             while (!_reaperElements.isEmpty()) {
+                /*
+                 * If the caller does not want to wait for the normal transaction timeout
+                 * periods to elapse before terminating, then we first start by enabling
+                 * our time machine!
+                 */
+
+                if (!waitForTransactions) {
+                    _reaperElements.setAllTimeoutsToZero();
+                    nextDynamicCheckTime.set(0);
+                    notifyAll();
+                }
+                
                 try {
-                    this.wait();
+                    this.wait(1000);
                 }
                 catch (final Exception ex) {
                 }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperElement.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperElement.java
@@ -323,4 +323,8 @@ public class ReaperElement implements Comparable<ReaperElement>
     public long getTransactionTimeoutAbsoluteMillis() {
         return _transactionTimeoutAbsoluteMillis;
     }
+
+    void setTransactionTimeoutAbsoluteMillis(long transactionTimeoutAbsoluteMillis) {
+        this._transactionTimeoutAbsoluteMillis = transactionTimeoutAbsoluteMillis;
+    }
 }

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperElementManager.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/coordinator/ReaperElementManager.java
@@ -100,6 +100,7 @@ public class ReaperElementManager
         flushPending();
         for(ReaperElement reaperElement : elementsOrderedByTimeout) {
             reaperElement.setNextCheckAbsoluteMillis(0);
+            reaperElement.setTransactionTimeoutAbsoluteMillis(0);
         }
     }
 

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/reaper/ReaperTestCase3.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/reaper/ReaperTestCase3.java
@@ -229,7 +229,14 @@ public class ReaperTestCase3  extends ReaperTestCaseControl
         // byteman rules will ensure that the reaper and reaperworker rendezvous gte deleted
         // under this call
 
+        long start = System.currentTimeMillis();
+
         TransactionReaper.terminate(false);
+
+        long duration = System.currentTimeMillis() - start;
+
+        // should complete quickly
+        assertTrue(duration < 500);
 
         assertEquals(0, reaper.numberOfTransactions());
 

--- a/ArjunaJTS/jtax/pom.xml
+++ b/ArjunaJTS/jtax/pom.xml
@@ -217,6 +217,11 @@
       <build>
         <plugins>
           <plugin>
+            <inherited>false</inherited>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
             <inherited>false</inherited>


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Please refer to our [guidelines for making contributions](https://github.com/jbosstm/narayana/blob/main/CONTRIBUTING.md) when creating your pull request. In particular, it helps the reviewer if you ensure that the:
- [x] Pull Request title is properly formatted: JBTM-XYZ Subject
- [x] Pull Request contains a link to the JIRA issue(s) and that they contain sufficient information for the reviewer to be able to gauge whether or not the proposed changes correctly address the issue

See https://issues.redhat.com/browse/JBTM-3830 - this ensures it takes more than a spurious wakeup for shutdown to continue.

I still need to also confirm that we're not entirely missing the removal in this case as well.

The build axis can be controlled by prefixing a ! on the following as appropriate:

CORE PERFORMANCE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !LRA !DB_TESTS !mysql !db2 !postgres !oracle

By default the pull request will run with `JDK11`, if you prefix a `!` to `JDK11` then it will not run with `JDK11`.

By default the PR will not compile and run with JDK 17. To override this you need to concatenate the two sets of characters: `JDK` `17` as a single word and provide the result into the description.

If it is determined that nothing needs to be tested for the pull request then you need to concatenate the two sets of characters: `NO_` `TEST` as a single word and provide the result into the description.

Please be aware that none of this configuration affects which GitHub Actions will run.
