### PR TITLE
[JBTM-3862] compensation leftover

### DIFF
--- a/code-coverage/pom.xml
+++ b/code-coverage/pom.xml
@@ -77,8 +77,6 @@
                         <fileset dir="../XTS/localjunit/WSTX11-interop/target/coverage-reports" includes="jacoco-ut.exec"/>
 
                         <fileset dir="../txbridge/target/coverage-reports" includes="jacoco-ut.exec"/>
-
-                        <fileset dir="../compensations/target/coverage-reports" includes="jacoco-ut.exec"/>
                       </executiondata>
 
                       <structure name="JaCoCo">
@@ -267,8 +265,6 @@
                       <fileset dir="../XTS/localjunit/WSTX11-interop/target/${surefire.reports.directory}" includes="**/*.xml"/>
 
                       <fileset dir="../txbridge/target/${surefire.reports.directory}" includes="**/*.xml"/>
-
-                      <fileset dir="../compensations/target/${surefire.reports.directory}" includes="**/*.xml"/>
 
                       <report format="noframes" styledir="xsl" todir="${project.build.directory}/junit">
                         <param name="narayana.url" expression="${narayana.home.url}"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3862

CORE !TOMCAT !AS_TESTS !RTS JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TEST

!JDK11 JDK17

disable coverage-report for compensation because surefire tests are now disabled by default.
