### PR TITLE
BUILD SCRIPT ONLY: Change jboss-profiler-jvmti and junit to compile scope as they are defined as test scope in the test BOM but QA builds tests as though they are main source

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -60,10 +60,12 @@
     <dependency>
       <groupId>jboss.profiler.jvmti</groupId>
       <artifactId>jboss-profiler-jvmti</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jacoco</groupId>


### PR DESCRIPTION
!CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS QA_JTA QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS mysql db2 postgres oracle
