### PR TITLE
[JBTM-3883] 'use a base64 encoder if required' fix

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/common/CoreEnvironmentBean.java
@@ -146,22 +146,22 @@ public class CoreEnvironmentBean implements CoreEnvironmentBeanMBean
         }
 
         if (nodeIdentifierBytes.length > TxControl.NODE_NAME_SIZE) {
-            tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier, TxControl.NODE_NAME_SIZE);
+            tsLogger.i18NLogger.fatal_nodename_too_long(nodeIdentifier, nodeIdentifierBytes.length);
             throw new CoreEnvironmentBeanException(tsLogger.i18NLogger.
-                    get_fatal_nodename_too_long(nodeIdentifier, TxControl.NODE_NAME_SIZE));
+                    get_fatal_nodename_too_long(nodeIdentifier, nodeIdentifierBytes.length));
         }
 
         String newName = new String(nodeIdentifierBytes, StandardCharsets.UTF_8);
 
-        if (newName.getBytes(StandardCharsets.UTF_8).length > NODE_NAME_SIZE)
+        if (newName.length() > NODE_NAME_SIZE)
         {
             //Encode the byte array in Base64
             //encoding the array might result in a longer array
             byte[] base64Result = Base64.getEncoder().encode(nodeIdentifierBytes);
             //truncate the array
-            byte[] slice = Arrays.copyOfRange(base64Result, 0, 28);
+            nodeIdentifierBytes = Arrays.copyOfRange(base64Result, 0, 28);
 
-            newName = new String(slice, StandardCharsets.UTF_8);
+            newName = new String(nodeIdentifierBytes, StandardCharsets.UTF_8);
 
             tsLogger.i18NLogger.warn_nodename_shortened(newName, NODE_NAME_SIZE);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3883

Update the nodeIdentifierBytes with the trimmed one when needed
Log the proper length of the bytes when error occurs
Check that the string is shorter than NODE_NAME_SIZE (not the bytes length)
! don't confuse TxControl.NODE_NAME_SIZE (which is 28) with NODE_NAME_SIZE (which is 64)

CORE !AS_TESTS !RTS! JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 
