### PR TITLE
JBTM-3940 NarayanaLRAClient is an internal class so does not need to …

### DIFF
--- a/rts/lra/client/src/main/java/io/narayana/lra/client/internal/NarayanaLRAClient.java
+++ b/rts/lra/client/src/main/java/io/narayana/lra/client/internal/NarayanaLRAClient.java
@@ -90,7 +90,6 @@ import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVER
  * A utility class for controlling the lifecycle of Long Running Actions (LRAs) but the preferred mechanism is to use
  * the annotation in the {@link org.eclipse.microprofile.lra.annotation} package
  */
-@Deprecated
 @RequestScoped
 public class NarayanaLRAClient implements Closeable {
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3940

When I moved the client API into an internal package (JBTM-3934) I forgot to remove the @Deprecated annotation. This PR rectifies that oversight.

NO_TEST