### PR TITLE
JBTM-3868 upgrade and clean up byteman dependency

### DIFF
--- a/ArjunaJTS/integration/pom.xml
+++ b/ArjunaJTS/integration/pom.xml
@@ -87,7 +87,6 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-bmunit</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/ArjunaJTS/jts/pom.xml
+++ b/ArjunaJTS/jts/pom.xml
@@ -101,7 +101,6 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/narayana-bom-test/pom.xml
+++ b/narayana-bom-test/pom.xml
@@ -44,7 +44,8 @@
     <version.org.apache.ant>1.10.12</version.org.apache.ant>
     <version.org.jboss.arquillian.container.weld>3.0.2.Final</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.arquillian.core>1.7.0.Final</version.org.jboss.arquillian.core>
-    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
+    <!-- remark: this property is duplicated in the top level pom -->
+    <version.org.jboss.byteman>4.0.22</version.org.jboss.byteman>
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
     <version.org.jboss.shrinkwrap.resolvers>3.1.4</version.org.jboss.shrinkwrap.resolvers>
     <version.org.jboss.weld>5.0.1.Final</version.org.jboss.weld>
@@ -455,6 +456,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jboss.byteman</groupId>
+        <artifactId>byteman-rulecheck-maven-plugin</artifactId>
+        <version>${version.org.jboss.byteman}</version>
+        <executions>
+          <execution>
+            <id>rulecheck</id>
+            <goals>
+              <goal>rulecheck</goal>
+            </goals>
+            <phase>test-compile</phase>
+            <configuration>
+              <includes>
+                <include>**/*.btm</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <inherited>false</inherited>
@@ -472,4 +493,37 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>byteman-rulecheck</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-rulecheck-maven-plugin</artifactId>
+            <version>${version.org.jboss.byteman}</version>
+            <executions>
+              <execution>
+                <id>rulecheck</id>
+                <goals>
+                  <goal>rulecheck</goal>
+                </goals>
+                <phase>test-compile</phase>
+                <configuration>
+                  <includes>
+                    <include>**/*.btm</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/narayana-bom/pom.xml
+++ b/narayana-bom/pom.xml
@@ -55,7 +55,6 @@
     <version.org.eclipse.microprofile.reactive-streams-operators>3.0</version.org.eclipse.microprofile.reactive-streams-operators>
     <version.org.jboss.arquillian.container.weld>3.0.2.Final</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.arquillian.core>1.7.0.Final</version.org.jboss.arquillian.core>
-    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
     <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
     <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
     <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,6 @@
 
     <version.org.jacoco>0.8.8</version.org.jacoco>
     <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
-    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
     <!-- Needed forWildflyLRACoordinatorDeployment class -->
     <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>
     <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.13</version.org.sonatype.plugins.nexus-staging-maven-plugin>
@@ -243,11 +242,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.jboss.byteman</groupId>
-          <artifactId>byteman-rulecheck-maven-plugin</artifactId>
-          <version>${version.org.jboss.byteman}</version>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
@@ -524,37 +518,6 @@
     </plugins>
   </build>
   <profiles>
-    <profile>
-      <id>byteman-rulecheck</id>
-      <activation>
-        <property>
-          <name>!skipTests</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jboss.byteman</groupId>
-            <artifactId>byteman-rulecheck-maven-plugin</artifactId>
-            <version>${version.org.jboss.byteman}</version>
-            <executions>
-              <execution>
-                <id>rulecheck</id>
-                <goals>
-                  <goal>rulecheck</goal>
-                </goals>
-                <phase>test-compile</phase>
-                <configuration>
-                  <includes>
-                    <include>**/*.btm</include>
-                  </includes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/rts/at/bridge/pom.xml
+++ b/rts/at/bridge/pom.xml
@@ -105,13 +105,11 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-submit</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/rts/at/integration/pom.xml
+++ b/rts/at/integration/pom.xml
@@ -68,21 +68,18 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-submit</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-bmunit</artifactId>
-      <version>${version.org.jboss.byteman}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3868

CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle

I added a separate commit for the RTS and JTS dependencies on byteman artifacts. I was unable to figure out why those artifacts were treated as special cases so I thought it best to change them in a separate commit.