### PR TITLE
Jbtm 3883

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
@@ -29,6 +29,7 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
 
     @FullPropertyName(name = "com.arjuna.ats.arjuna.nodeIdentifier")
     private volatile String nodeIdentifier = null;
+    private volatile byte[] nodeIdentifierBytes;
 
     @FullPropertyName(name = "com.arjuna.ats.internal.arjuna.utils.SocketProcessIdPort")
     private volatile int socketProcessIdPort = 0;
@@ -105,6 +106,25 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
         }
 
     	this.nodeIdentifier = nodeIdentifier;
+        this.nodeIdentifierBytes = nodeIdentifier.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] getNodeIdentifierBytes() {
+        return this.nodeIdentifierBytes;
+    }
+
+    public void setNodeIdentifier(byte[] bytes) throws CoreEnvironmentBeanException
+    {
+        String name = new String(bytes, StandardCharsets.UTF_8);
+
+        if (bytes.length > NODE_NAME_SIZE)
+        {
+            tsLogger.i18NLogger.fatal_nodename_too_long(name, NODE_NAME_SIZE);
+            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_too_long(name, NODE_NAME_SIZE));
+        }
+
+        this.nodeIdentifierBytes = bytes;
+        this.nodeIdentifier = name;
     }
 
     /**

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxControl.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TxControl.java
@@ -219,7 +219,7 @@ public class TxControl
 	private static TransactionStatusManager transactionStatusManager = null;
 
 	static String xaNodeName = arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifier();
-	static byte[] xaNodeNameBytes = (xaNodeName == null ? null : xaNodeName.getBytes(StandardCharsets.UTF_8));
+	static byte[] xaNodeNameBytes = arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifierBytes();
 
 	static int _defaultTimeout = arjPropertyManager.getCoordinatorEnvironmentBean().getDefaultTimeout();
 

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/common/ArjPropertyManagerTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/common/ArjPropertyManagerTest.java
@@ -4,11 +4,18 @@
  */
 package com.hp.mwtests.ts.arjuna.common;
 
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,5 +49,21 @@ public class ArjPropertyManagerTest {
         arjPropertyManager.getObjectStoreEnvironmentBean().setObjectStoreSync(true);
         assertTrue(BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).isObjectStoreSync());
         assertTrue(BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, "communicationStore").isObjectStoreSync());
+    }
+
+    @Test
+    public void testNodeIdentifier() throws CoreEnvironmentBeanException {
+        CoreEnvironmentBean config = BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class);
+        String random = UUID.randomUUID().toString(); // String form of a random UUID
+
+        assertEquals(36, random.length()); // a UUID consists of 32 hex digits along with 4 “-” symbols
+
+        config.setNodeIdentifier(random);//random.getBytes());
+        byte[] bytes = config.getNodeIdentifierBytes();
+        String name1 = config.getNodeIdentifier();
+        String name2 = new String(bytes);
+
+        assertEquals(name1, name2);
+        assertEquals(name1, random);
     }
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/utils/XAUtils.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/utils/XAUtils.java
@@ -81,6 +81,12 @@ public class XAUtils
         return XATxConverter.getNodeName(getXIDfromXid(xid));
 	}
 
+	public static byte[] getXANodeNameBytes (Xid xid)
+	{
+	    XID theXid = getXIDfromXid(xid); // narayana XidImple
+	    return XATxConverter.getNodeNameBytes(theXid);
+	}
+
 	/**
 	 * Returning subordinate node name codified inside of the Xid.
 	 *

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XATxConverter.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/xa/XATxConverter.java
@@ -164,6 +164,16 @@ public class XATxConverter
 		return new String(Arrays.copyOfRange(globalTransactionId, offset, globalTransactionId.length), StandardCharsets.UTF_8);
 	}
 
+	public static byte[] getNodeNameBytes(XID xid) {
+		Xid xidImple = new XidImple(xid);
+		byte[] globalTransactionId = xidImple.getGlobalTransactionId();
+
+		// the node name follows the Uid with no separator, so the only
+		// way to tell where it starts is to figure out how long the Uid is.
+		int offset = Uid.UID_SIZE;
+		return Arrays.copyOfRange(globalTransactionId, offset, globalTransactionId.length);
+	}
+
 	public static void setSubordinateNodeName(XID theXid, String xaNodeName) {
 		if (theXid == null || !FormatConstants.isNarayanaFormatId(theXid.formatID)) {
 			return;

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/NodeIdentifierUnitTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/xa/NodeIdentifierUnitTest.java
@@ -1,0 +1,71 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+package com.hp.mwtests.ts.jta.xa;
+
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
+import com.arjuna.ats.arjuna.common.Uid;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.coordinator.TxControl;
+import com.arjuna.ats.internal.jta.utils.XAUtils;
+import com.arjuna.ats.jta.xa.XidImple;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class NodeIdentifierUnitTest
+{
+    // TxControl initialises the node id in a static initializer so use just a test
+    @BeforeClass
+    public static void before() throws NoSuchAlgorithmException {
+        String random = UUID.randomUUID().toString(); // String form of a random UUID
+
+        assertEquals(36, random.length()); // a UUID consists of 32 hex digits along with 4 “-” symbols
+
+        setNodeIdentifier(random); // set nodeIdentifier in the config bean
+    }
+
+    @Test
+    public void testNodeIdentifier() {
+        XidImple xid = new XidImple(new Uid()); // the Xid will encode the nodeName plus other data
+
+        byte[] nodeNameConfiguredBytes = arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifierBytes();
+        byte[] xaNodeNameBytes = XAUtils.getXANodeNameBytes(xid);
+
+        String nodeName = arjPropertyManager.getCoreEnvironmentBean().getNodeIdentifier();
+        String nodeNameFromBytes = new String(nodeNameConfiguredBytes); // nodeName from the config bean
+        String xaNodeName = XAUtils.getXANodeName(xid); // extract the node id from a Xid
+        String tmNodeName = TxControl.getXANodeName(); // TxControl's view of the node id
+        String xaNodeNameFromBytes = new String(xaNodeNameBytes); // TxControl's view of the node id bytes
+
+        assertNotNull(nodeName); // can't be null (see the setNodeIdentifier method)
+        assertTrue(nodeName.length() <= TxControl.NODE_NAME_SIZE);
+
+        // they all should agree
+        assertEquals(nodeName, nodeNameFromBytes);
+        assertEquals(nodeName, xaNodeName);
+        assertEquals(xaNodeName, tmNodeName);
+        assertEquals(tmNodeName, xaNodeNameFromBytes);
+    }
+
+    private static void setNodeIdentifier(String nodeIdentifier) throws NoSuchAlgorithmException {
+        byte[] nodeIdentifierAsBytes = nodeIdentifier.getBytes();
+        MessageDigest messageDigest224 = MessageDigest.getInstance("SHA-224");
+        byte[] digest = messageDigest224.digest(nodeIdentifierAsBytes);
+
+        try {
+            arjPropertyManager.getCoreEnvironmentBean().setNodeIdentifier(digest);
+        } catch (CoreEnvironmentBeanException e) {
+            fail("unable to set nodeIdentifier: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3883

CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle

This PR follows up on #2259 and adds more input validation and javadoc to CoreEnvironmentBean#setNodeIdentifier(byte[] nodeIdentifierBytes) and also adds a test for the config setting (see ArjPropertyManagerTest.java).