### PR TITLE
[JBTM-3946] Class.newInstance() can be replaced by Class.getDeclaredConstructor().newInstance() as class.newInstance is deprecated in java 9

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
@@ -447,7 +447,7 @@ public abstract class AbstractRecord extends StateManager
 	    {
         	    Class recordClass = RecordType.typeToClass(type);
         
-        	    return (AbstractRecord) recordClass.newInstance();
+        	    return (AbstractRecord) recordClass.getDeclaredConstructor().newInstance();
 	    }
 	    catch (final NullPointerException ex) {
             tsLogger.i18NLogger.warn_coordinator_AbstractRecord_npe(Integer.toString(type));

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/jdbc/JDBCStore.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/jdbc/JDBCStore.java
@@ -197,7 +197,7 @@ public class JDBCStore implements ObjectStoreAPI {
                 jdbcAccess.initialise(null);
             } else if (connectionDetails != null) {
                 StringTokenizer stringTokenizer = new StringTokenizer(connectionDetails, ";");
-                jdbcAccess = (JDBCAccess) Class.forName(stringTokenizer.nextToken()).newInstance();
+                jdbcAccess = (JDBCAccess) Class.forName(stringTokenizer.nextToken()).getDeclaredConstructor().newInstance();
                 jdbcAccess.initialise(stringTokenizer);
             } else {
                 throw new ObjectStoreException("Invalid store configuration");
@@ -245,7 +245,7 @@ public class JDBCStore implements ObjectStoreAPI {
                 }
             }
 
-            _theImple = (com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCImple_driver) jdbcImpleClass.newInstance();
+            _theImple = (com.arjuna.ats.internal.arjuna.objectstore.jdbc.JDBCImple_driver) jdbcImpleClass.getDeclaredConstructor().newInstance();
 
             _theImple.initialise(jdbcAccess, tableName, jdbcStoreEnvironmentBean);
             imples.put(key, _theImple);

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/jdbc/accessors/DynamicDataSourceJDBCAccess.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/internal/arjuna/objectstore/jdbc/accessors/DynamicDataSourceJDBCAccess.java
@@ -35,7 +35,7 @@ public class DynamicDataSourceJDBCAccess implements JDBCAccess {
 			}
 			try {
 				this.dataSource = (DataSource) Class.forName(
-						configuration.remove("ClassName")).newInstance();
+						configuration.remove("ClassName")).getDeclaredConstructor().newInstance();
 				Iterator<String> iterator = configuration.keySet().iterator();
 				while (iterator.hasNext()) {
 					String key = iterator.next();

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/TestTransactionalBean.java
@@ -48,7 +48,7 @@ public class TestTransactionalBean {
     public void invokeWithDefault(Class<? extends Throwable> throwable) throws Throwable {
 
         AssertionParticipant.enlist();
-        throw throwable.newInstance();
+        throw throwable.getDeclaredConstructor().newInstance();
     }
 
 
@@ -56,28 +56,28 @@ public class TestTransactionalBean {
     public void invokeWithDefaultAndRollbackOn(Class<? extends Throwable> throwable) throws Throwable {
 
         AssertionParticipant.enlist();
-        throw throwable.newInstance();
+        throw throwable.getDeclaredConstructor().newInstance();
     }
 
     @Transactional(dontRollbackOn = TestRuntimeException.class)
     public void invokeWithDefaultAndDontRollbackOn(Class<? extends Throwable> throwable) throws Throwable {
 
         AssertionParticipant.enlist();
-        throw throwable.newInstance();
+        throw throwable.getDeclaredConstructor().newInstance();
     }
 
     @Transactional(dontRollbackOn = Error.class)
     public void invokeWithRequiresAndDontRollbackOnError(Class<? extends Throwable> throwable) throws Throwable {
 
         AssertionParticipant.enlist();
-        throw throwable.newInstance();
+        throw throwable.getDeclaredConstructor().newInstance();
     }
 
     @Transactional(dontRollbackOn = TestException.class, rollbackOn = TestException.class)
     public void invokeWithDefaultAndDoAndDontRollbackOn(Class<? extends Throwable> throwable) throws Throwable {
 
         AssertionParticipant.enlist();
-        throw throwable.newInstance();
+        throw throwable.getDeclaredConstructor().newInstance();
     }
 
     @Transactional(Transactional.TxType.REQUIRES_NEW)

--- a/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/drivers/XADataSourceReflectionWrapper.java
+++ b/ArjunaJTA/jdbc/classes/com/arjuna/ats/internal/jdbc/drivers/XADataSourceReflectionWrapper.java
@@ -23,7 +23,7 @@ public class XADataSourceReflectionWrapper
     {
         try
         {
-            xaDataSource = (XADataSource)Class.forName(classname).newInstance();
+            xaDataSource = (XADataSource)Class.forName(classname).getDeclaredConstructor().newInstance();
         }
         catch(Exception e) {
             throw new ExceptionInInitializerError(e);

--- a/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/basic/SimpleJdbcTest.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/basic/SimpleJdbcTest.java
@@ -91,7 +91,7 @@ public class SimpleJdbcTest {
 		InitialContext initialContext = prepareInitialContext();
 
 		Class clazz = Class.forName("org.h2.jdbcx.JdbcDataSource");
-		XADataSource xaDataSource = (XADataSource) clazz.newInstance();
+		XADataSource xaDataSource = (XADataSource) clazz.getDeclaredConstructor().newInstance();
 		clazz.getMethod("setURL", new Class[] { String.class }).invoke(
 				xaDataSource, new Object[] { "jdbc:h2:mem:JBTMDB;DB_CLOSE_DELAY=-1" });
 

--- a/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/basic/StableConnections.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/basic/StableConnections.java
@@ -57,7 +57,7 @@ public class StableConnections {
         InitialContext initialContext = prepareInitialContext();
 
         Class clazz = Class.forName("org.postgresql.xa.PGXADataSource");
-        XADataSource xaDataSource = (XADataSource) clazz.newInstance();
+        XADataSource xaDataSource = (XADataSource) clazz.getDeclaredConstructor().newInstance();
         clazz.getMethod("setServerName", new Class[] { String.class }).invoke(
             xaDataSource, new Object[] { DB_HOST });
         clazz.getMethod("setDatabaseName", new Class[] { String.class })

--- a/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/utils/JNDISetup.java
+++ b/ArjunaJTA/jdbc/tests/classes/com/hp/mwtests/ts/jdbc/utils/JNDISetup.java
@@ -19,7 +19,7 @@ public class JNDISetup
     @Test
     public void test() throws Exception
     {
-        DBPlugin plugin = (DBPlugin)Thread.currentThread().getContextClassLoader().loadClass("TODO").newInstance();
+        DBPlugin plugin = (DBPlugin)Thread.currentThread().getContextClassLoader().loadClass("TODO").getDeclaredConstructor().newInstance();
 
         String jndiName = "jdbc/DB";
         DataSource ds = plugin.getDataSource(new String[] {"TODO"});

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/SubordinationManager.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/jca/SubordinationManager.java
@@ -81,7 +81,7 @@ public class SubordinationManager
             try
             {
                 Class clazz = Class.forName("com.arjuna.ats.internal.jta.transaction.jts.jca.TransactionImporterImple");
-                transactionImporter = (TransactionImporter)clazz.newInstance();
+                transactionImporter = (TransactionImporter)clazz.getDeclaredConstructor().newInstance();
             }
             catch(Exception e)
             {
@@ -110,7 +110,7 @@ public class SubordinationManager
             try
             {
                 Class clazz = Class.forName("com.arjuna.ats.internal.jta.transaction.jts.jca.XATerminatorImple");
-                xaTerminator = (XATerminator)clazz.newInstance();
+                xaTerminator = (XATerminator)clazz.getDeclaredConstructor().newInstance();
             }
             catch(Exception e)
             {

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/utils/JNDIManager.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/utils/JNDIManager.java
@@ -140,7 +140,7 @@ public class JNDIManager
         String tsrImplementation = jtaPropertyManager.getJTAEnvironmentBean().getTransactionSynchronizationRegistryClassName();
         Object tsr = null;
         try {
-            tsr = Class.forName(tsrImplementation).newInstance();
+            tsr = Class.forName(tsrImplementation).getDeclaredConstructor().newInstance();
         } catch(Exception e) {
             NamingException namingException = new ConfigurationException(jtaLogger.i18NLogger.get_utils_JNDIManager_tsr1());
             namingException.setRootCause(e);

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/basic/JTATest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/basic/JTATest.java
@@ -27,7 +27,7 @@ public class JTATest
         String connectionString = null;
         boolean tmCommit = true;
 
-        XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).newInstance();
+        XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).getDeclaredConstructor().newInstance();
         XAResource theResource = creator.create(connectionString, true);
         XAResource theResource2 = creator.create(connectionString, true);
 

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/PerformanceTestCommitMarkableResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/commitmarkable/PerformanceTestCommitMarkableResource.java
@@ -223,7 +223,7 @@ public class PerformanceTestCommitMarkableResource extends
 		if (dbType.equals("oracle")) {
 			Class clazz = Class
 					.forName("oracle.jdbc.xa.client.OracleXADataSource");
-			dataSource = (XADataSource) clazz.newInstance();
+			dataSource = (XADataSource) clazz.getDeclaredConstructor().newInstance();
 			clazz.getMethod("setDriverType", new Class[] { String.class })
 					.invoke(dataSource, new Object[] { "thin" });
 			clazz.getMethod("setServerName", new Class[] { String.class })
@@ -242,7 +242,7 @@ public class PerformanceTestCommitMarkableResource extends
 		} else if (dbType.equals("sybase")) {
 			Class clazz = Class
 					.forName("com.sybase.jdbc3.jdbc.SybXADataSource");
-			dataSource = (XADataSource) clazz.newInstance();
+			dataSource = (XADataSource) clazz.getDeclaredConstructor().newInstance();
 
 			clazz.getMethod("setServerName", new Class[] { String.class })
 					.invoke(dataSource, new Object[] { "192.168.1.5" });
@@ -278,7 +278,7 @@ public class PerformanceTestCommitMarkableResource extends
 			((MysqlXADataSource) dataSource).setPassword("dtf11");
 		} else if (dbType.equals("db2")) {
 			Class clazz = Class.forName("com.ibm.db2.jcc.DB2XADataSource");
-			dataSource = (XADataSource) clazz.newInstance();
+			dataSource = (XADataSource) clazz.getDeclaredConstructor().newInstance();
 			clazz.getMethod("setServerName", new Class[] { String.class })
 					.invoke(dataSource,
 							new Object[] { "tywin.eng.hst.ams2.redhat.com" });
@@ -295,7 +295,7 @@ public class PerformanceTestCommitMarkableResource extends
 		} else if (dbType.equals("sqlserver")) {
 			Class clazz = Class
 					.forName("com.microsoft.sqlserver.jdbc.SQLServerXADataSource");
-			dataSource = (XADataSource) clazz.newInstance();
+			dataSource = (XADataSource) clazz.getDeclaredConstructor().newInstance();
 
 			clazz.getMethod("setServerName", new Class[] { String.class })
 					.invoke(dataSource,

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/hammer/JTAHammer.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/hammer/JTAHammer.java
@@ -109,7 +109,7 @@ public class JTAHammer
 	 * specification). However, for simplicity we will ignore this.
 	 */
 
-	XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).newInstance();
+	XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).getDeclaredConstructor().newInstance();
 
 	number = threads;
 

--- a/ArjunaJTA/spi/src/test/java/io/narayana/spi/util/XADSWrapper.java
+++ b/ArjunaJTA/spi/src/test/java/io/narayana/spi/util/XADSWrapper.java
@@ -39,7 +39,7 @@ public class XADSWrapper implements XADataSource, Serializable, Referenceable, D
 
     public XADSWrapper(String binding, String driver, String databaseName, String host, Integer port, String xaDSClassName, String userName, String password) {
         try {
-            xaDataSource = (XADataSource)Class.forName(xaDSClassName).newInstance();
+            xaDataSource = (XADataSource)Class.forName(xaDSClassName).getDeclaredConstructor().newInstance();
             txDriverUrl = TransactionalDriver.arjunaDriver + binding;
 
             this.binding = binding;

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/SimpleIsolatedServers.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/SimpleIsolatedServers.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -53,7 +54,7 @@ public class SimpleIsolatedServers {
 
     @Before
     public void setup() throws SecurityException, NoSuchMethodException, InstantiationException, IllegalAccessException, ClassNotFoundException,
-            CoreEnvironmentBeanException, IOException, IllegalArgumentException, NoSuchFieldException {
+            CoreEnvironmentBeanException, IOException, IllegalArgumentException, NoSuchFieldException, InvocationTargetException {
 
         for (int i = 0; i < serverNodeNames.length; i++) {
             List<String> otherNodes = new ArrayList<String>();
@@ -122,13 +123,13 @@ public class SimpleIsolatedServers {
     }
 
     private void boot(int index) throws SecurityException, NoSuchMethodException, InstantiationException, IllegalAccessException,
-            ClassNotFoundException, IllegalArgumentException, CoreEnvironmentBeanException, IOException, NoSuchFieldException {
+            ClassNotFoundException, IllegalArgumentException, CoreEnvironmentBeanException, IOException, NoSuchFieldException, InvocationTargetException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         IsolatableServersClassLoader classLoaderForTransactionManager = new IsolatableServersClassLoader(null, SimpleIsolatedServers.class.getPackage()
                 .getName(), contextClassLoader);
         IsolatableServersClassLoader classLoader = new IsolatableServersClassLoader(SimpleIsolatedServers.class.getPackage().getName(), null,
                 classLoaderForTransactionManager);
-        localServers[index] = (LocalServer) classLoader.loadClass("com.arjuna.ats.jta.distributed.server.impl.ServerImpl").newInstance();
+        localServers[index] = (LocalServer) classLoader.loadClass("com.arjuna.ats.jta.distributed.server.impl.ServerImpl").getDeclaredConstructor().newInstance();
         Thread.currentThread().setContextClassLoader(classLoaderForTransactionManager);
         localServers[index].initialise(lookupProvider, serverNodeNames[index], serverPortOffsets[index], clusterBuddies[index],
                 classLoaderForTransactionManager);

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/basic/JTATest.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/basic/JTATest.java
@@ -51,7 +51,7 @@ public class JTATest
 	
 	try
 	{
-	    XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).newInstance();
+	    XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).getDeclaredConstructor().newInstance();
 	    XAResource theResource = creator.create(connectionString, true);
 
 	    if (theResource == null)

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/hammer/JTAHammer.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/hammer/JTAHammer.java
@@ -129,7 +129,7 @@ public class JTAHammer
 	 * specification). However, for simplicity we will ignore this.
 	 */
 
-	XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).newInstance();
+	XACreator creator = (XACreator) Thread.currentThread().getContextClassLoader().loadClass(xaResource).getDeclaredConstructor().newInstance();
 
 	number = threads;
 

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/recovery/RecoveryInit.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/recovery/RecoveryInit.java
@@ -77,7 +77,7 @@ public class RecoveryInit
             {
                 Class recoveryCoordinatorInitialiser = ClassloadingUtility.loadClass(initClassName);
 
-                recoveryCoordinatorInitialiser.newInstance();
+                recoveryCoordinatorInitialiser.getDeclaredConstructor().newInstance();
             }
 
 		    // register the ContactWriter to watch for the first ArjunaFactory construction

--- a/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/internal/utils/InitLoader.java
+++ b/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/internal/utils/InitLoader.java
@@ -7,6 +7,7 @@
 
 package com.arjuna.orbportability.internal.utils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import com.arjuna.common.internal.util.ClassloadingUtility;
@@ -60,7 +61,7 @@ private void createInstance (String attrName, String className)
         }
         try
         {
-            Object o = c.newInstance();
+            Object o = c.getDeclaredConstructor().newInstance();
 
             if ( o instanceof InitClassInterface )
             {
@@ -69,13 +70,9 @@ private void createInstance (String attrName, String className)
 
             o = null;
         }
-        catch (IllegalAccessException e1)
+        catch (IllegalAccessException | InstantiationException | InvocationTargetException | NoSuchMethodException e)
         {
-            opLogger.i18NLogger.warn_internal_utils_InitLoader_exception(initName, e1);
-        }
-        catch (InstantiationException e2)
-        {
-            opLogger.i18NLogger.warn_internal_utils_InitLoader_exception(initName, e2);
+            opLogger.i18NLogger.warn_internal_utils_InitLoader_exception(initName, e);
         }
     }
     }

--- a/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/oa/core/OA.java
+++ b/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/oa/core/OA.java
@@ -43,7 +43,7 @@ public class OA
                 opLogger.logger.trace("OA.initialise() - using OA Implementation " + clazz.getCanonicalName());
             }
 
-            _theOA = clazz.newInstance();
+            _theOA = clazz.getDeclaredConstructor().newInstance();
         }
         catch (Exception e)
         {

--- a/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/orb/core/ORB.java
+++ b/ArjunaJTS/orbportability/classes/com/arjuna/orbportability/orb/core/ORB.java
@@ -38,7 +38,7 @@ public class ORB
                 opLogger.logger.trace("ORB.initialise() - using ORB Implementation " + clazz.getCanonicalName());
             }
 
-            _theORB = clazz.newInstance();
+            _theORB = clazz.getDeclaredConstructor().newInstance();
         }
         catch (Exception e)
         {

--- a/XTS/WS-C/dev/src/com/arjuna/webservices11/util/ServiceAction.java
+++ b/XTS/WS-C/dev/src/com/arjuna/webservices11/util/ServiceAction.java
@@ -8,6 +8,8 @@ package com.arjuna.webservices11.util;
 import com.arjuna.webservices.logging.WSCLogger;
 
 import jakarta.xml.ws.Service;
+
+import java.lang.reflect.InvocationTargetException;
 import java.security.PrivilegedAction;
 
 /**
@@ -28,8 +30,8 @@ public final class ServiceAction<T extends Service> implements PrivilegedAction<
     @Override
     public T run() {
         try {
-            return serviceClass.newInstance();
-        } catch (final InstantiationException | IllegalAccessException e) {
+            return serviceClass.getDeclaredConstructor().newInstance();
+        } catch (final InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             WSCLogger.i18NLogger.warn_cannot_create_service_instance(serviceClass, e);
             throw new RuntimeException(e);
         }

--- a/XTS/WSCF/classes/com/arjuna/mw/wscf/protocols/ProtocolManager.java
+++ b/XTS/WSCF/classes/com/arjuna/mw/wscf/protocols/ProtocolManager.java
@@ -14,6 +14,7 @@ import com.arjuna.mwlabs.wscf.utils.ContextProvider;
 import com.arjuna.mwlabs.wscf.utils.HLSProvider;
 import org.jboss.jbossts.xts.environment.XTSPropertyManager;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 /**
@@ -118,14 +119,12 @@ public class ProtocolManager
                 HLSProvider hlsProvider = clazz.getAnnotation(HLSProvider.class);
                 String serviceType = hlsProvider.serviceType();
                 wscfLogger.i18NLogger.info_protocols_ProtocolManager_4(className, serviceType);
-                Object object = clazz.newInstance();
+                Object object = clazz.getDeclaredConstructor().newInstance();
                 _protocols.put(serviceType, object);
-            } catch (InstantiationException ie) {
-                wscfLogger.i18NLogger.error_protocols_ProtocolManager_5(className, ie);
-            } catch (IllegalAccessException iae) {
-                wscfLogger.i18NLogger.error_protocols_ProtocolManager_5(className, iae);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                wscfLogger.i18NLogger.error_protocols_ProtocolManager_5(className, e);
             }
-		}
+	}
 
         for (Class<?> clazz : contextProviderClasses) {
             String className = clazz.getName();
@@ -135,15 +134,13 @@ public class ProtocolManager
                 if (contextProvider !=  null) {
                     String coordinationType = contextProvider.coordinationType();
                     wscfLogger.i18NLogger.info_protocols_ProtocolManager_4(className, coordinationType);
-                    Object object = clazz.newInstance();
+                    Object object = clazz.getDeclaredConstructor().newInstance();
                     _protocols.put(coordinationType, object);
                 }
-            } catch (InstantiationException ie) {
-                wscfLogger.i18NLogger.error_protocols_ProtocolManager_5(className, ie);
-            } catch (IllegalAccessException iae) {
-                wscfLogger.i18NLogger.error_protocols_ProtocolManager_5(className, iae);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                wscfLogger.i18NLogger.error_protocols_ProtocolManager_5(className, e);
             }
-		}
+	}
 	}
 
 	private HashMap _protocols = new HashMap();

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/ParticipantRecord.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/ParticipantRecord.java
@@ -524,7 +524,7 @@ public class ParticipantRecord extends
 			{
                 String resourcehandleImplClassName = os.unpackString();
                 Class clazz = ClassLoaderHelper.forName(ParticipantRecord.class, resourcehandleImplClassName);
-                _resourceHandle = (Participant)clazz.newInstance();
+                _resourceHandle = (Participant)clazz.getDeclaredConstructor().newInstance();
 
                 result = _resourceHandle.restore_state(os);
 

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ParticipantRecord.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/twophase/arjunacore/ParticipantRecord.java
@@ -525,7 +525,7 @@ public class ParticipantRecord extends
 			{
                 String resourcehandleImplClassName = os.unpackString();
                 Class clazz = ClassLoaderHelper.forName(ParticipantRecord.class, resourcehandleImplClassName);
-                _resourceHandle = (Participant)clazz.newInstance();
+                _resourceHandle = (Participant)clazz.getDeclaredConstructor().newInstance();
 
                 result = _resourceHandle.restore_state(os);
 

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf11/model/sagas/arjunacore/SagasHLSImple.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf11/model/sagas/arjunacore/SagasHLSImple.java
@@ -172,7 +172,7 @@ public class SagasHLSImple implements SagasHLS, UserCoordinatorService
         ensureContextInitialised();
         if (CONTEXT_IMPLE_CLASS != null) {
             try {
-                SOAPContext ctx = (SOAPContext) CONTEXT_IMPLE_CLASS.newInstance();
+                SOAPContext ctx = (SOAPContext) CONTEXT_IMPLE_CLASS.getDeclaredConstructor().newInstance();
 
                 ctx.initialiseContext(_coordManager.currentCoordinator());
 

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf11/model/twophase/arjunacore/TwoPhaseHLSImple.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf11/model/twophase/arjunacore/TwoPhaseHLSImple.java
@@ -171,7 +171,7 @@ public class TwoPhaseHLSImple implements TwoPhaseHLS, UserCoordinatorService
         ensureContextInitialised();
         if (CONTEXT_IMPLE_CLASS != null) {
             try {
-                SOAPContext ctx = (SOAPContext) CONTEXT_IMPLE_CLASS.newInstance();
+                SOAPContext ctx = (SOAPContext) CONTEXT_IMPLE_CLASS.getDeclaredConstructor().newInstance();
 
                 ctx.initialiseContext(_coordManager.currentCoordinator());
 

--- a/XTS/WSTX/classes/com/arjuna/mw/wst11/deploy/WSTXInitialisation.java
+++ b/XTS/WSTX/classes/com/arjuna/mw/wst11/deploy/WSTXInitialisation.java
@@ -59,16 +59,16 @@ public class WSTXInitialisation
         // we only load classes which have been configured
         
         if (userTx != null) {
-            UserTransaction.setUserTransaction((UserTransaction)ClassLoaderHelper.forName(WSTXInitialisation.class, userTx).newInstance()) ;
+            UserTransaction.setUserTransaction((UserTransaction)ClassLoaderHelper.forName(WSTXInitialisation.class, userTx).getDeclaredConstructor().newInstance()) ;
         }
         if (txManager != null) {
-            TransactionManager.setTransactionManager((TransactionManager)ClassLoaderHelper.forName(WSTXInitialisation.class, txManager).newInstance()) ;
+            TransactionManager.setTransactionManager((TransactionManager)ClassLoaderHelper.forName(WSTXInitialisation.class, txManager).getDeclaredConstructor().newInstance()) ;
         }
         if (userBa != null) {
-            UserBusinessActivity.setUserBusinessActivity((UserBusinessActivity)ClassLoaderHelper.forName(WSTXInitialisation.class, userBa).newInstance()) ;
+            UserBusinessActivity.setUserBusinessActivity((UserBusinessActivity)ClassLoaderHelper.forName(WSTXInitialisation.class, userBa).getDeclaredConstructor().newInstance()) ;
         }
         if (baManager != null) {
-            BusinessActivityManager.setBusinessActivityManager((BusinessActivityManager)ClassLoaderHelper.forName(WSTXInitialisation.class, baManager).newInstance());
+            BusinessActivityManager.setBusinessActivityManager((BusinessActivityManager)ClassLoaderHelper.forName(WSTXInitialisation.class, baManager).getDeclaredConstructor().newInstance()) ;
         }
     }
 

--- a/XTS/WSTX/classes/com/arjuna/mwlabs/wst/util/PersistableParticipantHelper.java
+++ b/XTS/WSTX/classes/com/arjuna/mwlabs/wst/util/PersistableParticipantHelper.java
@@ -88,7 +88,7 @@ public class PersistableParticipantHelper
             {
                 final String className = ios.unpackString() ;
                 final Class resourceClass = ClassLoaderHelper.forName(PersistableParticipantHelper.class, className) ; // returns Class not instance
-                final Object resource = resourceClass.newInstance();
+                final Object resource = resourceClass.getDeclaredConstructor().newInstance();
                 ((PersistableParticipant)resource).restoreState(ios) ;
                 return resource ;
             }

--- a/XTS/localjunit/WSTFSC07-interop/src/main/java/com/jboss/transaction/wstf/test/TestRunner.java
+++ b/XTS/localjunit/WSTFSC07-interop/src/main/java/com/jboss/transaction/wstf/test/TestRunner.java
@@ -5,6 +5,8 @@
 
 package com.jboss.transaction.wstf.test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestResult;
@@ -91,9 +93,9 @@ public class TestRunner
      * @throws IllegalArgumentException For an invalid test class.
      */
     private static TestCase createTest(final Class testClass, final String participantURI, final long testTimeout, final boolean asyncTest, final String testName)
-        throws IllegalAccessException, InstantiationException, IllegalArgumentException
+        throws IllegalAccessException, InstantiationException, IllegalArgumentException, NoSuchMethodException, InvocationTargetException
     {
-        final Object testObject = testClass.newInstance() ;
+        final Object testObject = testClass.getDeclaredConstructor().newInstance();
         if (testObject instanceof InteropTestCase)
         {
             final InteropTestCase interopTestCase = (InteropTestCase)testObject ;

--- a/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/test/TestRunner.java
+++ b/XTS/localjunit/WSTX11-interop/src/main/java/com/jboss/transaction/txinterop/test/TestRunner.java
@@ -5,6 +5,8 @@
 
 package com.jboss.transaction.txinterop.test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import com.jboss.transaction.txinterop.interop.ATTestCase;
 import com.jboss.transaction.txinterop.interop.BATestCase;
 import com.jboss.transaction.txinterop.interop.InteropTestCase;
@@ -117,9 +119,9 @@ public class TestRunner
      * @throws IllegalArgumentException For an invalid test class.
      */
     private static TestCase createTest(final Class testClass, final String participantURI, final long testTimeout, final boolean asyncTest, final String testName)
-        throws IllegalAccessException, InstantiationException, IllegalArgumentException
+        throws IllegalAccessException, InstantiationException, IllegalArgumentException, NoSuchMethodException, InvocationTargetException
     {
-        final Object testObject = testClass.newInstance() ;
+        final Object testObject = testClass.getDeclaredConstructor().newInstance();
         if (testObject instanceof InteropTestCase)
         {
             final InteropTestCase interopTestCase = (InteropTestCase)testObject ;

--- a/XTS/localjunit/xtstest/src/org/jboss/jbossts/xts/servicetests/bean/XTSServiceTestRunnerBean.java
+++ b/XTS/localjunit/xtstest/src/org/jboss/jbossts/xts/servicetests/bean/XTSServiceTestRunnerBean.java
@@ -84,7 +84,7 @@ public class XTSServiceTestRunnerBean
             }
 
             try {
-                testInstance = (XTSServiceTest)testClass.newInstance(); // assumes there is a no-arg constructor
+                testInstance = (XTSServiceTest)testClass.getDeclaredConstructor().newInstance(); // assumes there is a no-arg constructor
             } catch (InstantiationException ie) {
                 log.warn("XTSServiceTestRunner : cannot instantiate test class " + testName, ie);
                 throw new Exception("XTSServiceTestRunner : cannot instantiate test class " + testName, ie);

--- a/XTS/localjunit/xtstest/src/org/jboss/jbossts/xts/servicetests/webbean/XTSHTTPServiceTestRunner.java
+++ b/XTS/localjunit/xtstest/src/org/jboss/jbossts/xts/servicetests/webbean/XTSHTTPServiceTestRunner.java
@@ -11,6 +11,7 @@ import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
 
 import org.jboss.jbossts.xts.servicetests.test.XTSServiceTest;
 
@@ -66,12 +67,16 @@ public class XTSHTTPServiceTestRunner extends HttpServlet
                 }
 
                 try {
-                    _currentTest = (XTSServiceTest)testClass.newInstance();
+                    _currentTest = (XTSServiceTest)testClass.getDeclaredConstructor().newInstance();
                 } catch (InstantiationException ie) {
                     throw new ServletException("XTSHTTPServicetestRunner : cannot instantiate test class " + _testClassName, ie);
                 } catch (IllegalAccessException iae) {
                     throw new ServletException("XTSHTTPServicetestRunner : cannot access constructor for test class " + _testClassName, iae);
-                }
+                } catch (InvocationTargetException e) {
+                    throw new ServletException("XTSHTTPServicetestRunner : cannot invoke constructor for test class " + _testClassName, e);
+                 } catch (NoSuchMethodException e) {
+                    throw new ServletException("XTSHTTPServicetestRunner : cannot find constructor for test class " + _testClassName, e);
+                 }
 
                 // since we are running in the AS startup thread we need a separate thread for the test
 

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/coordinator/CoordinatorRecoveryInitialisation.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/coordinator/CoordinatorRecoveryInitialisation.java
@@ -11,6 +11,7 @@ import org.jboss.jbossts.xts.environment.XTSPropertyManager;
 import org.jboss.jbossts.xts.recovery.logging.RecoveryLogger;
 import org.jboss.jbossts.xts.recovery.XTSRecoveryModule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -62,7 +63,7 @@ public class CoordinatorRecoveryInitialisation
             }
             
             try {
-                XTSRecoveryModule module = (XTSRecoveryModule)clazz.newInstance();
+                XTSRecoveryModule module = (XTSRecoveryModule)clazz.getDeclaredConstructor().newInstance();
                 module.install();
                 RecoveryManager.manager().addModule(module);
                 recoveryModules.add(module);
@@ -70,8 +71,12 @@ public class CoordinatorRecoveryInitialisation
                 RecoveryLogger.i18NLogger.error_recovery_coordinator_CoordinatorRecoveryInitialisation_3(className, ie);
             } catch (IllegalAccessException iae) {
                 RecoveryLogger.i18NLogger.error_recovery_coordinator_CoordinatorRecoveryInitialisation_4(className, iae);
-            }
-        }
+            } catch (InvocationTargetException e) {
+                RecoveryLogger.i18NLogger.error_recovery_coordinator_CoordinatorRecoveryInitialisation_5(className, e);
+	    } catch (NoSuchMethodException e) {
+                RecoveryLogger.i18NLogger.error_recovery_coordinator_CoordinatorRecoveryInitialisation_6(className, e);
+	    }
+	}
 
         initialised = true;
     }

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/logging/recoveryI18NLogger.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/logging/recoveryI18NLogger.java
@@ -237,6 +237,22 @@ public interface recoveryI18NLogger {
     @LogMessage(level = ERROR)
     public void error_recovery_participant_ParticipantRecoveryInitialisation_4(String arg0, @Cause() Throwable arg1);
 
+    @Message(id = 46054, value = "Unable to invoke module class {0}", format = MESSAGE_FORMAT)
+    @LogMessage(level = ERROR)
+    public void error_recovery_coordinator_CoordinatorRecoveryInitialisation_5(String arg0, @Cause() Throwable arg1);
+
+    @Message(id = 46055, value = "Unable to find module class {0}", format = MESSAGE_FORMAT)
+    @LogMessage(level = ERROR)
+    public void error_recovery_coordinator_CoordinatorRecoveryInitialisation_6(String arg0, @Cause() Throwable arg1);
+
+    @Message(id = 46056, value = "Unable to invoke module class {0}", format = MESSAGE_FORMAT)
+    @LogMessage(level = ERROR)
+    public void error_recovery_participant_ParticipantRecoveryInitialisation_5(String arg0, @Cause() Throwable arg1);
+
+    @Message(id = 46057, value = "Unable to find module class {0}", format = MESSAGE_FORMAT)
+    @LogMessage(level = ERROR)
+    public void error_recovery_participant_ParticipantRecoveryInitialisation_6(String arg0, @Cause() Throwable arg1);
+
     /*
         Allocate new messages directly above this notice.
           - id: use the next id number in numeric sequence. Don't reuse ids.

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/ParticipantRecoveryInitialisation.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/ParticipantRecoveryInitialisation.java
@@ -11,6 +11,7 @@ import org.jboss.jbossts.xts.environment.XTSPropertyManager;
 import org.jboss.jbossts.xts.recovery.logging.RecoveryLogger;
 import org.jboss.jbossts.xts.recovery.XTSRecoveryModule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -65,7 +66,7 @@ public class ParticipantRecoveryInitialisation
             }
             
             try {
-                XTSRecoveryModule module = (XTSRecoveryModule)clazz.newInstance();
+                XTSRecoveryModule module = (XTSRecoveryModule)clazz.getDeclaredConstructor().newInstance();
                 module.install();
                 RecoveryManager.manager().addModule(module);
                 recoveryModules.add(module);
@@ -73,8 +74,12 @@ public class ParticipantRecoveryInitialisation
                 RecoveryLogger.i18NLogger.error_recovery_participant_ParticipantRecoveryInitialisation_3(className, ie);
             } catch (IllegalAccessException iae) {
                 RecoveryLogger.i18NLogger.error_recovery_participant_ParticipantRecoveryInitialisation_4(className, iae);
-            }
-        }
+            } catch (InvocationTargetException e) {
+                RecoveryLogger.i18NLogger.error_recovery_participant_ParticipantRecoveryInitialisation_5(className, e);
+	    } catch (NoSuchMethodException e) {
+                RecoveryLogger.i18NLogger.error_recovery_participant_ParticipantRecoveryInitialisation_6(className, e);
+	    }
+	}
 
         initialised =  true;
     }

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/ATParticipantRecoveryModule.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/ATParticipantRecoveryModule.java
@@ -16,6 +16,7 @@ import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.internal.arjuna.common.UidHelper;
 import org.jboss.jbossts.xts.recovery.XTSRecoveryModule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Vector;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -151,7 +152,7 @@ public class ATParticipantRecoveryModule implements XTSRecoveryModule
                         try {
                             // create a participant engine instance and tell it to recover itself
                             Class participantRecordClazz = Class.forName(participantRecordClazzName);
-                            ATParticipantRecoveryRecord participantRecord = (ATParticipantRecoveryRecord)participantRecordClazz.newInstance();
+                            ATParticipantRecoveryRecord participantRecord = (ATParticipantRecoveryRecord)participantRecordClazz.getDeclaredConstructor().newInstance();
                             participantRecord.restoreState(inputState);
                             // ok, now insert into recovery map if needed
                             XTSATRecoveryManager.getRecoveryManager().addParticipantRecoveryRecord(recoverUid, participantRecord);
@@ -160,12 +161,9 @@ public class ATParticipantRecoveryModule implements XTSRecoveryModule
                             // last time and 1.1 this time or vice versa or something is rotten in
                             // the state of Danmark
                             RecoveryLogger.i18NLogger.error_participant_at_ATParticipantRecoveryModule_4(participantRecordClazzName, recoverUid, cnfe);
-                        } catch (InstantiationException ie) {
+                        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                             // this is also worrying, log an error
-                            RecoveryLogger.i18NLogger.error_participant_at_ATParticipantRecoveryModule_5(participantRecordClazzName, recoverUid, ie);
-                        } catch (IllegalAccessException iae) {
-                            // this is another configuration problem, log an error
-                            RecoveryLogger.i18NLogger.error_participant_at_ATParticipantRecoveryModule_5(participantRecordClazzName, recoverUid, iae);
+                            RecoveryLogger.i18NLogger.error_participant_at_ATParticipantRecoveryModule_5(participantRecordClazzName, recoverUid, e);
                         }
                     } catch (IOException ioe) {
                         // hmm, record corrupted? log this as a warning

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/XTSATSubordinateRecoveryModule.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/at/XTSATSubordinateRecoveryModule.java
@@ -40,7 +40,7 @@ public class XTSATSubordinateRecoveryModule implements XTSATRecoveryModule
             ios.setBuffer(recoveryState);
             String className = ios.unpackString();
             Class participantClass =  this.getClass().getClassLoader().loadClass(className);
-            Durable2PCParticipant participant = (Durable2PCParticipant)participantClass.newInstance();
+            Durable2PCParticipant participant = (Durable2PCParticipant)participantClass.getDeclaredConstructor().newInstance();
             ((PersistableParticipant)participant).restoreState(ios);
             return participant;
         }

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/ba/BAParticipantRecoveryModule.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/ba/BAParticipantRecoveryModule.java
@@ -16,6 +16,7 @@ import com.arjuna.ats.arjuna.common.Uid;
 import com.arjuna.ats.internal.arjuna.common.UidHelper;
 import org.jboss.jbossts.xts.recovery.XTSRecoveryModule;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Vector;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -151,7 +152,7 @@ public class BAParticipantRecoveryModule implements XTSRecoveryModule
                         try {
                             // create a participant engine instance and tell it to recover itself
                             Class participantRecordClazz = Class.forName(participantRecordClazzName);
-                            BAParticipantRecoveryRecord participantRecord = (BAParticipantRecoveryRecord)participantRecordClazz.newInstance();
+                            BAParticipantRecoveryRecord participantRecord = (BAParticipantRecoveryRecord)participantRecordClazz.getDeclaredConstructor().newInstance();
                             participantRecord.restoreState(inputState);
                             // ok, now insert into recovery map if needed
                             XTSBARecoveryManager.getRecoveryManager().addParticipantRecoveryRecord(recoverUid, participantRecord);
@@ -160,12 +161,9 @@ public class BAParticipantRecoveryModule implements XTSRecoveryModule
                             // last time and 1.1 this time or vice versa or something is rotten in
                             // the state of Danmark
                             RecoveryLogger.i18NLogger.error_participant_ba_BAParticipantRecoveryModule_4(participantRecordClazzName, recoverUid, cnfe);
-                        } catch (InstantiationException ie) {
+                        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
                             // this is also worrying, log an error
-                            RecoveryLogger.i18NLogger.error_participant_ba_BAParticipantRecoveryModule_5(participantRecordClazzName, recoverUid, ie);
-                        } catch (IllegalAccessException iae) {
-                            // this is another configuration problem, log an error
-                            RecoveryLogger.i18NLogger.error_participant_ba_BAParticipantRecoveryModule_5(participantRecordClazzName, recoverUid, iae);
+                            RecoveryLogger.i18NLogger.error_participant_ba_BAParticipantRecoveryModule_5(participantRecordClazzName, recoverUid, e);
                         }
                     } catch (IOException ioe) {
                         // hmm, record corrupted? log this as a warning

--- a/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/ba/XTSBASubordinateRecoveryModule.java
+++ b/XTS/recovery/src/org/jboss/jbossts/xts/recovery/participant/ba/XTSBASubordinateRecoveryModule.java
@@ -53,7 +53,7 @@ public class XTSBASubordinateRecoveryModule implements XTSBARecoveryModule
             ios.setBuffer(recoveryState);
             String className = ios.unpackString();
             Class participantClass =  this.getClass().getClassLoader().loadClass(className);
-            BusinessAgreementWithCoordinatorCompletionParticipant participant = (BusinessAgreementWithCoordinatorCompletionParticipant)participantClass.newInstance();
+            BusinessAgreementWithCoordinatorCompletionParticipant participant = (BusinessAgreementWithCoordinatorCompletionParticipant)participantClass.getDeclaredConstructor().newInstance();
             ((PersistableParticipant)participant).restoreState(ios);
             return participant;
         }

--- a/XTS/sar/src/org/jboss/jbossts/XTSService.java
+++ b/XTS/sar/src/org/jboss/jbossts/XTSService.java
@@ -55,7 +55,7 @@ public class XTSService implements XTSServiceMBean {
             }
 
             try {
-                XTSInitialisation initialisation = (XTSInitialisation)clazz.newInstance();
+                XTSInitialisation initialisation = (XTSInitialisation)clazz.getDeclaredConstructor().newInstance();
                 initialisation.startup();
                 xtsInitialisations.add(initialisation);
             } catch (InstantiationException ie) {

--- a/common/classes/com/arjuna/common/internal/util/ClassloadingUtility.java
+++ b/common/classes/com/arjuna/common/internal/util/ClassloadingUtility.java
@@ -121,7 +121,7 @@ public class ClassloadingUtility
             }
             if(environmentBeanClass == null && environmentBeanInstanceName == null) {
                 // no bean ctor, try default ctor
-                instance = clazz.newInstance();
+                instance = clazz.getDeclaredConstructor().newInstance();
             }
 
         } catch (InstantiationException | InvocationTargetException e) {
@@ -134,6 +134,14 @@ public class ClassloadingUtility
             commonLogger.logger.warn(message);
         } catch (IllegalAccessException e) {
             String message = commonLogger.i18NLogger.warn_common_ClassloadingUtility_5(className, e);
+            if (failOnError) {
+                if (e.getCause() != null) {
+                    throw new Error(message, e.getCause().fillInStackTrace());
+                }
+            }
+            commonLogger.logger.warn(message);
+        } catch (NoSuchMethodException e) {
+            String message = commonLogger.i18NLogger.warn_common_NoSuchMethodException(className, e);
             if (failOnError) {
                 if (e.getCause() != null) {
                     throw new Error(message, e.getCause().fillInStackTrace());

--- a/common/classes/com/arjuna/common/internal/util/propertyservice/BeanPopulator.java
+++ b/common/classes/com/arjuna/common/internal/util/propertyservice/BeanPopulator.java
@@ -64,7 +64,7 @@ public class BeanPopulator
         if(!beanInstances.containsKey(key)) {
             T bean = null;
             try {
-                bean = beanClass.newInstance();
+                bean = beanClass.getDeclaredConstructor().newInstance();
                 if (properties != null) {
                     configureFromProperties(bean, name, properties);
                 } else {

--- a/common/classes/com/arjuna/common/logging/commonI18NLogger.java
+++ b/common/classes/com/arjuna/common/logging/commonI18NLogger.java
@@ -60,6 +60,9 @@ public interface commonI18NLogger {
     @LogMessage(level = WARN)
     public void warn_common_ClassloadingUtility_6(String arg0, @Cause() Throwable arg1);
 
+    @Message(id = 48009, value = "cannot create new instance of {0} as no zero-argument constructor exists", format = MESSAGE_FORMAT)
+    public String warn_common_NoSuchMethodException(String arg0, @Cause() Throwable arg1);
+
     /*
      * Allocate new messages directly above this notice. - id: use the next id
      * number in sequence. Don't reuse ids. The first two digits of the


### PR DESCRIPTION
ISSUE: https://issues.redhat.com/browse/JBTM-3946

CORE AS_TESTS !RTS !JACOCO XTS QA_JTA QA_JTS_OPENJDKORB !PERFORMANCE !LRA !DB_TESTS