### PR TITLE
JBTM-3852 Enable code coverage to be ran on LRA_TESTS when JACOCO PROFILE is ran

### DIFF
--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/OpenAPIIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/OpenAPIIT.java
@@ -47,7 +47,7 @@ public class OpenAPIIT extends TestBase {
         String output = response.readEntity(String.class);
         assertFalse("WildFly OpenAPI document has paths at wrong location",
                 output.contains("/lra-coordinator/lra-coordinator:"));
-        assertTrue("WildFly OpenAPI document does not have paths for expected location",
+        assertTrue("WildFly OpenAPI document does not have paths for expected location:\n" + output,
                 output.contains("/lra-coordinator:"));
         assertTrue("WildFly OpenAPI document does not have server URL",
                 output.contains("url: /lra-coordinator"));

--- a/rts/lra/test/pom.xml
+++ b/rts/lra/test/pom.xml
@@ -332,7 +332,12 @@
         </plugins>
       </build>
     </profile>
-
+    <profile>
+      <id>codeCoverage</id>
+      <properties>
+        <server.jvm.args>${jvm.args.other} ${jvm.args.memory} ${jvm.args.debug} ${jvm.args.jacoco} ${jvm.args.modular}</server.jvm.args>
+      </properties>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -146,7 +146,7 @@ function init_test_options {
           comment_on_pull "Started testing this pull request with JACOCO profile: $BUILD_URL"
           export AS_BUILD=1 AS_CLONE=1 AS_TESTS=0 NARAYANA_BUILD=1 NARAYANA_TESTS=1 XTS_AS_TESTS=0 XTS_TESTS=1 COMPENSATIONS_TESTS=1 txbridge=1
           export RTS_AS_TESTS=0 RTS_TESTS=1 JTA_CDI_TESTS=1 QA_TESTS=1 JAC_ORB=0 JTA_AS_TESTS=1
-          export TOMCAT_TESTS=0 LRA_TESTS=0 LRA_AS_TESTS=0 CODE_COVERAGE=1 CODE_COVERAGE_ARGS="-PcodeCoverage -Pfindbugs"
+          export TOMCAT_TESTS=0 LRA_TESTS=1 LRA_AS_TESTS=0 CODE_COVERAGE=1 CODE_COVERAGE_ARGS="-PcodeCoverage -Pfindbugs"
           [ -z ${MAVEN_OPTS+x} ] && export MAVEN_OPTS="-Xms2048m -Xmx2048m"
         else
           export COMMENT_ON_PULL=""
@@ -504,7 +504,8 @@ function lra_tests {
   echo "#0. LRA Test"
   cd ./rts/lra/
   echo "#0. Running LRA tests using $ARQ_PROF profile"
-  PRESERVE_WORKING_DIR=true ../../build.sh -fae -B -Pcommunity -P$ARQ_PROF $CODE_COVERAGE_ARGS $ENABLE_LRA_TRACE_LOGS -Dlra.test.timeout.factor="${LRA_TEST_TIMEOUT_FACTOR:-1.5}" "$@"
+  # Ideally the following target would be test and integration-test but that doesn't seem to shutdown the server each time
+  PRESERVE_WORKING_DIR=true ../../build.sh -fae -B -Pcommunity -P$ARQ_PROF $CODE_COVERAGE_ARGS $ENABLE_LRA_TRACE_LOGS -Dlra.test.timeout.factor="${LRA_TEST_TIMEOUT_FACTOR:-1.5}" "$@" install
   lra_arq=$?
   if [ $lra_arq != 0 ] ; then fatal "LRA Test failed with failures in $ARQ_PROF profile" ; fi
 }

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -525,6 +525,8 @@ function compensations_tests {
   [ $? -eq 0 ] || fatal "compensations build failed"
   ./build.sh -f compensations/pom.xml -fae -B -P$ARQ_PROF-weld $CODE_COVERAGE_ARGS "$@" test
   [ $? -eq 0 ] || fatal "compensations build failed"
+  rm $JBOSS_HOME/standalone/deployments/restat-web-*.war
+  [ $? -eq 0 ] || fatal "Could not remove .war file"
 }
 
 function xts_tests {


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3852 (partial, only enable LRA_TESTS when JACOCO is ran)

!CORE !TOMCAT !AS_TESTS !RTS JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS mysql db2 postgres oracle

!JDK11