### PR TITLE
[JBTM-3862] Compensation is removed from WildFly, disable integration

### DIFF
--- a/compensations/pom.xml
+++ b/compensations/pom.xml
@@ -186,9 +186,9 @@
                                 <node.address>127.0.0.1</node.address>
                                 <server.config>standalone-xts.xml</server.config>
                             </systemPropertyVariables>
-                            <includes>
-                                <include>**/*TestLocal.java</include>
-                            </includes>
+                            <excludes>
+                                <exclude>**/*</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -222,10 +222,9 @@
                                 <node.address>127.0.0.1</node.address>
                                 <server.config>standalone-xts.xml</server.config>
                             </systemPropertyVariables>
-                            <includes>
-                                <include>**/*TestRemote.java</include>
-                            </includes>
-                        </configuration>
+                            <excludes>
+                                <exclude>**/*</exclude>
+                            </excludes>                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -259,10 +258,9 @@
                                 <node.address>[::1]</node.address>
                                 <server.config>standalone.xml</server.config>
                             </systemPropertyVariables>
-                            <includes>
-                                <include>**/*TestLocal.java</include>
-                            </includes>
-                        </configuration>
+                            <excludes>
+                                <exclude>**/*</exclude>
+                            </excludes>                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -296,10 +294,9 @@
                                 <node.address>[::1]</node.address>
                                 <server.config>standalone-xts.xml</server.config>
                             </systemPropertyVariables>
-                            <includes>
-                                <include>**/*TestRemote.java</include>
-                            </includes>
-                        </configuration>
+                            <excludes>
+                                <exclude>**/*</exclude>
+                            </excludes>                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -364,10 +361,9 @@
                         <configuration>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <skip>false</skip>
-                            <includes>
-                                <include>**/*TestWeld.java</include>
-                            </includes>
-                        </configuration>
+                            <excludes>
+                                <exclude>**/*</exclude>
+                            </excludes>                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3862

CORE !TOMCAT AS_TESTS !RTS !JACOCO XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS mysql db2 postgres oracle


I am also OK with removing arquillian dependencies and tests, but I left them because those may be of use when testing against older version of WildFly.
