### PR TITLE
JBTM-3932 Ensure that when a resource throws XAException.XA_RBTRANSIE…

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
@@ -276,7 +276,7 @@ public class XAResourceRecord extends AbstractRecord implements ExceptionDeferre
                     addDeferredThrowable(e1);
 
                     if ((e1.errorCode >= XAException.XA_RBBASE)
-                            && (e1.errorCode < XAException.XA_RBEND)) {
+                            && (e1.errorCode <= XAException.XA_RBEND)) {
                         /*
                          * Has been marked as rollback-only. If the branch has not been
                          * already rolled back (i.e. _rolledBack == false), we still need

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/resources/jts/orbspecific/XAResourceRecord.java
@@ -308,7 +308,7 @@ public class XAResourceRecord extends com.arjuna.ArjunaOTS.OTSAbstractRecordPOA 
                     }
                 } catch (XAException e1) {
                     if ((e1.errorCode >= XAException.XA_RBBASE)
-                            && (e1.errorCode < XAException.XA_RBEND)) {
+                            && (e1.errorCode <= XAException.XA_RBEND)) {
                         /*
                          * Has been marked as rollback-only. If the branch has not been
                          * already rolled back (i.e. _rolledBack == true ), we still need


### PR DESCRIPTION
CORE AS_TESTS !RTS !JACOCO !XTS QA_JTA QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS mysql db2 postgres oracle

!JDK11