### PR TITLE
JBTM-3331 Test for early timeouts during enlistment

### DIFF
--- a/rts/lra/coordinator/pom.xml
+++ b/rts/lra/coordinator/pom.xml
@@ -23,6 +23,26 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-install</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-submit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-bmunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.lra</groupId>
       <artifactId>microprofile-lra-api</artifactId>
     </dependency>

--- a/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
+++ b/rts/lra/coordinator/src/main/java/io/narayana/lra/coordinator/domain/model/LongRunningAction.java
@@ -415,6 +415,8 @@ public class LongRunningAction extends BasicAction {
 
     boolean isFinished() {
         switch (status) {
+            case Active:
+                return false; // this is not covered by the default arm of the switch if there are no participants
             case Closed:
                 /* FALLTHROUGH */
             case Cancelled:
@@ -807,6 +809,10 @@ public class LongRunningAction extends BasicAction {
         } else {
             // use the shiny new working method
             p.setRecoveryURI(recoveryUrlBase, this.get_uid().fileStringForm(), pid);
+        }
+
+        if (isInEndState()) {
+            return null;
         }
 
         if (add(p) != AddOutcome.AR_REJECTED) {

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/BytemanHelper.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/BytemanHelper.java
@@ -1,0 +1,22 @@
+package io.narayana.lra.coordinator.domain.model;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BytemanHelper {
+    static AtomicBoolean businessCalled = new AtomicBoolean(false);
+    public void rendezvousEnlistAbort() throws InterruptedException {
+        synchronized (businessCalled) {
+            businessCalled.set(true);
+            businessCalled.notifyAll();
+            businessCalled.wait();
+        }
+    }
+    public void rendezvousAbortEnlist() throws InterruptedException {
+        synchronized (businessCalled) {
+            while (!businessCalled.get()) {
+                businessCalled.wait();
+            }
+            businessCalled.notify();
+        }
+    }
+}

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/BytemanHelper.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/BytemanHelper.java
@@ -1,22 +1,13 @@
 package io.narayana.lra.coordinator.domain.model;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class BytemanHelper {
-    static AtomicBoolean businessCalled = new AtomicBoolean(false);
-    public void rendezvousEnlistAbort() throws InterruptedException {
-        synchronized (businessCalled) {
-            businessCalled.set(true);
-            businessCalled.notifyAll();
-            businessCalled.wait();
-        }
-    }
-    public void rendezvousAbortEnlist() throws InterruptedException {
-        synchronized (businessCalled) {
-            while (!businessCalled.get()) {
-                businessCalled.wait();
-            }
-            businessCalled.notify();
-        }
+    public void abortLRA(LongRunningAction lra) throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        Method method = lra.getClass().getDeclaredMethod("abortLRA");
+        method.setAccessible(true);
+        method.invoke(lra);
     }
 }

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -10,7 +10,13 @@ import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -1015,12 +1021,13 @@ public class LRATest extends LRATestBase {
 
     @Test
     @BMRules(rules={
-        @BMRule(name = "Rendezvous doEnlistParticipant", targetClass = "io.narayana.lra.coordinator.domain.model.LongRunningAction",
-                targetMethod = "enlistParticipant", targetLocation = "ENTRY", helper = "io.narayana.lra.coordinator.domain.model.BytemanHelper",
-                action = "rendezvousEnlistAbort();"),
-        @BMRule(name = "Rendezvous abortLRA", targetClass = "io.narayana.lra.coordinator.domain.model.LongRunningAction",
-                targetMethod = "abortLRA", targetLocation = "EXIT", helper = "io.narayana.lra.coordinator.domain.model.BytemanHelper",
-                action = "rendezvousAbortEnlist();")
+            // a rule to abort an LRA when a participant is being enlisted
+            @BMRule(name = "Rendezvous doEnlistParticipant",
+                    targetClass = "io.narayana.lra.coordinator.domain.model.LongRunningAction",
+                    targetMethod = "enlistParticipant",
+                    targetLocation = "ENTRY",
+                    helper = "io.narayana.lra.coordinator.domain.model.BytemanHelper",
+                    action = "abortLRA($0)")
     })
     public void testTimeoutWhileJoining() throws URISyntaxException {
         String target = TestPortProvider.generateURL("/base/test/timeout-while-joining");
@@ -1031,12 +1038,14 @@ public class LRATest extends LRATestBase {
                 .get()) {
             assertEquals("expected HTTP 410 Gone", 410, response.getStatus());
 
-            // assert that the method was not invoked
+            // assert that the business method was not invoked
+            // the filter should detect that enlisting with the failed and respond with message code 25025
             String methodResponse = response.readEntity(String.class);
 
-            assertNotEquals("business method should not have been called", "success", methodResponse);
+            assertNotEquals("business method should not have been called",
+                    TIMEOUT_BEFORE_JOIN_BUSINESS_DATA, methodResponse);
 
-            // TODO LRA025025 is the generic error code but can we get more specific
+            // LRA025025 is the generic error code but can we get more specific
             assertTrue("Expected LRA025025 but was " + methodResponse, methodResponse.startsWith("LRA025025"));
         }
 

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATest.java
@@ -10,12 +10,7 @@ import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -1010,6 +1005,28 @@ public class LRATest extends LRATestBase {
         assertEquals(compensations + 1, compensateCount.get());
         LRAStatus status = getStatus(new URI(lraId));
         assertTrue("LRA should have cancelled", status == null || status == LRAStatus.Cancelled);
+    }
+
+    @Test
+    public void testTimeoutWhileJoining() throws URISyntaxException {
+        String target = TestPortProvider.generateURL("/base/test/timeout-while-joining");
+        int compensations = compensateCount.get();
+
+        try (Response response = client.target(target)
+                .request()
+                .get()) {
+            assertEquals("expected HTTP 410 Gone", 410, response.getStatus());
+
+            // assert that the method was not invoked
+            String methodResponse = response.readEntity(String.class);
+
+            assertNotEquals("business method should not have been called", "success", methodResponse);
+
+            // TODO LRA025025 is the generic error code but can we get more specific
+            assertTrue("Expected LRA025025 but was " + methodResponse, methodResponse.startsWith("LRA025025"));
+        }
+
+        assertEquals("participant should not have been enlisted", compensations, compensateCount.get());
     }
 
     @Test

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATestBase.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATestBase.java
@@ -142,6 +142,19 @@ public class LRATestBase {
         }
 
         @GET
+        @Path("timeout-while-joining")
+        @Produces(MediaType.APPLICATION_JSON)
+        @LRA(value = LRA.Type.REQUIRED, timeLimit = 10, timeUnit = ChronoUnit.MILLIS)
+        public Response timeoutBeforeJoin(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                LRALogger.logger.debugf("Interrupted because time limit elapsed", e);
+            }
+            return Response.status(Response.Status.OK).entity("success").build();
+        }
+
+        @GET
         @Path("timed-action")
         @LRA(value = LRA.Type.REQUIRED, end = false, timeLimit = LRA_SHORT_TIMELIMIT) // the default unit is SECONDS
         public Response actionWithLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI contextId,

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATestBase.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATestBase.java
@@ -57,6 +57,7 @@ public class LRATestBase {
     static final long LRA_SHORT_TIMELIMIT = 10L;
     private static LRAStatus status = LRAStatus.Active;
     private static final AtomicInteger acceptCount = new AtomicInteger(0);
+    static final String TIMEOUT_BEFORE_JOIN_BUSINESS_DATA = "success";
 
     // count the number of times the AfterLRA notification was delivered.
     // Note that the default resource scope is @RequestScope so a new instance of the resource is created
@@ -143,10 +144,9 @@ public class LRATestBase {
 
         @GET
         @Path("timeout-while-joining")
-        @Produces(MediaType.APPLICATION_JSON)
         @LRA(value = LRA.Type.REQUIRED, timeLimit = 1000, timeUnit = ChronoUnit.MILLIS)
         public Response timeoutBeforeJoin(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
-            return Response.status(Response.Status.CONFLICT).entity("success").build();
+            return Response.status(Response.Status.OK).entity(TIMEOUT_BEFORE_JOIN_BUSINESS_DATA).build();
         }
 
         @GET

--- a/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATestBase.java
+++ b/rts/lra/coordinator/src/test/java/io/narayana/lra/coordinator/domain/model/LRATestBase.java
@@ -144,14 +144,9 @@ public class LRATestBase {
         @GET
         @Path("timeout-while-joining")
         @Produces(MediaType.APPLICATION_JSON)
-        @LRA(value = LRA.Type.REQUIRED, timeLimit = 10, timeUnit = ChronoUnit.MILLIS)
+        @LRA(value = LRA.Type.REQUIRED, timeLimit = 1000, timeUnit = ChronoUnit.MILLIS)
         public Response timeoutBeforeJoin(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                LRALogger.logger.debugf("Interrupted because time limit elapsed", e);
-            }
-            return Response.status(Response.Status.OK).entity("success").build();
+            return Response.status(Response.Status.CONFLICT).entity("success").build();
         }
 
         @GET


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3331 (Test for early timeouts during enlistment)

Includes three commits:

- one to add the test,
- a second one to add byteman support, and
- another to fix the original test and to include a bug fix

!CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE LRA !DB_TESTS !mysql !db2 !postgres !oracle !JDK17