### PR TITLE
Quarkus dependency removal

### DIFF
--- a/narayana-bom-test/pom.xml
+++ b/narayana-bom-test/pom.xml
@@ -55,7 +55,6 @@
     <version.org.wildfly.core>20.0.0.Final</version.org.wildfly.core>
     <version.org.wildfly.extras.creaper>2.0.2</version.org.wildfly.extras.creaper>
     <version.postgresql>42.7.2</version.postgresql>
-    <version.quarkus>3.2.6.Final</version.quarkus>
     <version.squareup.okhttp>1.5.4</version.squareup.okhttp>
   </properties>
 
@@ -439,19 +438,6 @@
         <version>${version.org.wildfly.core}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-resteasy</artifactId>
-        <version>${version.quarkus}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jboss.threads</groupId>
-            <artifactId>jboss-threads</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
   <build>

--- a/rts/at/tx/pom.xml
+++ b/rts/at/tx/pom.xml
@@ -153,11 +153,6 @@
       <artifactId>jakarta.transaction-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- Quarkus -->
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/service/TMApplication.java
@@ -9,8 +9,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import jakarta.ws.rs.core.Application;
-
 import org.jboss.jbossts.star.logging.RESTATLogger;
 import org.jboss.jbossts.star.provider.HttpResponseMapper;
 import org.jboss.jbossts.star.provider.NotFoundMapper;
@@ -25,6 +23,10 @@ import com.arjuna.ats.arjuna.coordinator.abstractrecord.RecordTypeManager;
 import com.arjuna.ats.arjuna.coordinator.abstractrecord.RecordTypeMap;
 import com.arjuna.ats.arjuna.recovery.RecoveryManager;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationScoped
 public class TMApplication extends Application {
     private static final Logger log = Logger.getLogger(TMApplication.class);
 

--- a/rts/at/tx/src/test/java/org/jboss/jbossts/star/test/BaseTest.java
+++ b/rts/at/tx/src/test/java/org/jboss/jbossts/star/test/BaseTest.java
@@ -13,7 +13,6 @@ import com.arjuna.ats.arjuna.state.InputObjectState;
 import com.arjuna.ats.internal.arjuna.common.UidHelper;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.AtomicAction;
 import com.squareup.okhttp.OkHttpClient;
-import io.quarkus.runtime.QuarkusApplication;
 import io.undertow.Undertow;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -67,8 +66,7 @@ public class BaseTest {
 
     protected static final ExecutorService executor = Executors.newFixedThreadPool(4);
     protected static boolean USE_NETTY = false;
-    protected static boolean USE_UNDERTOW = false;
-    protected static boolean USE_QUARKUS = true;
+    protected static boolean USE_UNDERTOW = true;
 // jarkarta TODO jersey    private static HttpServer grizzlyServer;
     protected static final String USE_SPDY_PROP = "rts.usespdy";
     protected static final String USE_SSL_PROP = "rts.usessl";
@@ -86,8 +84,6 @@ public class BaseTest {
     private static NettyJaxrsServer netty = null;
 // jakarta TODO    private static SelectorThread threadSelector = null;
     private static UndertowJaxrsServer undertow;
-    private static Undertow quarkusUndertow;
-
     protected static void setTxnMgrUrl(String txnMgrUrl) {
         TXN_MGR_URL = txnMgrUrl;
     }
@@ -101,22 +97,6 @@ public class BaseTest {
 
         System.out.printf("server is ready:");
 
-    }
-
-    protected static void startQuarkusApplication(Class<?> ... classes) throws Exception {
-
-    QuarkusApplication quarkusApplication = new QuarkusApplication() {
-            @Override
-            public int run(String... args) {
-                UndertowJaxrsServer server = new UndertowJaxrsServer();
-                // create a deployment object and add our REST endpoint class to it
-                server.start(Undertow.builder().addHttpListener(PORT, "localhost"));
-                server.deploy(new TMApplication(classes));//, SURL + "tx/");
-                System.out.printf("server started");
-                return 0;
-            }
-        };
-        quarkusApplication.run();
     }
 
     protected static void startRestEasy(Class<?> ... classes) throws Exception {
@@ -186,8 +166,6 @@ public class BaseTest {
             startRestEasy(classes);
         if (USE_UNDERTOW)
             startUndertow(classes);
-        else if (USE_QUARKUS)
-            startQuarkusApplication(classes);
         else
             throw new RuntimeException("Grizzly app server not supported with jakarta");
 //            startJersey(packages);
@@ -356,7 +334,6 @@ public class BaseTest {
     private static class Work {
         String id;
         String tid;
-        String uri;
         String pLinks;
         String enlistUrl;
         String recoveryUrl;
@@ -374,7 +351,6 @@ public class BaseTest {
         Work(String id, String tid, String uri, String pLinks, String enlistUrl, String recoveryUrl, String fault) {
             this.id = id;
             this.tid = tid;
-            this.uri = uri;
             this.pLinks = pLinks;
             this.enlistUrl = enlistUrl;
             this.recoveryUrl = recoveryUrl;


### PR DESCRIPTION
Starting from quarkus 3.7 the minimum JDK version is 17.
Because the narayana supports JDK 11 we need to decide if we want to create jdk maven profiles or remove quarkus dependency from Narayana codebase.
I would prefer to move quarkus dependencies in quickstart and use maven jdk profile there if needed.
 
CORE !AS_TESTS RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 

