### PR TITLE
[JBTM-3874] The Security Manager is deprecated

### DIFF
--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/ServiceRegistrySecurityManagerTest.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/ServiceRegistrySecurityManagerTest.java
@@ -2,47 +2,71 @@
    Copyright The Narayana Authors
    SPDX-License-Identifier: Apache-2.0
  */
-
 package com.arjuna.wsc.tests.local;
 
-import com.arjuna.webservices11.ServiceRegistry;
+import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.arjuna.webservices11.ServiceRegistry;
+
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ *
+ *         Remove this unit test class once JDK21 is the minimum JDK
+ *
+ *         JDK21 throws UnsupportedOperationException when
+ *         System.setSecurityManager is called, see https://openjdk.org/jeps/411
  */
 public class ServiceRegistrySecurityManagerTest {
 
     private static final String SERVICE_REGISTRY_PERMISSION_NAME = ServiceRegistry.class.getName() + ".getRegistry";
-
+    private final Logger logger = Logger.getLogger(ServiceRegistrySecurityManagerTest.class);
+    @SuppressWarnings("removal")
     private SecurityManager oldSecurityManager;
-
+    @SuppressWarnings("removal")
     @Before
     public void before() {
         oldSecurityManager = System.getSecurityManager();
     }
 
+    @SuppressWarnings("removal")
     @After
     public void after() {
-        System.setSecurityManager(oldSecurityManager);
+        try {
+            System.setSecurityManager(oldSecurityManager);
+        }
+        catch (UnsupportedOperationException e) {
+            logger.warn("setting the SecurityManager is no longer supported", e);
+        }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testWithoutSecurityManager() {
-        System.setSecurityManager(null);
-        Assert.assertNotNull(ServiceRegistry.getRegistry());
+        try {
+            System.setSecurityManager(null);
+            Assert.assertNotNull(ServiceRegistry.getRegistry());
+        }
+        catch (UnsupportedOperationException e) {
+            logger.warn("setting the SecurityManager is no longer supported", e);
+        }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testWithSecurityManager() {
-        final SinglePermissionSecurityManager testSecurityManager = new SinglePermissionSecurityManager(SERVICE_REGISTRY_PERMISSION_NAME);
-        System.setSecurityManager(testSecurityManager);
-
-        Assert.assertNotNull(ServiceRegistry.getRegistry());
-        Assert.assertTrue(testSecurityManager.wasCalled());
+        final SinglePermissionSecurityManager testSecurityManager = new SinglePermissionSecurityManager(
+                SERVICE_REGISTRY_PERMISSION_NAME);
+        try {
+            System.setSecurityManager(testSecurityManager);
+            Assert.assertNotNull(ServiceRegistry.getRegistry());
+            Assert.assertTrue(testSecurityManager.wasCalled());
+        }
+        catch (UnsupportedOperationException e) {
+            logger.warn("setting the SecurityManager is no longer supported", e);
+        }
     }
-
 }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/SinglePermissionSecurityManager.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/SinglePermissionSecurityManager.java
@@ -10,6 +10,7 @@ import java.security.Permission;
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
+@SuppressWarnings("removal")
 public final class SinglePermissionSecurityManager extends SecurityManager {
 
     private final String permissionName;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3874

Removing tests related to Security Manager, because it is deprecated in JDK17 and will be removed in a future release.
See [JEP 411](https://openjdk.org/jeps/411)
!CORE !TOMCAT !AS_TESTS !RTS JACOCO XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 

JDK17 JDK21