### PR TITLE
Fix 'occured' -> 'occurred' typos across 6 files (18 instances)

### DIFF
--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/utils/jtaxI18NLogger.java
@@ -266,7 +266,7 @@ public interface jtaxI18NLogger {
 	@LogMessage(level = WARN)
 	void warn_could_not_enlist_xar(XAResource xar, Object[] params, @Cause() Exception e1);
 
-	@Message(id = 24062, value = "ORB ''{0}'' occured on one phase commit for xid {1}", format = MESSAGE_FORMAT)
+	@Message(id = 24062, value = "ORB ''{0}'' occurred on one phase commit for xid {1}", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
 	public void warn_jtax_resources_jts_orbspecific_cant_commit_onephase(Xid xid, Class<? extends Throwable> corbaException, @Cause() Throwable e);
 	

--- a/ArjunaJTS/jts/classes/com/arjuna/ats/jts/logging/jtsI18NLogger.java
+++ b/ArjunaJTS/jts/classes/com/arjuna/ats/jts/logging/jtsI18NLogger.java
@@ -306,7 +306,7 @@ public interface jtsI18NLogger {
 	@Message(id = 22093, value = "Cannot create a codec of the required encoding.", format = MESSAGE_FORMAT)
 	public String get_orbspecific_javaidl_interceptors_context_codeccreate();
 
-	@Message(id = 22094, value = "{0} - a failure occured when getting {1} codec - unknown encoding.", format = MESSAGE_FORMAT)
+	@Message(id = 22094, value = "{0} - a failure occurred when getting {1} codec - unknown encoding.", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
 	public void warn_orbspecific_javaidl_interceptors_context_codecerror(String arg0, String arg1, @Cause() Throwable arg2);
 
@@ -331,7 +331,7 @@ public interface jtsI18NLogger {
 	@Message(id = 22100, value = "Cannot create a codec of the required encoding.", format = MESSAGE_FORMAT)
 	public String get_orbspecific_javaidl_interceptors_interposition_codeccreate();
 
-	@Message(id = 22101, value = "{0} - a failure occured when getting {1} codec - unknown encoding.", format = MESSAGE_FORMAT)
+	@Message(id = 22101, value = "{0} - a failure occurred when getting {1} codec - unknown encoding.", format = MESSAGE_FORMAT)
 	@LogMessage(level = WARN)
 	public void warn_orbspecific_javaidl_interceptors_interposition_codecerror(String arg0, String arg1, @Cause() Throwable arg2);
 

--- a/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/ParticipantRecord.java
+++ b/XTS/WSCF/classes/com/arjuna/mwlabs/wscf/model/sagas/arjunacore/ParticipantRecord.java
@@ -198,19 +198,19 @@ public class ParticipantRecord extends
 				}
                 catch (WrongStateException ex)
                 {
-                    // this indicates a fail occured and was detected during cancel (or compensation?) so we return a
+                    // this indicates a fail occurred and was detected during cancel (or compensation?) so we return a
                     // HEURISTIC_HAZARD which will place the participant in the heuristic list
                     return TwoPhaseOutcome.HEURISTIC_HAZARD;
                 }
                 catch (CancelFailedException ex)
                 {
-                    // this indicates a fail occured and was detected during cancel so we return a HEURISTIC_HAZARD
+                    // this indicates a fail occurred and was detected during cancel so we return a HEURISTIC_HAZARD
                     // which will place the participant in the heuristic list
                     return TwoPhaseOutcome.HEURISTIC_HAZARD;
                 }
                 catch (CompensateFailedException ex)
                 {
-                    // this indicates a fail occured during compensation so we return a HEURISTIC_HAZARD
+                    // this indicates a fail occurred during compensation so we return a HEURISTIC_HAZARD
                     // which will place the participant in the heuristic list
                     return TwoPhaseOutcome.HEURISTIC_HAZARD;
                 }

--- a/qa/tests/src/org/jboss/jbossts/qa/ArjunaCore/StateManager/impl/BasicStateRecord.java
+++ b/qa/tests/src/org/jboss/jbossts/qa/ArjunaCore/StateManager/impl/BasicStateRecord.java
@@ -52,7 +52,7 @@ public class BasicStateRecord extends StateManager
 
 	/**
 	 * This constructor will be used to recreate an object after a
-	 * crash has occured.
+	 * crash has occurred.
 	 */
 	public BasicStateRecord(Uid oldId)
 	{

--- a/rts/at/tx/src/main/java/org/jboss/jbossts/star/client/ServerSRAFilter.java
+++ b/rts/at/tx/src/main/java/org/jboss/jbossts/star/client/ServerSRAFilter.java
@@ -329,7 +329,7 @@ public class ServerSRAFilter implements ContainerRequestFilter, ContainerRespons
 //                if (failureMessage != null) {
 //                    SRALogger.logger.warn(failureMessage);
 //
-//                    // the actual failure(s) will also have been added to the i18NLogger logs at the time they occured
+//                    // the actual failure(s) will also have been added to the i18NLogger logs at the time they occurred
 //                    responseContext.setEntity(failureMessage, null, MediaType.TEXT_PLAIN_TYPE);
 //                }
 //            }

--- a/rts/at/util/src/main/java/org/jboss/jbossts/star/logging/atI18NLogger.java
+++ b/rts/at/util/src/main/java/org/jboss/jbossts/star/logging/atI18NLogger.java
@@ -67,43 +67,43 @@ public interface atI18NLogger {
     void warn_isInStoreInboundBridgeOrphanFilter(@Cause Throwable t);
 
     @LogMessage(level = WARN)
-    @Message(id = 27010, value = "XAException occured while subordinate rollback. '%s'")
+    @Message(id = 27010, value = "XAException occurred while subordinate rollback. '%s'")
     void warn_subordinateRollbackXAException(String cause, @Cause XAException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 27011, value = "XAException occured while subordinate commit. '%s'")
+    @Message(id = 27011, value = "XAException occurred while subordinate commit. '%s'")
     void warn_subordinateCommitXAException(String cause, @Cause XAException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 27012, value = "XAException occured while subordinate vote. '%s'")
+    @Message(id = 27012, value = "XAException occurred while subordinate vote. '%s'")
     void warn_subordinateVoteXAException(String cause, @Cause XAException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 27013, value = "XAException occured while InboundBridgeRecoveryModule periodicWorkSecondPass. '%s'")
+    @Message(id = 27013, value = "XAException occurred while InboundBridgeRecoveryModule periodicWorkSecondPass. '%s'")
     void warn_inboundBridgeRecoveryModulePeriodicWorkSecondPass(String cause, @Cause XAException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 27014, value = "XAException occured while InboundBridgeRecoveryModule addBridgesToMapping. '%s'")
+    @Message(id = 27014, value = "XAException occurred while InboundBridgeRecoveryModule addBridgesToMapping. '%s'")
     void warn_inboundBridgeRecoveryModuleAddBridgesToMapping(String cause, @Cause XAException e);
 
     @LogMessage(level = WARN)
-    @Message(id = 27015, value = "Exception occured while InboundBridgeRecoveryModule getUidsToRecover. '%s'")
+    @Message(id = 27015, value = "Exception occurred while InboundBridgeRecoveryModule getUidsToRecover. '%s'")
     void warn_InboundBridgeRecoveryModulegetUidsToRecover(String cause, @Cause Throwable t);
 
     @LogMessage(level = WARN)
-    @Message(id = 27016, value = "Exception occured while Tx Support getIntValue. '%s'")
+    @Message(id = 27016, value = "Exception occurred while Tx Support getIntValue. '%s'")
     void warn_txSupportGetIntValue(String cause, @Cause Throwable t);
 
     @LogMessage(level = DEBUG)
-    @Message(id = 27017, value = "Exception occured while Tx Support HttpRequest. '%s'")
+    @Message(id = 27017, value = "Exception occurred while Tx Support HttpRequest. '%s'")
     void info_txSupportHttpRequest(String cause, @Cause Throwable t);
 
     @LogMessage(level = WARN)
-    @Message(id = 27018, value = "Exception occured while Tx Support AddLocationHeader. '%s'")
+    @Message(id = 27018, value = "Exception occurred while Tx Support AddLocationHeader. '%s'")
     void warn_txSupportAddLocationHeader(String cause, @Cause Throwable t);
 
     @LogMessage(level = WARN)
-    @Message(id = 27019, value = "Exception occured while InboundBridgeParticipantDeserializer Participant deserialize. '%s'")
+    @Message(id = 27019, value = "Exception occurred while InboundBridgeParticipantDeserializer Participant deserialize. '%s'")
     void warn_deserializeInboundBridgeParticipantDeserializer(String cause, @Cause Throwable t);
 
     @LogMessage(level = WARN)


### PR DESCRIPTION
Fix 18 instances of `occured` → `occurred` across 6 files.

| File | Instances |
|------|-----------|
| `atI18NLogger.java` | 10 |
| `ParticipantRecord.java` | 3 |
| `jtsI18NLogger.java` | 2 |
| `ServerSRAFilter.java` | 1 |
| `jtaxI18NLogger.java` | 1 |
| `BasicStateRecord.java` | 1 |

For the `I18NLogger` files the `@Message` ID is what drives translation lookup; only the English `value` strings are corrected. No message ID changes.