### PR TITLE
[JBTM-3871] Build Narayana with JDK 21

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,7 @@ The build axis can be controlled by prefixing a ! on the following as appropriat
 
 CORE TOMCAT AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_OPENJDKORB PERFORMANCE LRA DB_TESTS mysql db2 postgres oracle
 
-By default the pull request will run with `JDK11`, if you prefix a `!` to `JDK11` then it will not run with `JDK11`.
-
-By default the PR will not compile and run with JDK 17. To override this you need to concatenate the two sets of characters: `JDK` `17` as a single word and provide the result into the description.
+Pull requests build and run with JDK11 and JDK17. Add the prefix `!` to disable these defaults. Include the text `JDK21` to build and run with JDK21
 
 If it is determined that nothing needs to be tested for the pull request then you need to concatenate the two sets of characters: `NO_` `TEST` as a single word and provide the result into the description.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3871
Enable by default JDK17 for new PRs and enable JDK21 when needed. Update the PULL_REQUEST_TEMPLATE.md

NO_TEST
