### PR TITLE
JBTM-4037 disable cluster rebalance verification

### DIFF
--- a/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/objectstore/infinispan/InfinispanGrouperTest.java
+++ b/ArjunaCore/arjuna/tests/classes/com/hp/mwtests/ts/arjuna/objectstore/infinispan/InfinispanGrouperTest.java
@@ -315,28 +315,6 @@ public class InfinispanGrouperTest extends InfinispanTestBase {
             }
         }
 
-        /*
-         * verify that a new primary is selected if the current one is down
-         */
-
-        // stop the primary
-        primaryStore.stop();
-
-        // a new primary store should be chosen since the old one was removed from the cluster when we stopped it:
-        // wait for the cluster to rebalance
-        int maxRetries = 5;
-        String newPrimary = waitForTopologyChange(maxRetries, primary, dm, aKey);
-
-        Assertions.assertNotEquals(primary, newPrimary);
-
-        for (Store s : stores) {
-            // make sure we don't try accessing the cache we just stopped
-            if (s.manager().isRunning(s.cache().getName())) {
-                Assertions.assertEquals(0, s.manager().getCache(CLUSTER_NAME).size());
-                store.stop();
-            }
-        }
-
         recoveryStore.stop();
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-4037
JDK25 CORE

I [updated](https://redhat.atlassian.net/browse/JBTM-4037?focusedCommentId=17127050) the issue tracker indicating that the cluster re-balance failed on another GH Action run even with the backoff. I’m reluctant to keep extending the wait time so I have removed the verification of cluster re-balancing while I investigate alternative ways of testing it.

