### PR TITLE
Update jboss dependencies

### DIFF
--- a/narayana-bom/pom.xml
+++ b/narayana-bom/pom.xml
@@ -57,11 +57,11 @@
     <version.org.jboss.invocation>2.0.0.Final</version.org.jboss.invocation>
     <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
     <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
-    <version.org.jboss.logging.jboss-logging>3.5.0.Final</version.org.jboss.logging.jboss-logging>
-    <version.org.jboss.logging.jboss-logging-processor>2.2.1.Final</version.org.jboss.logging.jboss-logging-processor>
-    <version.org.jboss.logmanager>1.5.1.Final</version.org.jboss.logmanager>
-    <version.org.jboss.openjdk-orb>9.0.1.Final</version.org.jboss.openjdk-orb>
-    <version.org.jboss.ws>2.0.0.Final</version.org.jboss.ws>
+    <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
+    <version.org.jboss.logging.jboss-logging-tools>3.0.2.Final</version.org.jboss.logging.jboss-logging-tools>
+    <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
+    <version.org.jboss.openjdk-orb>10.1.0.Final</version.org.jboss.openjdk-orb>
+    <version.org.jboss.ws>3.0.0.Final</version.org.jboss.ws>
     <version.parsson>1.1.3</version.parsson>
     <version.smallrye-converter-api>2.7.0</version.smallrye-converter-api>
     <version.sortpom>3.0.0</version.sortpom>
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-processor</artifactId>
-        <version>${version.org.jboss.logging.jboss-logging-processor}</version>
+        <version>${version.org.jboss.logging.jboss-logging-tools}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.narayana</groupId>
@@ -528,7 +528,7 @@
       <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-annotations</artifactId>
-        <version>${version.org.jboss.logging.jboss-logging-processor}</version>
+        <version>${version.org.jboss.logging.jboss-logging-tools}</version>
         <optional>true</optional>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,14 +183,10 @@
     <!-- The surefire/failsafe test execution logs goes to a file by default -->
     <testLogToFile>true</testLogToFile>
     <version.com.github.spotbugs.spotbugs-maven-plugin>4.8.3.1</version.com.github.spotbugs.spotbugs-maven-plugin>
-    <version.compiler.plugin>3.8.0-jboss-2</version.compiler.plugin>
 
     <version.doxia>1.8.1</version.doxia>
     <version.io.narayana.checkstyle-config>1.0.1.Final</version.io.narayana.checkstyle-config>
     <version.javadoc.plugin>3.5.0</version.javadoc.plugin>
-    <version.maven-failsafe-plugin>3.0.0-M7</version.maven-failsafe-plugin>
-    <version.maven-surefire-plugin>3.0.0-M7</version.maven-surefire-plugin>
-    <version.maven.checkstyle-plugin>3.1.2</version.maven.checkstyle-plugin>
     <version.maven.jandex-plugin>3.1.7</version.maven.jandex-plugin>
 
     <!-- Needed forWildflyLRACoordinatorDeployment class -->
@@ -281,7 +277,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${version.compiler.plugin}</version>
           <!-- Remove this when org.jboss.logging becomes Jakarta compatible -->
           <configuration>
             <compilerArgs>
@@ -320,7 +315,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${version.maven-surefire-plugin}</version>
           <configuration>
             <argLine>${surefireArgLine}</argLine>
             <forkCount>1</forkCount>
@@ -454,7 +448,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven.checkstyle-plugin}</version>
         <configuration>
           <configLocation>narayana-checkstyle/checkstyle.xml</configLocation>
           <suppressionsLocation>narayana-checkstyle/suppressions.xml</suppressionsLocation>


### PR DESCRIPTION
Update plugin dependencies

jboss.logmanager>2.1.19.Final
jboss-logging-processor>3.0.2.Final
jboss-logging>3.6.1.Final
jboss.openjdk-orb>10.1.0.Final
jboss.ws>3.0.0.Final

I removed the plugin version so that it uses the versions defined in the jboss-parent.

CORE AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS 