### PR TITLE
[JBTM-3905]  (6.0.) Declare no-arg constructor to TMApplication

### DIFF
--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/resource/RESTRecord.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/resource/RESTRecord.java
@@ -150,8 +150,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
     private void check_suspend(Fault f) {
         if (fault.equals(f))
         {
-            try
-            {
+            try {
                 log.infof("%s: for 10 seconds", f);
                 Thread.sleep(10000);
             } catch (InterruptedException e) {
@@ -212,8 +211,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
         if (prepareURI == null || txId == null)
             return TwoPhaseOutcome.PREPARE_READONLY;
 
-        try
-        {
+        try {
             String body = new TxSupport().httpRequest(new int[] {HttpURLConnection.HTTP_OK}, this.prepareURI, "PUT",
                     TxMediaType.TX_STATUS_MEDIA_TYPE, TxSupport.toStatusContent(TxStatus.TransactionPrepared.name()));
 
@@ -308,8 +306,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
         String commitUri = (nextState == TxStatus.TransactionCommittedOnePhase && this.commitOnePhaseURI != null)
             ? this.commitOnePhaseURI : this.commitURI;
 
-        try
-        {
+        try {
             if (log.isTraceEnabled())
                 log.tracef("committing %s", commitUri);
 
@@ -374,8 +371,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
                     return false;
                 }
 
-                try
-                {
+                try {
                     TxSupport.getStatus(new TxSupport().httpRequest(new int[] {HttpURLConnection.HTTP_OK},
                             uri, "PUT", TxMediaType.TX_STATUS_MEDIA_TYPE,
                             TxSupport.toStatusContent(nextState.name())));
@@ -407,8 +403,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
      * @return true if the participant did move
      */
     private boolean hasParticipantMoved() {
-        try
-        {
+        try {
             if (log.isTraceEnabled())
                 log.tracef("seeing if participant has moved: %s  recoveryURI: %s", coordinatorID, recoveryURI);
 
@@ -476,8 +471,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
     }
 
     public boolean save_state(OutputObjectState os, int t) {
-        try
-        {
+        try {
             os.packString(txId);
             os.packBoolean(prepared);
             os.packString(participantURI);
@@ -501,8 +495,7 @@ public class RESTRecord extends AbstractRecord implements Comparable {
     }
 
     public boolean restore_state(InputObjectState os, int t) {
-        try
-        {
+        try {
             txId = os.unpackString();
             prepared = os.unpackBoolean();
             participantURI = os.unpackString();

--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
@@ -47,6 +47,16 @@ public class TMApplication extends Application {
     Set<Class<?>> classes = new HashSet<Class<?>> ();
 
     public TMApplication(Class<?> ... extraClasses) {
+        this();
+        
+        try
+        {
+            Collections.addAll(classes, extraClasses);
+        } catch (Throwable e) {
+          RESTATLogger.atI18NLogger.warn_jaxrsTM(e.getMessage(), e);
+        }
+    }
+    public TMApplication() {
 //        singletons.addAll(Arrays.asList(resources));
         try
         {
@@ -68,7 +78,6 @@ public class TMApplication extends Application {
 
             Collections.addAll(classes, resourceClasses);
             Collections.addAll(classes, mappers);
-            Collections.addAll(classes, extraClasses);
         } catch (Throwable e) {
           RESTATLogger.atI18NLogger.warn_jaxrsTM(e.getMessage(), e);
         }

--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
@@ -48,9 +48,8 @@ public class TMApplication extends Application {
 
     public TMApplication(Class<?> ... extraClasses) {
         this();
-        
-        try
-        {
+
+        try {
             Collections.addAll(classes, extraClasses);
         } catch (Throwable e) {
           RESTATLogger.atI18NLogger.warn_jaxrsTM(e.getMessage(), e);
@@ -58,8 +57,7 @@ public class TMApplication extends Application {
     }
     public TMApplication() {
 //        singletons.addAll(Arrays.asList(resources));
-        try
-        {
+        try {
             // TODO move com/arjuna/ats/jbossatx/jt[as]/TransactionManagerService.isRecoveryManagerRunning
             // to RecoveryManager and change logging
             // by default do not colocate the coordinator and recovery manager


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3905

backporting commit from main branch:
' Jakarta ee cdi specification bean constructors:
If a bean class does not explicitly declare a constructor using @Inject,
the constructor that accepts
no parameters is the bean constructor'

NOTE: this PR would fix failure shown in quickstart build (https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/btny-pulls-narayana-quickstart-60/4/console), see log https://ci-jenkins-csb-narayana.apps.ocp-c1.prod.psi.redhat.com/job/btny-pulls-narayana-quickstart-60/4/artifact/rts/at/jta-service/jpa/target/surefire-reports/org.jboss.narayana.quickstart.rest.bridge.inbound.jpa.test.TaskResourceTest-output.txt