### PR TITLE
[JBTM-3867] leftover

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -40,6 +40,8 @@ function wildfly_minimum_jdk {
   if [ "$_jdk" -lt 17 ]; then
     echo "WildFly must be built with JDK 17 or greater" 
     export AS_BUILD=0 AS_CLONE=0 AS_TESTS=0 JTA_AS_TESTS=0 RTS_AS_TESTS=0 LRA_AS_TESTS=0 XTS_AS_TESTS=0 XTS_TRACE=0 txbridge=0 ARQ_PROF=no_arq 
+    # without AS test results the code coverage does not work, so not running it
+    export CODE_COVERAGE=0
   fi
 }
 function get_pull_xargs {


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3867

Avoid running code coverage with JDK11 because it doesn't work when AS tests are not executed

!CORE !TOMCAT !AS_TESTS !RTS JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 

See failure on CI: https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/narayana/PROFILE=JACOCO,jdk=openJDK11,label=jnlp-agent/260/console