### PR TITLE
JBTM-3883 Add javadoc and more checks when setting the nodeIdentifer …

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
@@ -6,6 +6,8 @@ package com.arjuna.ats.arjuna.common;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+
+import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.arjuna.ats.arjuna.logging.tsLogger;
 import com.arjuna.ats.arjuna.utils.Process;
 import com.arjuna.ats.arjuna.utils.Utility;
@@ -87,6 +89,10 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
 
     /**
      * Sets the node identifier. Should be uniq amongst all instances that share resource managers or an objectstore.
+     * <p>
+     * This config setting has the side effect of setting the node identifier bytes by extracting the bytes from
+     * the passed in String using the UTF_8 character set (if you need to control the length of the byte array
+     * please use the {@link #setNodeIdentifier(byte[]) method} directly).
      *
      * @param nodeIdentifier the Node Identifier.
      * @throws CoreEnvironmentBeanException if node identifier is null or too long.
@@ -113,18 +119,42 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
         return this.nodeIdentifierBytes;
     }
 
-    public void setNodeIdentifier(byte[] bytes) throws CoreEnvironmentBeanException
+    /**
+     * Sets the node identifier bytes and must be unique amongst all instances that share resource managers
+     * or an objectstore. This method is subtly different from the other form because it does not use any character
+     * encoding (such encodings can change the length of a Java String). The byte array is restricted to
+     * {@value com.arjuna.ats.arjuna.coordinator.TxControl#NODE_NAME_SIZE} bytes - the length restriction is
+     * required because these bytes are encoded into other structures which have limited sizes.
+     * <p>
+     * This config setting has the side effect of setting the node identifier String (by encoding the passed
+     * in bytes with the UTF_8 character set) and if the length of the resulting String is greater than
+     * {@link #NODE_NAME_SIZE} then a CoreEnvironmentBeanException is thrown.
+     *
+     * @param nodeIdentifierBytes the bytes for node identifier.
+     * @throws CoreEnvironmentBeanException if node identifier is null or too long.
+     */
+    public void setNodeIdentifier(byte[] nodeIdentifierBytes) throws CoreEnvironmentBeanException
     {
-        String name = new String(bytes, StandardCharsets.UTF_8);
-
-        if (bytes.length > NODE_NAME_SIZE)
-        {
-            tsLogger.i18NLogger.fatal_nodename_too_long(name, NODE_NAME_SIZE);
-            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_too_long(name, NODE_NAME_SIZE));
+        if (nodeIdentifierBytes == null) {
+            tsLogger.i18NLogger.fatal_nodename_null();
+            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_null());
         }
 
-        this.nodeIdentifierBytes = bytes;
-        this.nodeIdentifier = name;
+        if (nodeIdentifierBytes.length > TxControl.NODE_NAME_SIZE) {
+            tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier, TxControl.NODE_NAME_SIZE);
+            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.
+                    get_fatal_nodename_too_long(nodeIdentifier, TxControl.NODE_NAME_SIZE));
+        }
+
+        String newName = new String(nodeIdentifierBytes, StandardCharsets.UTF_8);
+        if (newName.getBytes(StandardCharsets.UTF_8).length > NODE_NAME_SIZE)
+        {
+            tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier, NODE_NAME_SIZE);
+            throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.get_fatal_nodename_too_long(nodeIdentifier, NODE_NAME_SIZE));
+        }
+
+        this.nodeIdentifier = newName;
+        this.nodeIdentifierBytes = nodeIdentifierBytes; // replace the bytes set via the last call
     }
 
     /**

--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/common/ArjPropertyManagerTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/common/ArjPropertyManagerTest.java
@@ -4,11 +4,18 @@
  */
 package com.hp.mwtests.ts.arjuna.common;
 
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.common.internal.util.propertyservice.BeanPopulator;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -42,5 +49,21 @@ public class ArjPropertyManagerTest {
         arjPropertyManager.getObjectStoreEnvironmentBean().setObjectStoreSync(true);
         assertTrue(BeanPopulator.getDefaultInstance(ObjectStoreEnvironmentBean.class).isObjectStoreSync());
         assertTrue(BeanPopulator.getNamedInstance(ObjectStoreEnvironmentBean.class, "communicationStore").isObjectStoreSync());
+    }
+
+    @Test
+    public void testNodeIdentifier() throws CoreEnvironmentBeanException {
+        CoreEnvironmentBean config = BeanPopulator.getDefaultInstance(CoreEnvironmentBean.class);
+        String random = UUID.randomUUID().toString(); // String form of a random UUID
+
+        assertEquals(36, random.length()); // a UUID consists of 32 hex digits along with 4 “-” symbols
+
+        config.setNodeIdentifier(random);//random.getBytes());
+        byte[] bytes = config.getNodeIdentifierBytes();
+        String name1 = config.getNodeIdentifier();
+        String name2 = new String(bytes);
+
+        assertEquals(name1, name2);
+        assertEquals(name1, random);
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3883

CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle

This PR follows up on #2259 and adds more input validation and javadoc to CoreEnvironmentBean#setNodeIdentifier(byte[] nodeIdentifierBytes). It also adds an extra test for the new config setting (see ArjPropertyManagerTest.java).