### PR TITLE
BUILD SCRIPT: When definiing a different AS_BRANCH, allow the Narayan…

### DIFF
--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -341,6 +341,8 @@ function clone_as {
     [ -z "$AS_BRANCH" ] || git checkout $AS_BRANCH
     [ $? -eq 0 ] || fatal "git fetch of pull branch failed"
     [ -z "$AS_BRANCH" ] || echo "Using non-default AS_BRANCH: $AS_BRANCH"
+    [ -z "$AS_BRANCH" ] || [ -z "$NARAYANA_FORK_BRANCH_TO_REBASE_ON" ] || git pull --rebase jbosstm $NARAYANA_FORK_BRANCH_TO_REBASE_ON && [ $? -eq 0 ] || fatal "git fetch of pull branch failed"
+    [ -z "$AS_BRANCH" ] || [ -z "$NARAYANA_FORK_BRANCH_TO_REBASE_ON" ] || echo "Rebased AS_BRANCH on jbosstm/jboss-as $NARAYANA_FORK_BRANCH_TO_REBASE_ON"
 
     git fetch upstream
     echo "This is the JBoss-AS commit"

--- a/scripts/hudson/narayana.sh
+++ b/scripts/hudson/narayana.sh
@@ -341,8 +341,11 @@ function clone_as {
     [ -z "$AS_BRANCH" ] || git checkout $AS_BRANCH
     [ $? -eq 0 ] || fatal "git fetch of pull branch failed"
     [ -z "$AS_BRANCH" ] || echo "Using non-default AS_BRANCH: $AS_BRANCH"
-    [ -z "$AS_BRANCH" ] || [ -z "$NARAYANA_FORK_BRANCH_TO_REBASE_ON" ] || git pull --rebase jbosstm $NARAYANA_FORK_BRANCH_TO_REBASE_ON && [ $? -eq 0 ] || fatal "git fetch of pull branch failed"
-    [ -z "$AS_BRANCH" ] || [ -z "$NARAYANA_FORK_BRANCH_TO_REBASE_ON" ] || echo "Rebased AS_BRANCH on jbosstm/jboss-as $NARAYANA_FORK_BRANCH_TO_REBASE_ON"
+    if [ -n "$AS_BRANCH" ] && [ -n "$NARAYANA_FORK_BRANCH_TO_REBASE_ON" ]; then
+        git pull --rebase jbosstm "$NARAYANA_FORK_BRANCH_TO_REBASE_ON" \
+            && echo "Rebased AS_BRANCH on jbosstm/jboss-as $NARAYANA_FORK_BRANCH_TO_REBASE_ON" \
+            || fatal "git pull --rebase failed"
+    fi
 
     git fetch upstream
     echo "This is the JBoss-AS commit"


### PR DESCRIPTION
This pull request allows the caller to further specify the branch name from our fork to rebase on.

As an example, if you have a Narayana pull request (e.g. https://github.com/jbosstm/narayana/pull/2382) that depends on an specific AS pull request in our fork (e.g. https://github.com/jbosstm/jboss-as/pull/99) the script will take the pull "target branch" specified in the AS pull request and rebase it, but that will be directly on WildFly main and thus will not rebase also on our AS fork's branch (in other words the "base branch" in the AS pull request) and thus omit the commits (we presumably need/want) in our fork.

BTW We could consider to hard code `$NARAYANA_FORK_BRANCH_TO_REBASE_ON` to `main` alone if we wanted to instead as we are hardcoding the WildFly branch

CORE AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !DB_TESTS mysql db2 postgres oracle

!JDK21