### PR TITLE
fix: periodic shutdown hangs

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TransactionReaper.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TransactionReaper.java
@@ -568,7 +568,7 @@ public class TransactionReaper
             throw new IllegalStateException(tsLogger.i18NLogger.get_coordinator_TransactionReaper_1());
         }
 
-        if (_dynamic && reaperElement.getNextCheckAbsoluteMillis() < nextDynamicCheckTime.get()) {
+        if (reaperElement.getNextCheckAbsoluteMillis() < nextDynamicCheckTime.get()) {
             updateCheckTimeForEarlierInsert(reaperElement.getNextCheckAbsoluteMillis());
         }
     }

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/reaper/ReaperTestCase4.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/reaper/ReaperTestCase4.java
@@ -1,0 +1,87 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.arjuna.reaper;
+
+import org.junit.Test;
+
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.coordinator.TransactionReaper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ReaperTestCase4 extends ReaperTestCaseControl {
+
+    @Test
+    public void testReaperForce() throws Exception
+    {
+        arjPropertyManager.getCoordinatorEnvironmentBean().setTxReaperMode(TransactionReaper.PERIODIC);
+        arjPropertyManager.getCoordinatorEnvironmentBean().setTxReaperTimeout(100);
+        try {
+            shutdown(true);
+        } finally {
+            arjPropertyManager.getCoordinatorEnvironmentBean().setTxReaperMode(TransactionReaper.DYNAMIC);
+            arjPropertyManager.getCoordinatorEnvironmentBean().setTxReaperTimeout(TransactionReaper.defaultCheckPeriod);
+        }
+    }
+
+    private void shutdown(boolean wait) throws InterruptedException {
+        TransactionReaper reaper = TransactionReaper.transactionReaper();
+
+        // give the reaper worker time to start too
+
+        Thread.sleep(1000);
+
+        // create test reapables some of which will not respond immediately to cancel requests
+
+        Uid uid0 = new Uid();
+        Uid uid1 = new Uid();
+        Uid uid2 = new Uid();
+        Uid uid3 = new Uid();
+
+        // reapable0 will return CANCELLED from cancel and will rendezvous inside the cancel call
+        // so we can delay it. prevent_commit should not get called so we don't care about the arguments
+        TestReapable reapable0 = new TestReapable(uid0, true, false, false, false);
+        // reapable1 will return CANCELLED from cancel and will not rendezvous inside the cancel call
+        // prevent_commit should not get called so we don't care about the arguments
+        TestReapable reapable1 = new TestReapable(uid1, true, false, false, false);
+        // reapable2 will return CANCELLED from cancel and will not rendezvous inside the cancel call
+        // prevent_commit should not get called so we don't care about the arguments
+        TestReapable reapable2 = new TestReapable(uid2, true, false, false, false);
+        // reapable3 will return CANCELLED from cancel and will not rendezvous inside the cancel call
+        // prevent_commit should not get called so we don't care about the arguments
+        TestReapable reapable3 = new TestReapable(uid3, true, false, false, false);
+
+        reaper.insert(reapable0, 1);
+
+        reaper.insert(reapable1, 2);
+
+        reaper.insert(reapable2, 3);
+
+        reaper.insert(reapable3, 4);
+
+        long start = System.currentTimeMillis();
+
+        TransactionReaper.terminate(wait);
+
+        long duration = System.currentTimeMillis() - start;
+
+        if (wait) {
+            assertTrue(String.valueOf(duration), duration < 4500);
+        } else {
+            assertTrue(String.valueOf(duration), duration < 500);
+        }
+
+        assertEquals(0, reaper.numberOfTransactions());
+
+        assertTrue(reapable0.getCancelTried());
+        assertTrue(reapable1.getCancelTried());
+        assertTrue(reapable2.getCancelTried());
+        assertTrue(reapable3.getCancelTried());
+    }
+
+}


### PR DESCRIPTION
Follow on to https://github.com/jbosstm/narayana/pull/2201#discussion_r1491384185 - the inconsistent usage of the dynamic next time will cause the reaper to not shutdown in periodic mode. 

I'm not sure if this needs another JIRA, or if you want to have an additional non-byteman testcase for this. Like what @jmfinelli was working on, it would be nice to just have a test matrix of shutdown combinations.

Thanks for submitting your Pull Request!

Please refer to our [guidelines for making contributions](https://github.com/jbosstm/narayana/blob/main/CONTRIBUTING.md) when creating your pull request. In particular, it helps the reviewer if you ensure that the:
- [ ] Pull Request title is properly formatted: JBTM-XYZ Subject
- [ ] Pull Request contains a link to the JIRA issue(s) and that they contain sufficient information for the reviewer to be able to gauge whether or not the proposed changes correctly address the issue

The build axis can be controlled by prefixing a ! on the following as appropriate:

CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_OPENJDKORB PERFORMANCE LRA DB_TESTS mysql db2 postgres oracle

By default the pull request will run with `JDK11`, if you prefix a `!` to `JDK11` then it will not run with `JDK11`.

By default the PR will not compile and run with JDK 17. To override this you need to concatenate the two sets of characters: `JDK` `17` as a single word and provide the result into the description.

If it is determined that nothing needs to be tested for the pull request then you need to concatenate the two sets of characters: `NO_` `TEST` as a single word and provide the result into the description.

Please be aware that none of this configuration affects which GitHub Actions will run.
