### PR TITLE
JBTM-3056 xts-test-servlet is not needed in the full distribution

### DIFF
--- a/narayana-full/pom.xml
+++ b/narayana-full/pom.xml
@@ -85,11 +85,6 @@
       <classifier>participant</classifier>
       <type>war</type>
     </dependency>
-    <!-- This dependency should be removed in JBTM-3056 -->
-    <dependency>
-      <groupId>org.jboss.narayana.xts</groupId>
-      <artifactId>xts-test-servlet</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.jboss.narayana</groupId>
       <artifactId>jbosstxbridge</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3056

xts-test-servlet does not need to be in the full distro

XTS !CORE !TOMCAT !AS_TESTS !RTS !JACOCO !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle
