### PR TITLE
[JBTM-3894] Test should fail when there are too many PeriodicRecover's passes

### DIFF
--- a/ArjunaCore/arjuna/tests/byteman-scripts/RecoverySuspendTest/recoverySuspendTest_FailTest.btm
+++ b/ArjunaCore/arjuna/tests/byteman-scripts/RecoverySuspendTest/recoverySuspendTest_FailTest.btm
@@ -38,7 +38,7 @@ ENDRULE
 RULE failIfTooManyRecoveryCycles
 CLASS com.arjuna.ats.internal.arjuna.recovery.PeriodicRecovery
 METHOD suspendScan
-AT EXIT
+AT READ _workLeftToDo
 IF readCounter("recoveryCycles") > 1
 DO throw RuntimeException("[Thrown from Byteman script - PeriodicRecovery] too many recovery cycles (i.e. " +
     readCounter("recoveryCycles") + "), " +


### PR DESCRIPTION
Test should fail when there are too many PeriodicRecover's passes

CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !DB_TESTS