### PR TITLE
[SCRIPT] GitHub Actions updated

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -3,7 +3,7 @@ name: CORE
 on:
   push:
   pull_request:
-    types: [opened, labeled, unlabeled]
+    types: [ opened, edited, synchronize, ready_for_review, labeled, unlabeled, reopened ]
   workflow_dispatch:
     
 # Only run the latest job


### PR DESCRIPTION
When the author of a PR pushes a new commit, some GH Actions are not triggered. The root cause is that the list of types for `pull_request` should also contain `synchronize`.

NO_TEST