### PR TITLE
Migrate the Deprecated forkMode Parameter to forkCount and reuseForks and JBTM-3939 Update nexus-staging-maven-plugin to 1.7.0

### DIFF
--- a/ArjunaJTA/jdbc/pom.xml
+++ b/ArjunaJTA/jdbc/pom.xml
@@ -135,7 +135,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <argLine>${surefireArgLine}</argLine>
-            <forkMode>pertest</forkMode>
+            <forkCount>1</forkCount>
+            <reuseForks>false</reuseForks>
             <workingDirectory>target/test-classes</workingDirectory>
             <runOrder>alphabetical</runOrder>
             <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>

--- a/XTS/localjunit/pom.xml
+++ b/XTS/localjunit/pom.xml
@@ -170,7 +170,8 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <forkMode>once</forkMode>
+              <forkCount>1</forkCount>
+              <reuseForks>true</reuseForks>
               <systemPropertyVariables combine.children="append">
                 <!--
                                   Used in arquillian.xml
@@ -201,7 +202,8 @@
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <forkMode>once</forkMode>
+              <forkCount>1</forkCount>
+              <reuseForks>true</reuseForks>
               <workingDirectory>.</workingDirectory>
               <systemPropertyVariables combine.children="append">
                 <!--
@@ -234,7 +236,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>${ipv6.server.jvm.args}</argLine>
-              <forkMode>once</forkMode>
+              <forkCount>1</forkCount>
+              <reuseForks>true</reuseForks>
               <workingDirectory>.</workingDirectory>
               <systemPropertyVariables combine.children="append">
                 <!--

--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,8 @@
           <version>${version.maven-surefire-plugin}</version>
           <configuration>
             <argLine>${surefireArgLine}</argLine>
-            <forkMode>pertest</forkMode>
+            <forkCount>1</forkCount>
+            <reuseForks>false</reuseForks>
             <workingDirectory>target/test-classes</workingDirectory>
             <runOrder>alphabetical</runOrder>
             <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
@@ -504,7 +505,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration combine.self="append">
-          <forkMode>pertest</forkMode>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
           <childDelegation>true</childDelegation>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <argLine>-Djdk.attach.allowAttachSelf=true ${jvm.args.modular}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <version.org.jboss.as.plugins.jboss-as-maven-plugin>7.4.Final</version.org.jboss.as.plugins.jboss-as-maven-plugin>
     <!-- Needed forWildflyLRACoordinatorDeployment class -->
     <version.org.jboss.resteasy>6.2.5.Final</version.org.jboss.resteasy>
-    <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.13</version.org.sonatype.plugins.nexus-staging-maven-plugin>
+    <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.7.0</version.org.sonatype.plugins.nexus-staging-maven-plugin>
     <version.quarkus-bom>3.0.1.Final</version.quarkus-bom>
     <version.quarkus-maven-plugin>3.0.1.Final</version.quarkus-maven-plugin>
     <version.sortpom>3.0.0</version.sortpom>

--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -209,7 +209,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkMode>pertest</forkMode>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
           <!--
                   <argLine>${surefireArgLine}</argLine>
                   -->

--- a/rts/at/webservice/pom.xml
+++ b/rts/at/webservice/pom.xml
@@ -102,7 +102,8 @@
           <includes>
             <include>**/*UnitTest.java</include>
           </includes>
-          <forkMode>always</forkMode>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
       <plugin>
@@ -184,7 +185,8 @@
                   <includes>
                     <include>**/*IntegrationTest.java</include>
                   </includes>
-                  <forkMode>always</forkMode>
+                  <forkCount>1</forkCount>
+                  <reuseForks>false</reuseForks>
                   <skip>false</skip>
                 </configuration>
               </execution>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3939

[Migrating the Deprecated forkMode Parameter to forkCount and reuseForks](https://github.com/jbosstm/narayana/commit/c462467b523add7ffe7200e478df02f56a959aed) as per https://maven.apache.org/surefire-archives/surefire-2.20.1/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html

Upgrade nexus-stagin-maven-plugin to 1.7.0

CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 