### PR TITLE
Jbtm 3871 Update spotbugs maven plugin to 4.8.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
     <sortpom.skip>false</sortpom.skip>
     <!-- The surefire/failsafe test execution logs goes to a file by default -->
     <testLogToFile>true</testLogToFile>
-    <version.com.github.spotbugs.spotbugs-maven-plugin>4.5.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
+    <version.com.github.spotbugs.spotbugs-maven-plugin>4.8.3.1</version.com.github.spotbugs.spotbugs-maven-plugin>
     <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
 
     <version.doxia>1.8.1</version.doxia>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3871

!CORE !TOMCAT !AS_TESTS !RTS  !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 

As described in spotbugs release notes (https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.8.0.0) 4.8.x version is compatible with JDK21
JDK17
JACOCO
