### PR TITLE
JBTM-3881 Report heuristics for multiple one phase resources

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/logging/arjunaI18NLogger.java
@@ -1621,6 +1621,10 @@ public interface arjunaI18NLogger {
 	@LogMessage(level = INFO)
 	void info_osbSkipHandler(String type);
 
+	@Message(id = 12408, value = "One-phase commit of action {0} received heuristic decision: {1}", format = MESSAGE_FORMAT)
+	@LogMessage(level = WARN)
+	void warn_coordinator_BasicAction_71(Uid arg0, String arg1);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/abstractrecords/LastResourceRecord.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/abstractrecords/LastResourceRecord.java
@@ -96,7 +96,11 @@ public class LastResourceRecord extends AbstractRecord
 
         if (_lro != null)
         {
-            return _lro.rollback();
+            if (outcome == TwoPhaseOutcome.FINISH_OK) {
+                return _lro.rollback();
+            }
+
+            return outcome;
         }
         else
         {
@@ -239,6 +243,11 @@ public class LastResourceRecord extends AbstractRecord
     {
     }
 
+    public void setOutcome(int outcome) {
+        // cannot use setValue since value is overused (in this record it is used to return _lro, the OnePhaseResource)
+        this.outcome = outcome;
+    }
+
     public LastResourceRecord()
     {
         super();
@@ -257,6 +266,8 @@ public class LastResourceRecord extends AbstractRecord
             .isDisableMultipleLastResourcesWarning();
 
     private static boolean _issuedWarning = false;
+
+    private int outcome = TwoPhaseOutcome.FINISH_OK;
 
     /**
      * Static block writes warning messages to the log if either multiple last resources are enabled

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/lastresource/LastOnePhaseResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/lastresource/LastOnePhaseResource.java
@@ -22,7 +22,17 @@ public class LastOnePhaseResource implements XAResource, Serializable, LastResou
     public static final int ROLLBACK = 2 ;
     
     private int status = INITIAL ;
-    
+    private int commitErrcode;
+    private int rollbackErrcode;
+
+    public LastOnePhaseResource(int commitErrcode, int rollbackErrcode) {
+        this.commitErrcode = commitErrcode;
+        this.rollbackErrcode = rollbackErrcode;
+    }
+
+    public LastOnePhaseResource() {
+    }
+
     public int prepare(final Xid xid)
         throws XAException
     {
@@ -36,12 +46,18 @@ public class LastOnePhaseResource implements XAResource, Serializable, LastResou
         {
             throw new XAException("commit called with onePhaseCommit false") ;
         }
+        if (commitErrcode != 0) { // 0 corresponds to XA_OK
+            throw new XAException(commitErrcode);
+        }
         status = COMMIT ;
     }
 
     public void rollback(final Xid xid)
         throws XAException
     {
+        if (rollbackErrcode != 0) { // 0 corresponds to XA_OK
+            throw new XAException(rollbackErrcode);
+        }
         status = ROLLBACK ;
     }
     

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/lastresource/LastResourceAllowedTestCase.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/lastresource/LastResourceAllowedTestCase.java
@@ -5,8 +5,14 @@
 
 package com.hp.mwtests.ts.jta.lastresource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.arjuna.ats.arjuna.coordinator.TxStats;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.SystemException;
@@ -14,19 +20,72 @@ import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
 
-public class LastResourceAllowedTestCase
-{
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+public class LastResourceAllowedTestCase {
+    private XAResource xar;
+
     @Before
-    public void setUp() throws Exception
-    {
+    public void setUp() throws Exception {
         arjPropertyManager.getCoreEnvironmentBean().setAllowMultipleLastResources(true);
+        arjPropertyManager.getCoordinatorEnvironmentBean().setEnableStatistics(true);
+
+        xar = new XAResource() {
+            @Override
+            public void commit(Xid xid, boolean b) throws XAException {
+            }
+
+            @Override
+            public void end(Xid xid, int i) throws XAException {
+            }
+
+            @Override
+            public void forget(Xid xid) throws XAException {
+            }
+
+            @Override
+            public int getTransactionTimeout() throws XAException {
+                return 0;
+            }
+
+            @Override
+            public boolean isSameRM(XAResource xaResource) throws XAException {
+                return false;
+            }
+
+            @Override
+            public int prepare(Xid xid) throws XAException {
+                return 0;
+            }
+
+            @Override
+            public Xid[] recover(int i) throws XAException {
+                return new Xid[0];
+            }
+
+            @Override
+            public void rollback(Xid xid) throws XAException {
+            }
+
+            @Override
+            public boolean setTransactionTimeout(int i) throws XAException {
+                return false;
+            }
+
+            @Override
+            public void start(Xid xid, int i) throws XAException {
+            }
+        };
     }
-    
+
     @Test
     public void testAllowed()
         throws SystemException, NotSupportedException, RollbackException
@@ -47,6 +106,105 @@ public class LastResourceAllowedTestCase
         finally
         {
             tm.rollback() ;
+        }
+    }
+
+    @Test
+    public void testHeuristicMixed() throws SystemException, NotSupportedException, RollbackException
+    {
+        // first last resource (LR) commits, second LR throws XA_HEURRB
+        // then validate that the commit produces a HeuristicMixedException
+        final LastOnePhaseResource firstResource = new LastOnePhaseResource(XAException.XA_HEURRB, 0);
+        final LastOnePhaseResource secondResource = new LastOnePhaseResource(0, 0);
+
+        // since both last resources will fail the expectation is rollback
+        generateLastResourceFailures(true, HeuristicMixedException.class.getName(), xar, firstResource, secondResource);
+    }
+
+    @Test
+    public void testRollback() throws SystemException, NotSupportedException, RollbackException
+    {
+        // both last resources throw XA_HEURRB
+        // then validate that the commit produces a RollbackException
+        final LastOnePhaseResource firstResource = new LastOnePhaseResource(XAException.XA_HEURRB, 0);
+        final LastOnePhaseResource secondResource = new LastOnePhaseResource(XAException.XA_HEURRB, 0);
+
+        // the prepare phase should fail on the first resource throws XA_HEURRB so the decision will switch to
+        // rolling back the remaining resources and the overall outcome should be a RollbackException
+        generateLastResourceFailures(true, RollbackException.class.getName(), xar, firstResource, secondResource);
+    }
+
+    @Test
+    @Ignore // ignored for now because:
+    // BasicAction.Abort turns off heuristic reporting, so we won't get the expected HeuristicMixedException
+    // and the warning in the log does not include deferredThrowables (which would have helped)
+    public void testHeuristicRollback() throws SystemException, NotSupportedException, RollbackException
+    {
+        // first LR rolls back ok, second LR throws XA_HEURCOM
+        // then validate that the commit produces a HeuristicMixedException
+        final LastOnePhaseResource firstResource = new LastOnePhaseResource(0, XAException.XA_HEURCOM);
+        final LastOnePhaseResource secondResource = new LastOnePhaseResource(0, 0);
+
+        // even though the test produces the correct heuristic there doesn't appear to be a way to report it on rollback
+        generateLastResourceFailures(false, HeuristicMixedException.class.getName(), xar, firstResource, secondResource);
+    }
+
+    private void generateLastResourceFailures(boolean doCommit, String expectedExceptionClassName,
+                                              XAResource xar, LastOnePhaseResource ... lastResources)
+            throws SystemException, NotSupportedException, RollbackException
+    {
+        final TransactionManager tm = new TransactionManagerImple();
+        long numberOfHeuristics = TxStats.getInstance().getNumberOfHeuristics();
+
+        Transaction tx;
+
+        tm.setTransactionTimeout(300); // useful for debugging
+        tm.begin();
+
+        try {
+            tx = tm.getTransaction();
+
+            for (int i = 0; i < lastResources.length; i++) {
+                assertTrue("enlist resource " + i, tx.enlistResource(lastResources[i]));
+            }
+
+            if (xar != null) {
+                assertTrue("XA resource enlisted", tx.enlistResource(xar));
+            }
+        } finally {
+            try {
+                if (doCommit) {
+                    tm.commit();
+                } else {
+                    tm.rollback();
+                }
+                fail("commit or rollback should have thrown an exception of type " + expectedExceptionClassName);
+            } catch (HeuristicMixedException e) {
+                if (!expectedExceptionClassName.equals(e.getClass().getName())) {
+                    fail("HeuristicMixedException unexpected");
+                }
+                // verify that the exception contains the correct suppressed XAException
+                Throwable[] throwables = e.getSuppressed();
+                assertNotEquals("expected a suppressed XA_HEURRB XAException", 0, throwables.length);
+                Throwable t = throwables[0]; // the first one should be the resource exception
+                assertEquals("Expected an XAException not " + t.getClass().getName(),
+                        XAException.class, t.getClass());
+                assertEquals("suppressed XAException should have been XA_HEURRB",
+                        XAException.XA_HEURRB, ((XAException) t).errorCode);
+                assertEquals("too few heuristics reported",
+                        numberOfHeuristics + 1, TxStats.getInstance().getNumberOfHeuristics());
+            } catch (HeuristicRollbackException e) {
+                if (!expectedExceptionClassName.equals(e.getClass().getName())) {
+                    fail("HeuristicRollbackException unexpected");
+                }
+            } catch (Exception e) {
+                if (!expectedExceptionClassName.equals(e.getClass().getName())) {
+                    fail("expected exception of type " +
+                            expectedExceptionClassName +
+                            " but got " +
+                            e.getClass().getName());
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3881

CORE !TOMCAT !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle

FYI I updated the PR to use rollback if any of the last phase participants produce a ONE_PHASE_ERROR during the prepare phase (see BasicAction#doPrepare) - this is what BasicAction already does in the single last phase resource case (LRCO). Since multiple last resources is inherently unsafe I believe it is valid to switch to rollback for the XA participants if two of the last resources produce a mixed outcome.