### PR TITLE
JBTM-3881 clear ExtendedResourceRecord cache

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/AbstractRecord.java
@@ -53,6 +53,14 @@ public abstract class AbstractRecord extends StateManager
 	public abstract int typeIs ();
 
 	/**
+	 * Ask the record type to clear any data it has previously cached so that the data may be
+	 * recomputed, for example if a record has determined that an endpoint it needs has failed
+	 * then it might cache that fact and stop using it.
+	 */
+	public void clearAnyCachedData() {
+	}
+
+	/**
 	 * If this abstract record caused a heuristic then it should return an
 	 * object which implements <code>HeuristicInformation</code>
 	 *

--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/BasicAction.java
@@ -2721,6 +2721,10 @@ public class BasicAction extends StateManager
              * dropped if readonly.
              */
             boolean isLastResource = record.typeIs() == RecordType.LASTRESOURCE;
+            if (isLastResource) {
+                record.clearAnyCachedData();
+            }
+
             if (isLastResource && prevLastResource == null) {
                 // remember that we've processed a last resource so that if we have two such last resources
                 // we can detect and report heuristics caused by allowing multiple last resources

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/resources/ExtendedResourceRecord.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/resources/ExtendedResourceRecord.java
@@ -250,6 +250,11 @@ public class ExtendedResourceRecord extends
 		return r;
 	}
 
+	public void clearAnyCachedData() {
+		_cachedType = -1;
+		_endpointFailed = false;
+	}
+
 	public Object value ()
 	{
 		return _resourceHandle;


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3881

CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA QA_JTS_OPENJDKORB !PERFORMANCE !DB_TESTS !mysql !db2 !postgres !oracle !JDK21

ExtendedResourceRecord [caches the record type](https://github.com/jbosstm/narayana/blob/7.2.0.Final/ArjunaJTS/jts/classes/com/arjuna/ats/internal/jts/resources/ExtendedResourceRecord.java#L235) (type_id) which is causing an issue when it is called early in the prepare phase. This fix adds a method to clear the cached value so that the record is treated as a [RecordType.OTS_ABSTRACTRECORD](https://github.com/jbosstm/narayana/blob/7.2.0.Final/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/RecordType.java#L81) (record type151).

This fix that I have chosen for the QE test failure is not the only possible solution but I suspect it is the least invasive one and therefore less risky (my feeling is that the alternative fixes will not be backwardly compatible since they will probably involve changes to what gets stored in the record).