### PR TITLE
Update nexus-staging-maven-plugin to 1.6.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
     <!-- Needed forWildflyLRACoordinatorDeployment class -->
     <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>
-    <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
+    <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.13</version.org.sonatype.plugins.nexus-staging-maven-plugin>
     <version.quarkus-bom>3.0.1.Final</version.quarkus-bom>
     <version.quarkus-maven-plugin>3.0.1.Final</version.quarkus-maven-plugin>
     <version.sortpom>3.0.0</version.sortpom>


### PR DESCRIPTION
CORE TOMCAT! AS_TESTS! RTS! JACOCO! XTS! QA_JTA! QA_JTS_OPENJDKORB! PERFORMANCE! LRA! DB_TESTS!
I couldn't find the release notes of nexus-staging-maven-plugin releases, but the older version appeared not to be compatible with jdk17 