### PR TITLE
BUILD SCRIPT ONLY: Remove the restat-web-*.war if it exists

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -525,7 +525,7 @@ function compensations_tests {
   [ $? -eq 0 ] || fatal "compensations build failed"
   ./build.sh -f compensations/pom.xml -fae -B -P$ARQ_PROF-weld $CODE_COVERAGE_ARGS "$@" test
   [ $? -eq 0 ] || fatal "compensations build failed"
-  rm $JBOSS_HOME/standalone/deployments/restat-web-*.war
+  rm -f $JBOSS_HOME/standalone/deployments/restat-web-*.war
   [ $? -eq 0 ] || fatal "Could not remove .war file"
 }
 


### PR DESCRIPTION
This change adds a small correction to commit https://github.com/jbosstm/narayana/commit/ec13ede6937aaecf8ed6923ca2f5c06bb5924eb7 such that the build script won't fail if the target file to be removed does not exist. 

NO_TEST
!CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle
