### PR TITLE
JBTM-3929 Participant failover support

### DIFF
--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/Coordinator.java
@@ -641,7 +641,7 @@ public class Coordinator extends Application {
         }
 
         StringBuilder recoveryUrl = new StringBuilder();
-        int status = lraService.joinLRA(recoveryUrl, lraId, timeLimit, null, linkHeader, recoveryUrlBase, userData);
+        int status = lraService.joinLRA(recoveryUrl, lraId, timeLimit, null, linkHeader, recoveryUrlBase, userData, version);
 
         try {
             return Response.status(status)

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/api/RecoveryCoordinator.java
@@ -41,9 +41,6 @@ import static jakarta.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 
 @Tag(name = "LRA Recovery")
 public class RecoveryCoordinator {
-    @Context
-    private UriInfo context;
-
     private final LRAService lraService;
 
     public RecoveryCoordinator() {
@@ -67,9 +64,11 @@ public class RecoveryCoordinator {
             @Parameter(name = "RecCoordId",
                 description = "An identifier that was returned by the coordinator when a participant joined the LRA",
                 required = true)
-            @PathParam("RecCoordId") String rcvCoordId) throws NotFoundException {
+            @PathParam("RecCoordId") String rcvCoordId,
+            @Context UriInfo uriInfo) throws NotFoundException {
 
-        String compensatorUrl = lraService.getParticipant(rcvCoordId);
+        String context = uriInfo.getRequestUri().toASCIIString();
+        String compensatorUrl = lraService.getParticipant(context);
 
         if (compensatorUrl == null) {
             String errorMsg = LRALogger.i18nLogger.warn_cannotFoundCompensatorUrl(rcvCoordId, lraId);
@@ -102,8 +101,10 @@ public class RecoveryCoordinator {
                 description = "An identifier that was returned by the coordinator when a participant joined the LRA",
                 required = true)
             @PathParam("RecCoordId") String rcvCoordId,
+            @Context UriInfo uriInfo,
             String newCompensatorUrl) throws NotFoundException {
-        String compensatorUrl = lraService.getParticipant(rcvCoordId);
+        String context = uriInfo.getRequestUri().toASCIIString();
+        String compensatorUrl = lraService.getParticipant(context);
 
         if (compensatorUrl != null) {
             URI lra;
@@ -117,9 +118,9 @@ public class RecoveryCoordinator {
                         Response.status(INTERNAL_SERVER_ERROR.getStatusCode()).entity(errMsg).build());
             }
 
-            lraService.updateRecoveryURI(lra, newCompensatorUrl, rcvCoordId, true);
+            lraService.updateRecoveryURI(lra, newCompensatorUrl, context, true);
 
-            return context.getRequestUri().toASCIIString();
+            return context;
         }
 
         String errorMsg = LRALogger.i18nLogger.warn_cannotFoundCompensatorUrl(rcvCoordId, lraId);

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LRAParticipantRecord.java
@@ -1014,21 +1014,35 @@ public class LRAParticipantRecord extends AbstractRecord implements Comparable<A
         return participantPath;
     }
 
-    void setRecoveryURI(String recoveryURI) {
-        try {
-            this.recoveryURI = new URI(recoveryURI);
-        } catch (URISyntaxException e) {
-            String errorMsg = LRALogger.i18nLogger.error_invalidRecoveryUrlToJoinLRAURI(recoveryURI, lraId);
+    // the participant is asking to be called back on different URLs
+    void updateCallbacks(String linkStr) {
+        Exception e = parseLink(linkStr);
 
-            LRALogger.logger.info(errorMsg);
+        if (e != null) {
+            String errorMsg = LRALogger.i18nLogger.warn_invalid_compensator(e.getMessage(), linkStr);
 
             throw new WebApplicationException(errorMsg, e,
                     Response.status(BAD_REQUEST).entity(errorMsg).build());
         }
     }
 
-    void setRecoveryURI(String recoveryUrlBase, String txId, String coordinatorId) {
-        setRecoveryURI(recoveryUrlBase + txId + '/' + coordinatorId);
+    void setRecoveryURI(String recoveryURI) {
+        try {
+            this.recoveryURI = new URI(recoveryURI);
+        } catch (URISyntaxException e) {
+            String errorMsg = LRALogger.i18nLogger.error_invalidRecoveryUrlToJoinLRAURI(recoveryURI, lraId);
+
+            if (LRALogger.logger.isDebugEnabled()) {
+                LRALogger.logger.debugf(errorMsg);
+            }
+
+            throw new WebApplicationException(errorMsg, e,
+                    Response.status(BAD_REQUEST).entity(errorMsg).build());
+        }
+    }
+
+    void setRecoveryURI(String recoveryUrlBase, String txId, String participantId) {
+        setRecoveryURI(String.format("%s/%s/%s", recoveryUrlBase, txId, participantId));
     }
 
     public String getCompensator() {

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/service/LRAService.java
@@ -327,10 +327,15 @@ public class LRAService {
                     .entity(errorMsg).build());
         }
     }
-
     public int joinLRA(StringBuilder recoveryUrl, URI lra, long timeLimit,
                                     String compensatorUrl, String linkHeader, String recoveryUrlBase,
                                     StringBuilder compensatorData) {
+        return joinLRA(recoveryUrl, lra,timeLimit,  compensatorUrl, linkHeader, recoveryUrlBase, compensatorData, null);
+    }
+
+    public int joinLRA(StringBuilder recoveryUrl, URI lra, long timeLimit,
+                                    String compensatorUrl, String linkHeader, String recoveryUrlBase,
+                                    StringBuilder compensatorData, String version) {
         if (lra ==  null) {
             lraTrace(null, "Error missing LRA header in join request");
         } else {
@@ -374,7 +379,7 @@ public class LRAService {
             if (compensatorData != null) {
                 participant = transaction.enlistParticipant(lra,
                         linkHeader != null ? linkHeader : compensatorUrl, recoveryUrlBase,
-                        timeLimit, compensatorData.toString());
+                        timeLimit, compensatorData.toString(), version);
                 // return any previously registered data
                 compensatorData.setLength(0);
 
@@ -384,7 +389,7 @@ public class LRAService {
             } else {
                 participant = transaction.enlistParticipant(lra,
                         linkHeader != null ? linkHeader : compensatorUrl, recoveryUrlBase,
-                        timeLimit, null);
+                        timeLimit, null, version);
             }
         } catch (UnsupportedEncodingException e) {
             return Response.Status.PRECONDITION_FAILED.getStatusCode();

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/tools/osb/mbean/ObjStoreBrowserLRATest.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/tools/osb/mbean/ObjStoreBrowserLRATest.java
@@ -98,7 +98,7 @@ public class ObjStoreBrowserLRATest {
             String coordinatorUrl = "http://localhost:8080/lra-coordinator";
             String participantUrl = "http://localhost:8080/lra-participant";
             LRAParticipantRecord lraParticipant = lra.enlistParticipant(URI.create(coordinatorUrl), participantUrl,
-                    "/recover", Long.MAX_VALUE, null);
+                    "/recover", Long.MAX_VALUE, null, null);
 
             osb.probe();
 

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/LRAConstants.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/LRAConstants.java
@@ -31,6 +31,7 @@ public final class LRAConstants {
 
     public static final String API_VERSION_1_0 = "1.0";
     public static final String API_VERSION_1_1 = "1.1";
+    public static final String API_VERSION_1_2 = "1.2";
 
     /*
      * Supported Narayana LRA API versions.
@@ -41,14 +42,15 @@ public final class LRAConstants {
      */
     public static final String[] NARAYANA_LRA_API_SUPPORTED_VERSIONS = new String[] {
             API_VERSION_1_0,
-            API_VERSION_1_1
+            API_VERSION_1_1,
+            API_VERSION_1_2
     };
 
     /**
      * The Narayana API version for LRA coordinator supported for the release.
      * Any higher version is considered as unimplemented and unknown.
      */
-    public static final String CURRENT_API_VERSION_STRING = API_VERSION_1_1;
+    public static final String CURRENT_API_VERSION_STRING = API_VERSION_1_2;
 
     public static final String NARAYANA_LRA_API_VERSION_HEADER_NAME = "Narayana-LRA-API-version";
 

--- a/rts/lra/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
+++ b/rts/lra/service-base/src/main/java/io/narayana/lra/logging/LraI18nLogger.java
@@ -168,6 +168,10 @@ public interface LraI18nLogger {
     @LogMessage(level = WARN)
     @Message(id = 25040, value = "Lock not acquired, enlistment failed: cannot enlist participant, cannot lock transaction")
     void warn_enlistment();
+
+    @Message(id = 25041, value = "Participant provided invalid callback endpoints, reason: %s link: %s")
+    String warn_invalid_compensator(String reason, String linkStr);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3929

This PR fixes a problem with the recovery url associated with each participant that participates in an LRA

!CORE !AS_TESTS !RTS! JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE LRA !DB_TESTS !mysql !db2 !postgres oracle
