### PR TITLE
hacktoberfest Clarify code of conduct expectations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,29 @@ See the [README](README.md) file in the root directory of the repository.
 
 ## Before you contribute
 
+### Guidelines
+
+We follow [Open source participation guidelines](https://www.redhat.com/en/resources/open-source-participation-guidelines-overview).
+
+We expect all contributors and users to follow our [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) when communicating through project channels. These include, but are not limited to: chat, issues, code.
+
+#### Coding Guidelines
+
+We use the maven `checkstyle` and `sortpom` plugins which are enabled by default and skipped in certain cases for older modules.
+
+For older modules where checkstyle is disabled, when editing a file you should either
+a) follow the style currently used in the file you have edited or,
+b) reformat it according to our checkstyle ruleset (by temporarily enabling checkstyle
+on the affected module) but separate functional changes from formatting changes into different commits
+in the same PR (this rule facilitates traceability).
+In other words a file (in a module with checkstyle disabled) may only be re-formatted if it also
+contains a functional change and is made in a separate commit.
+
+Most IDEs allow you to configure a rule file from your IDE settings (for Intelij that would be Settings -> Other Settings -> Checkstyle). The rule file is located the [narayana-checkstyle repo](https://github.com/jbosstm/narayana-checkstyle-config/tree/main/src/main/resources/narayana-checkstyle)
+We do not use `@author` tags in the Javadoc in new code: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship, however GitHub provides [this nice page with your contributions](https://github.com/jbosstm/narayana/graphs/contributors).
+
+Commits should be atomic and semantic. Commits should be squashed before submitting the PR unless the commits are necessary to track different parts of a fix or to separate out formatting only changes from functional changes. Fixup commits can be used temporarily during the review process, to help the reviewer navigate your changeset, but these should be squashed before merging the PR (in order to provide the software with a more meaningful commit history).
+
 To contribute, use GitHub Pull Requests (PRs), from your **own** fork.
 
 When you create a PR, the description field of the PR will include brief instructions on what you need to include.
@@ -95,27 +118,6 @@ Before asking for a review it's best to wait for [Continuous Integration tests](
 Once a review has started both parties should attempt to respond to feedback in a timely manner.
 Do not approve the PR until you have either seen a successful CI test of the PR, or you can reasonably explain why a failure is unrelated to the code changes made in the PR (and documented in a PR comment).
 
-### Guidelines
-
-We follow [Open source participation guidelines](https://www.redhat.com/en/resources/open-source-participation-guidelines-overview)
-
-### Coding Guidelines
-
-We use the maven `checkstyle` and `sortpom` plugins which are enabled by default and skipped in certain cases for older modules.
-
-For older modules where checkstyle is disabled, when editing a file you should either
-a) follow the style currently used in the file you have edited or,
-b) reformat it according to our checkstyle ruleset (by temporarily enabling checkstyle
-on the affected module) but separate functional changes from formatting changes into different commits
-in the same PR (this rule facilitates traceability).
-In other words a file (in a module with checkstyle disabled) may only be re-formatted if it also
-contains a functional change and is made in a separate commit.
-
-Most IDEs allow you to configure a rule file from your IDE settings (for Intelij that would be Settings -> Other Settings -> Checkstyle). The rule file is located the [narayana-checkstyle repo](https://github.com/jbosstm/narayana-checkstyle-config/tree/main/src/main/resources/narayana-checkstyle)
-We do not use `@author` tags in the Javadoc in new code: they are hard to maintain, especially in a very active project, and we use the Git history to track authorship, however GitHub provides [this nice page with your contributions](https://github.com/jbosstm/narayana/graphs/contributors).
-
-Commits should be atomic and semantic. Commits should be squashed before submitting the PR unless the commits are necessary to track different parts of a fix or to separate out formatting only changes from functional changes. Fixup commits can be used temporarily during the review process, to help the reviewer navigate your changeset, but these should be squashed before merging the PR (in order to provide the software with a more meaningful commit history).
-
 ### Continuous Integration
 
 To ensure Narayana is stable for everyone, all changes should go through Narayana continuous integration: when you raise a pull request one of the members of the team will schedule a CI run to test your PR.
@@ -143,4 +145,4 @@ When the github Pull Request has passed all relevant CI checks and has been Appr
 
 ## Release
 
-The Narayana project applies the [Semantic Versioning Specification](https://semver.org/) (SemVer) 2.0.0 to mark its releases
+The Narayana project applies the [Semantic Versioning Specification](https://semver.org/) (SemVer) 2.0.0 to mark its releases.


### PR DESCRIPTION
Whilst reviewing our contributor guidelines I noticed that the guidelines should be more prominent so I have moved them (I didn't change the existing text) into the first paragraph of the "Before you contribute" section.

I also explicitly drew out out/added our code of conduct expectations using the text:

```
We expect all contributors and users to follow our [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/) when communicating through project channels. These include, but are not limited to: chat, issues, code.
```

!CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS !mysql !db2 !postgres !oracle

Pull requests build and run with JDK11 and JDK17. Add the prefix `!` to disable these defaults. Include the text `JDK21` to build and run with JDK21

If it is determined that nothing needs to be tested for the pull request then you need to concatenate the two sets of characters: `NO_` `TEST` as a single word and provide the result into the description.

Please be aware that none of this configuration affects which GitHub Actions will run.
