### PR TITLE
JBTM-3089 Report a reason for test failures

### DIFF
--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -442,7 +442,7 @@ public class LRATest {
         try {
             service.getLRA(lraId);
         } catch (NotFoundException e) {
-            fail("testReplay: LRA should still have been completing");
+            fail("testReplay: LRA should still have been completing: " + e.getMessage());
         }
 
         // the LRA should still be finishing (ie there should be a log record)

--- a/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/LRAAsyncIT.java
+++ b/rts/lra/test/basic/src/test/java/io/narayana/lra/arquillian/client/LRAAsyncIT.java
@@ -107,7 +107,7 @@ public class LRAAsyncIT extends TestBase {
 
         } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
-            fail("Error in testChainOfInvocations method");
+            fail("Error in testChainOfInvocations method: " + e.getMessage());
         }
     }
 
@@ -142,7 +142,7 @@ public class LRAAsyncIT extends TestBase {
 
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
-                fail("Error in testNoCurrent method");
+                fail("Error in testNoCurrent method: " + e.getMessage());
             }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3089

!CORE !AS_TESTS !RTS !JACOCO XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE LRA !DB_TESTS !mysql !db2 !postgres !oracle

Reports the exception reason for LRA test failures.