### PR TITLE
[JBTM-3890] Building Narayana 6.0.2.Final with Java SE 21 fails (jandex plugin version problem)

### DIFF
--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/ServiceRegistrySecurityManagerTest.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/ServiceRegistrySecurityManagerTest.java
@@ -21,44 +21,69 @@
  */
 package com.arjuna.wsc.tests.local;
 
-import com.arjuna.webservices11.ServiceRegistry;
+import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.arjuna.webservices11.ServiceRegistry;
+
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ *
+ *         Remove this unit test class once JDK21 is the minimum JDK
+ *
+ *         JDK21 throws UnsupportedOperationException when
+ *         System.setSecurityManager is called, see https://openjdk.org/jeps/411
  */
 public class ServiceRegistrySecurityManagerTest {
 
     private static final String SERVICE_REGISTRY_PERMISSION_NAME = ServiceRegistry.class.getName() + ".getRegistry";
-
+    private final Logger logger = Logger.getLogger(ServiceRegistrySecurityManagerTest.class);
+    @SuppressWarnings("removal")
     private SecurityManager oldSecurityManager;
-
+    @SuppressWarnings("removal")
     @Before
     public void before() {
         oldSecurityManager = System.getSecurityManager();
     }
 
+    @SuppressWarnings("removal")
     @After
     public void after() {
-        System.setSecurityManager(oldSecurityManager);
+        try {
+            System.setSecurityManager(oldSecurityManager);
+        }
+        catch (UnsupportedOperationException e) {
+            logger.warn("setting the SecurityManager is no longer supported", e);
+        }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testWithoutSecurityManager() {
-        System.setSecurityManager(null);
-        Assert.assertNotNull(ServiceRegistry.getRegistry());
+        try {
+            System.setSecurityManager(null);
+            Assert.assertNotNull(ServiceRegistry.getRegistry());
+        }
+        catch (UnsupportedOperationException e) {
+            logger.warn("setting the SecurityManager is no longer supported", e);
+        }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testWithSecurityManager() {
-        final SinglePermissionSecurityManager testSecurityManager = new SinglePermissionSecurityManager(SERVICE_REGISTRY_PERMISSION_NAME);
-        System.setSecurityManager(testSecurityManager);
-
-        Assert.assertNotNull(ServiceRegistry.getRegistry());
-        Assert.assertTrue(testSecurityManager.wasCalled());
+        final SinglePermissionSecurityManager testSecurityManager = new SinglePermissionSecurityManager(
+                SERVICE_REGISTRY_PERMISSION_NAME);
+        try {
+            System.setSecurityManager(testSecurityManager);
+            Assert.assertNotNull(ServiceRegistry.getRegistry());
+            Assert.assertTrue(testSecurityManager.wasCalled());
+        }
+        catch (UnsupportedOperationException e) {
+            logger.warn("setting the SecurityManager is no longer supported", e);
+        }
     }
-
 }

--- a/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/SinglePermissionSecurityManager.java
+++ b/XTS/localjunit/unit/src/test/java/com/arjuna/wsc/tests/local/SinglePermissionSecurityManager.java
@@ -26,6 +26,7 @@ import java.security.Permission;
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
+@SuppressWarnings("removal")
 public final class SinglePermissionSecurityManager extends SecurityManager {
 
     private final String permissionName;

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
     <version.org.jboss.arquillian.container.weld>3.0.2.Final</version.org.jboss.arquillian.container.weld>
     <version.org.jboss.arquillian.core>1.7.0.Alpha12</version.org.jboss.arquillian.core>
     <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
-    <version.org.jboss.byteman>4.0.19</version.org.jboss.byteman>
+    <version.org.jboss.byteman>4.0.22</version.org.jboss.byteman>
     <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
     <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
     <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <version.maven-failsafe-plugin>3.0.0-M7</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>3.0.0-M7</version.maven-surefire-plugin>
     <version.maven.checkstyle-plugin>3.1.2</version.maven.checkstyle-plugin>
-    <version.maven.jandex-plugin>3.0.5</version.maven.jandex-plugin>
+    <version.maven.jandex-plugin>3.0.8</version.maven.jandex-plugin>
     <version.microprofile.config-api>3.0.2</version.microprofile.config-api>
     <version.microprofile.fault-tolerance>4.0.2</version.microprofile.fault-tolerance>
     <version.microprofile.lra>2.0</version.microprofile.lra>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
 
     <version.ant-contrib>1.0b3</version.ant-contrib>
     <version.arquillian.byteman>1.1.0</version.arquillian.byteman>
-    <version.com.github.spotbugs.spotbugs-maven-plugin>4.5.3.0</version.com.github.spotbugs.spotbugs-maven-plugin>
+    <version.com.github.spotbugs.spotbugs-maven-plugin>4.8.3.1</version.com.github.spotbugs.spotbugs-maven-plugin>
     <version.com.h2database>1.4.195</version.com.h2database>
     <version.com.ibm>db2jcc4</version.com.ibm>
     <version.com.microsoft.sqlserver>mssql2005_sqljdbc_2.0</version.com.microsoft.sqlserver>

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -23,13 +23,8 @@ function which_java {
   fi
 
   if [[ "$_java" ]]; then
-    version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-
-    if [[ $version = 17* ]]; then
-      echo 17
-    elif [[ $version = 11* ]]; then
-      echo 11
-    fi
+    version=$("$_java" -version 2>&1 | grep -oP 'version "?(1\.)?\K\d+' || true)
+    echo $version
   fi
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3890

see comment about 3.0.8 version which backported fix https://issues.redhat.com/browse/JBEAP-27293?focusedId=25042672&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-25042672
 
CORE AS_TESTS RTS JACOCO XTS QA_JTA QA_JTS_OPENJDKORB PERFORMANCE LRA DB_TESTS mysql db2 postgres oracle
JDK21
