### PR TITLE
[JBTM-4043] Implemented readOnly transactions

### DIFF
--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionManager.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionManager.java
@@ -78,6 +78,24 @@ public abstract class DelegatingTransactionManager implements Serializable, Tran
   }
 
   /**
+   * Creates a new readOnly transaction and associates it with the current thread.
+   *
+   * @exception NotSupportedException if the thread is already
+   * associated with a transaction and this {@link TransactionManager}
+   * implementation does not support nested transactions
+   *
+   * @exception SystemException if this {@link TransactionManager}
+   * encounters an unexpected error condition
+   */
+  @Override
+  public void begin(boolean readOnly) throws NotSupportedException, SystemException {
+    if (this.delegate == null) {
+      throw new SystemException("delegate == null");
+    }
+    this.delegate.begin(readOnly);
+  }
+
+  /**
    * Completes the transaction associated with the current thread.
    *
    * <p>When this method completes, the thread is no longer associated

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionManager.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionManager.java
@@ -18,6 +18,8 @@ import jakarta.transaction.SystemException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 
+import com.arjuna.ats.internal.jta.utils.ReadOnlyTransactionSupport;
+
 /**
  * An {@code abstract} {@link TransactionManager} implementation that
  * delegates all method invocations to another {@link
@@ -87,12 +89,13 @@ public abstract class DelegatingTransactionManager implements Serializable, Tran
    * @exception SystemException if this {@link TransactionManager}
    * encounters an unexpected error condition
    */
-  @Override
+  // no @Override: TransactionManager only declares begin(boolean) from
+  // jakarta.transaction-api 2.0.2, and narayana compiles against 2.0.1
   public void begin(boolean readOnly) throws NotSupportedException, SystemException {
     if (this.delegate == null) {
       throw new SystemException("delegate == null");
     }
-    this.delegate.begin(readOnly);
+    ReadOnlyTransactionSupport.begin(this.delegate, readOnly);
   }
 
   /**

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionSynchronizationRegistry.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionSynchronizationRegistry.java
@@ -311,4 +311,12 @@ public abstract class DelegatingTransactionSynchronizationRegistry implements Se
         return this.delegate.getRollbackOnly();
     }
 
+    @Override
+    public boolean isReadOnly() {
+        if (this.delegate == null) {
+            throw new IllegalStateException("delegate == null");
+        }
+        return this.delegate.isReadOnly();
+    }
+
 }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionSynchronizationRegistry.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/DelegatingTransactionSynchronizationRegistry.java
@@ -15,6 +15,8 @@ import jakarta.transaction.Transaction; // for javadoc only
 import jakarta.transaction.TransactionManager; // for javadoc only
 import jakarta.transaction.TransactionSynchronizationRegistry;
 
+import com.arjuna.ats.internal.jta.utils.ReadOnlyTransactionSupport;
+
 /**
  * An {@code abstract} {@link TransactionSynchronizationRegistry}
  * implementation that delegates all method invocations to another
@@ -311,12 +313,13 @@ public abstract class DelegatingTransactionSynchronizationRegistry implements Se
         return this.delegate.getRollbackOnly();
     }
 
-    @Override
+    // no @Override: TransactionSynchronizationRegistry only declares isReadOnly()
+    // from jakarta.transaction-api 2.0.2, and narayana compiles against 2.0.1
     public boolean isReadOnly() {
         if (this.delegate == null) {
             throw new IllegalStateException("delegate == null");
         }
-        return this.delegate.isReadOnly();
+        return ReadOnlyTransactionSupport.isReadOnly(this.delegate);
     }
 
 }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/NarayanaTransactionManager.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/NarayanaTransactionManager.java
@@ -277,6 +277,14 @@ class NarayanaTransactionManager extends DelegatingTransactionManager {
     }
   }
 
+  @Override
+  public void begin(boolean readOnly) throws NotSupportedException, SystemException {
+    super.begin(readOnly);
+    if (this.transactionScopeInitializedBroadcaster != null) {
+      this.transactionScopeInitializedBroadcaster.fire(this.getTransaction());
+    }
+  }
+
   /**
    * Overrides {@link DelegatingTransactionManager#commit()} to
    * additionally {@linkplain Event#fire(Object) fire} an {@link Object} representing

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionHandler.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionHandler.java
@@ -60,8 +60,8 @@ public final class TransactionHandler {
             if (tx != tm.getTransaction()) {
                 throw new RuntimeException(jtaLogger.i18NLogger.get_wrong_tx_on_thread());
             }
-
-            if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK) {
+            // a read-only transaction can only roll back
+            if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK || tx.isReadOnly()) {
                 tm.rollback();
             } else {
                 tm.commit();

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionHandler.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/TransactionHandler.java
@@ -6,6 +6,7 @@
 
 package com.arjuna.ats.jta.cdi;
 
+import com.arjuna.ats.internal.jta.utils.ReadOnlyTransactionSupport;
 import com.arjuna.ats.jta.logging.jtaLogger;
 
 import jakarta.transaction.Status;
@@ -60,8 +61,10 @@ public final class TransactionHandler {
             if (tx != tm.getTransaction()) {
                 throw new RuntimeException(jtaLogger.i18NLogger.get_wrong_tx_on_thread());
             }
-            // a read-only transaction can only roll back
-            if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK || tx.isReadOnly()) {
+            // a read-only transaction can only roll back; isReadOnly is accessed
+            // reflectively because narayana compiles against jakarta.transaction-api
+            // 2.0.1, which does not have it
+            if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK || ReadOnlyTransactionSupport.isReadOnly(tx)) {
                 tm.rollback();
             } else {
                 tm.commit();

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
@@ -7,6 +7,7 @@
 package com.arjuna.ats.jta.cdi.transactional;
 
 
+import com.arjuna.ats.internal.jta.utils.ReadOnlyTransactionSupport;
 import com.arjuna.ats.jta.cdi.SneakyThrow;
 import com.arjuna.ats.jta.cdi.TransactionExtension;
 import com.arjuna.ats.jta.cdi.async.ContextPropagationAsyncHandler;
@@ -175,7 +176,10 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     protected Object invokeInOurTx(InvocationContext ic, TransactionManager tm, RunnableWithException afterEndTransaction) throws Exception {
         Transactional transactional = getTransactional(ic);
 
-        tm.begin(transactional.isReadOnly());
+        // The read-only API (Transactional.isReadOnly, TransactionManager.begin(boolean))
+        // is accessed reflectively because narayana compiles against
+        // jakarta.transaction-api 2.0.1, which does not have it.
+        ReadOnlyTransactionSupport.begin(tm, ReadOnlyTransactionSupport.isReadOnly(transactional));
         Transaction tx = tm.getTransaction();
 
         boolean throwing = false;
@@ -205,10 +209,12 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     protected Object invokeInCallerTx(InvocationContext ic, Transaction tx) throws Exception {
         // Only propagating modes (REQUIRED, MANDATORY, SUPPORTS) call this path.
         // Validate that the active transaction's read-only flag matches the annotation.
-        Transactional transactional = getTransactional(ic);
-        if (tx.isReadOnly() != transactional.isReadOnly()) {
+        // Accessed reflectively (see invokeInOurTx); with the 2.0.1 API both values
+        // are always false, so the check passes.
+        boolean annotationReadOnly = ReadOnlyTransactionSupport.isReadOnly(getTransactional(ic));
+        if (ReadOnlyTransactionSupport.isReadOnly(tx) != annotationReadOnly) {
             throw new TransactionalException(
-                    "The isReadOnly value of the @Transactional annotation (" + transactional.isReadOnly()
+                    "The isReadOnly value of the @Transactional annotation (" + annotationReadOnly
                             + ") does not match the read-only mode of the transaction context",
                     new InvalidTransactionException());
         }

--- a/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
+++ b/ArjunaJTA/cdi/classes/com/arjuna/ats/jta/cdi/transactional/TransactionalInterceptorBase.java
@@ -22,9 +22,12 @@ import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.inject.Inject;
 import jakarta.interceptor.InvocationContext;
+import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.Transaction;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.Transactional;
+import jakarta.transaction.TransactionalException;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.security.PrivilegedAction;
@@ -170,8 +173,9 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     }
 
     protected Object invokeInOurTx(InvocationContext ic, TransactionManager tm, RunnableWithException afterEndTransaction) throws Exception {
+        Transactional transactional = getTransactional(ic);
 
-        tm.begin();
+        tm.begin(transactional.isReadOnly());
         Transaction tx = tm.getTransaction();
 
         boolean throwing = false;
@@ -186,7 +190,7 @@ public abstract class TransactionalInterceptorBase implements Serializable {
             AtomicReference<Object> retRef = new AtomicReference<>(ret);
             boolean asyncReturnType =
                     ContextPropagationAsyncHandler.tryHandleAsynchronously(
-                            tm, tx, getTransactional(ic), retRef, ic.getMethod().getReturnType(), afterEndTransaction);
+                            tm, tx, transactional, retRef, ic.getMethod().getReturnType(), afterEndTransaction);
             if (throwing || ret == null || !asyncReturnType) {
                 // is throwing (OR) is null (OR) is not asynchronous type (OR) no async handler classes on classpath : handle synchronously
                 TransactionHandler.endTransaction(tm, tx, afterEndTransaction);
@@ -199,6 +203,15 @@ public abstract class TransactionalInterceptorBase implements Serializable {
     }
 
     protected Object invokeInCallerTx(InvocationContext ic, Transaction tx) throws Exception {
+        // Only propagating modes (REQUIRED, MANDATORY, SUPPORTS) call this path.
+        // Validate that the active transaction's read-only flag matches the annotation.
+        Transactional transactional = getTransactional(ic);
+        if (tx.isReadOnly() != transactional.isReadOnly()) {
+            throw new TransactionalException(
+                    "The isReadOnly value of the @Transactional annotation (" + transactional.isReadOnly()
+                            + ") does not match the read-only mode of the transaction context",
+                    new InvalidTransactionException());
+        }
 
         try {
             return ic.proceed();

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/AddReadOnlyTransactionalExtension.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/AddReadOnlyTransactionalExtension.java
@@ -1,0 +1,24 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.readonly;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+
+import com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension.AnnotatedTypeWrapper;
+
+/**
+ * Adds a read-only Transactional annotation to {@link ReadOnlyBean}.
+ */
+public class AddReadOnlyTransactionalExtension implements Extension {
+
+    void processAnnotatedType(@Observes ProcessAnnotatedType<ReadOnlyBean> bean) {
+        AnnotatedTypeWrapper<ReadOnlyBean> wrapper = new AnnotatedTypeWrapper<ReadOnlyBean>(bean);
+        wrapper.addAnnotation(new ReadOnlyTransactionalLiteral());
+        bean.setAnnotatedType(wrapper);
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyBean.java
@@ -1,0 +1,54 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.readonly;
+
+import jakarta.annotation.Resource;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+
+/**
+ * Deliberately not annotated with Transactional: the
+ * {@link AddReadOnlyTransactionalExtension} adds a read-only
+ * {@link ReadOnlyTransactionalLiteral} at deployment time (writing
+ * Transactional(isReadOnly = true) in source would not compile against
+ * jakarta.transaction-api 2.0.1).
+ */
+public class ReadOnlyBean {
+
+    /** Completion status observed by the last transactional invocation. */
+    public static volatile int completionStatus = -1;
+
+    @Resource
+    private TransactionSynchronizationRegistry tsr;
+
+    public static void reset() {
+        completionStatus = -1;
+    }
+
+    public void run() {
+        if (tsr.getTransactionStatus() != Status.STATUS_ACTIVE) {
+            throw new IllegalStateException("expected an active transaction");
+        }
+
+        tsr.registerInterposedSynchronization(new Synchronization() {
+            @Override
+            public void beforeCompletion() {
+            }
+
+            @Override
+            public void afterCompletion(int status) {
+                completionStatus = status;
+            }
+        });
+    }
+
+    public void runWithoutSynchronization() {
+        if (tsr.getTransactionStatus() != Status.STATUS_ACTIVE) {
+            throw new IllegalStateException("expected an active transaction");
+        }
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyDummyBean.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyDummyBean.java
@@ -1,0 +1,18 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.readonly;
+
+import jakarta.transaction.Transactional;
+
+/**
+ * A Transactional bean visible to the WildFly deployment processor so the
+ * Narayana transactional interceptors are activated for the deployment; the
+ * annotation on {@link ReadOnlyBean} itself is only added by extension, which
+ * the processor does not see (same trick as the stereotype extension tests).
+ */
+@Transactional
+public class ReadOnlyDummyBean {
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyTransactionalLiteral.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyTransactionalLiteral.java
@@ -1,0 +1,39 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.readonly;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.transaction.Transactional;
+
+/**
+ * A Transactional literal marked read-only. The isReadOnly method is
+ * deliberately not annotated with @Override so this compiles whether or not
+ * the Transactional interface declares it (it only does from
+ * jakarta.transaction-api 2.0.2); the interceptor only sees the value when
+ * the runtime API declares the method.
+ */
+class ReadOnlyTransactionalLiteral extends AnnotationLiteral<Transactional> implements Transactional {
+
+    @Override
+    public TxType value() {
+        return TxType.REQUIRED;
+    }
+
+    @Override
+    public Class[] rollbackOn() {
+        return new Class[] {};
+    }
+
+    @Override
+    public Class[] dontRollbackOn() {
+        return new Class[] {};
+    }
+
+    public boolean isReadOnly() {
+        return true;
+    }
+
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyTransactionalTest.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/readonly/ReadOnlyTransactionalTest.java
@@ -1,0 +1,115 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.cdi.transactional.readonly;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Status;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.TransactionalException;
+import jakarta.transaction.UserTransaction;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.hp.mwtests.ts.jta.cdi.transactional.stereotype.extension.AnnotatedTypeWrapper;
+
+/**
+ * Behaviour of a bean whose Transactional annotation is read-only (added by
+ * extension, since the attribute cannot be written in source against
+ * jakarta.transaction-api 2.0.1).
+ *
+ * Expectations are keyed off the transaction API available at runtime in the
+ * container: with the read-only API (2.0.2+) a read-only method's transaction
+ * can only roll back and a propagation mismatch is rejected; without it the
+ * read-only marker is invisible and behaviour is exactly that of a plain
+ * REQUIRED method. The same tests therefore stay valid before and after the
+ * EE11 API bump.
+ */
+@RunWith(Arquillian.class)
+public class ReadOnlyTransactionalTest {
+
+    @Inject
+    ReadOnlyBean bean;
+
+    @Inject
+    UserTransaction userTransaction;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class, "readonly-test.war")
+                .addPackage(ReadOnlyTransactionalTest.class.getPackage())
+                .addClass(AnnotatedTypeWrapper.class)
+                .addAsWebInfResource(new StringAsset("<beans bean-discovery-mode=\"all\"></beans>"), "beans.xml")
+                .addAsServiceProvider(jakarta.enterprise.inject.spi.Extension.class, AddReadOnlyTransactionalExtension.class);
+    }
+
+    @After
+    public void tearDown() {
+        ReadOnlyBean.reset();
+        try {
+            userTransaction.rollback();
+        } catch (Exception e) {
+            // do nothing
+        }
+    }
+
+    @Test
+    public void testReadOnlyMethodCompletesWithRollback() throws Exception {
+        ReadOnlyBean.reset();
+
+        bean.run();
+
+        // a read-only transaction can only roll back; without the read-only
+        // API the marker is invisible and the transaction commits
+        int expected = readOnlyApiPresent() ? Status.STATUS_ROLLEDBACK : Status.STATUS_COMMITTED;
+
+        Assert.assertEquals(expected, ReadOnlyBean.completionStatus);
+
+        Assert.assertEquals(Status.STATUS_NO_TRANSACTION, userTransaction.getStatus());
+    }
+
+    @Test
+    public void testReadOnlyMismatchWithCallerTransaction() throws Exception {
+        userTransaction.begin();
+
+        try {
+            if (readOnlyApiPresent()) {
+                try {
+                    bean.runWithoutSynchronization();
+
+                    Assert.fail("a read-only method joining a read-write transaction must throw TransactionalException");
+                } catch (TransactionalException e) {
+                    // expected
+                }
+            } else {
+                // without the read-only API both flags read false, so the
+                // method simply joins the caller's transaction
+                bean.runWithoutSynchronization();
+            }
+
+            Assert.assertEquals(Status.STATUS_ACTIVE, userTransaction.getStatus());
+        } finally {
+            userTransaction.rollback();
+        }
+    }
+
+    private static boolean readOnlyApiPresent() {
+        try {
+            Transactional.class.getMethod("isReadOnly");
+
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+}

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalLiteral.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalLiteral.java
@@ -26,7 +26,8 @@ class TransactionalLiteral extends AnnotationLiteral<Transactional> implements T
         return new Class[] {};
     }
 
-    @Override
+    // no @Override: Transactional only declares isReadOnly() from
+    // jakarta.transaction-api 2.0.2, and narayana compiles against 2.0.1
     public boolean isReadOnly() {
         return false;
     }

--- a/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalLiteral.java
+++ b/ArjunaJTA/cdi/tests/classes/com/hp/mwtests/ts/jta/cdi/transactional/stereotype/extension/TransactionalLiteral.java
@@ -26,4 +26,9 @@ class TransactionalLiteral extends AnnotationLiteral<Transactional> implements T
         return new Class[] {};
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/BaseTransaction.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/BaseTransaction.java
@@ -30,6 +30,12 @@ public class BaseTransaction
 	public void begin() throws jakarta.transaction.NotSupportedException,
 			jakarta.transaction.SystemException
 	{
+		begin(false);
+	}
+
+	public void begin(boolean readOnly) throws jakarta.transaction.NotSupportedException,
+			jakarta.transaction.SystemException
+	{
 		if (jtaLogger.logger.isTraceEnabled()) {
             jtaLogger.logger.trace("BaseTransaction.begin");
         }
@@ -73,7 +79,7 @@ public class BaseTransaction
 
 		// TODO set default timeout
 
-		TransactionImple.putTransaction(new TransactionImple(v));
+		TransactionImple.putTransaction(new TransactionImple(v, readOnly));
 	}
 
 	/**

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -21,6 +21,7 @@ import com.arjuna.ats.arjuna.coordinator.RecordType;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
+import jakarta.transaction.xa.ExtendedXAResource;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -87,6 +88,17 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 
         _txLocalResources = Collections.synchronizedMap(new HashMap());
     }
+
+	/**
+	 * Create a new transaction with the specified timeout and read-only mode.
+	 */
+
+	public TransactionImple(int timeout, boolean readOnly)
+	{
+		this(timeout);
+
+		_readOnly = readOnly;
+	}
 
 	/**
 	 * Overloads Object.equals()
@@ -170,6 +182,18 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 				break;
 			default:
 				throw new IllegalStateException( jtaLogger.i18NLogger.get_transaction_arjunacore_inactive(_theTransaction.get_uid()) );
+			}
+
+			/*
+			 * The only possible outcome of a read-only transaction is rollback.
+			 */
+
+			if (_readOnly)
+			{
+				rollback();
+
+				throw new RollbackException(
+						jtaLogger.i18NLogger.get_transaction_arjunacore_readonly());
 			}
 
 			/*
@@ -609,6 +633,15 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 
 				while (!associatedWork)
 				{
+					/*
+					 * If the transaction is read-only, tell the resource before
+					 * xa_start. This is done outside the try block below so that
+					 * an XAException from setReadOnly is not mistaken for an XID
+					 * collision and retried.
+					 */
+
+					setResourceReadOnly(xaRes, xid);
+
 					try
 					{
 						if (_xaTransactionTimeoutEnabled)
@@ -731,6 +764,10 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 
 				xid = existingRM.xid();
 
+				// if the transaction is read-only, tell the resource before xa_start
+
+				setResourceReadOnly(xaRes, xid);
+
 				try
 				{
 					int xaStartJoin = ((theModifier == null) ? XAResource.TMJOIN
@@ -774,6 +811,32 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 			markRollbackOnly();
 
 			return false;
+		}
+	}
+
+	/**
+	 * If this transaction is read-only, attempt to put the resource into
+	 * read-only mode. The spec requires this to be attempted before the
+	 * resource is started via xa_start, at most once for a given Xid.
+	 *
+	 * If the resource does not implement ExtendedXAResource, or setReadOnly
+	 * returns false, the resource cannot be put into read-only mode. That is
+	 * not an error and must not mark the transaction rollback-only: the
+	 * resource will simply be rolled back when the transaction completes,
+	 * since the only possible outcome of a read-only transaction is rollback.
+	 */
+	private void setResourceReadOnly (XAResource xaRes, Xid xid)
+			throws XAException
+	{
+		if (_readOnly && (xaRes instanceof ExtendedXAResource))
+		{
+			if (!((ExtendedXAResource) xaRes).setReadOnly(xid))
+			{
+				if (jtaLogger.logger.isTraceEnabled()) {
+					jtaLogger.logger.trace("TransactionImple.setResourceReadOnly - resource declined read-only mode: "
+							+ xaRes);
+				}
+			}
 		}
 	}
 
@@ -1293,6 +1356,27 @@ public class TransactionImple implements jakarta.transaction.Transaction,
             jtaLogger.logger.trace("TransactionImple.commitAndDisassociate");
         }
 
+		/*
+		 * The only possible outcome of a read-only transaction is rollback.
+		 */
+
+		if (_readOnly)
+		{
+			RollbackException rollbackException = new RollbackException(
+					jtaLogger.i18NLogger.get_transaction_arjunacore_readonly());
+
+			try
+			{
+				rollbackAndDisassociate();
+			}
+			catch (Exception e)
+			{
+				rollbackException.addSuppressed(e);
+			}
+
+			throw rollbackException;
+		}
+
 		try
 		{
 			if (_theTransaction != null)
@@ -1738,6 +1822,11 @@ public class TransactionImple implements jakarta.transaction.Transaction,
         return Collections.EMPTY_MAP;
     }
 
+    public boolean isReadOnly()
+    {
+        return _readOnly;
+    }
+
     protected com.arjuna.ats.arjuna.AtomicAction _theTransaction;
 
 	private Hashtable _resources;
@@ -1778,4 +1867,6 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 			.getCommitMarkableResourceJNDINames();
 
 	private static final boolean STRICTJTA12DUPLICATEXAENDPROTOERR = jtaPropertyManager.getJTAEnvironmentBean().isStrictJTA12DuplicateXAENDPROTOErr();
+
+	private boolean _readOnly = false;
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -8,6 +8,8 @@
 package com.arjuna.ats.internal.jta.transaction.arjunacore;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -21,7 +23,6 @@ import com.arjuna.ats.arjuna.coordinator.RecordType;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
-import jakarta.transaction.xa.ExtendedXAResource;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -824,13 +825,47 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 	 * not an error and must not mark the transaction rollback-only: the
 	 * resource will simply be rolled back when the transaction completes,
 	 * since the only possible outcome of a read-only transaction is rollback.
+	 *
+	 * ExtendedXAResource is loaded and invoked reflectively so that this class
+	 * still links against jakarta.transaction-api versions that do not have it.
 	 */
 	private void setResourceReadOnly (XAResource xaRes, Xid xid)
 			throws XAException
 	{
-		if (_readOnly && (xaRes instanceof ExtendedXAResource))
+		if (_readOnly && (EXTENDED_XA_RESOURCE_INTERFACE != null)
+				&& EXTENDED_XA_RESOURCE_INTERFACE.isInstance(xaRes))
 		{
-			if (!((ExtendedXAResource) xaRes).setReadOnly(xid))
+			boolean accepted;
+
+			try
+			{
+				accepted = (Boolean) EXTENDED_XA_RESOURCE_SET_READ_ONLY.invoke(xaRes, xid);
+			}
+			catch (InvocationTargetException e)
+			{
+				if (e.getCause() instanceof XAException)
+				{
+					throw (XAException) e.getCause();
+				}
+
+				if (e.getCause() instanceof RuntimeException)
+				{
+					throw (RuntimeException) e.getCause();
+				}
+
+				if (e.getCause() instanceof Error)
+				{
+					throw (Error) e.getCause();
+				}
+
+				throw new RuntimeException(e.getCause());
+			}
+			catch (IllegalAccessException e)
+			{
+				throw new RuntimeException(e);
+			}
+
+			if (!accepted)
 			{
 				if (jtaLogger.logger.isTraceEnabled()) {
 					jtaLogger.logger.trace("TransactionImple.setResourceReadOnly - resource declined read-only mode: "
@@ -1869,4 +1904,34 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 	private static final boolean STRICTJTA12DUPLICATEXAENDPROTOERR = jtaPropertyManager.getJTAEnvironmentBean().isStrictJTA12DuplicateXAENDPROTOErr();
 
 	private boolean _readOnly = false;
+
+	/*
+	 * jakarta.transaction.xa.ExtendedXAResource is loaded reflectively: it only
+	 * exists from jakarta.transaction-api 2.0.2, and read-only resource support
+	 * is unavailable when running against an older version of the API.
+	 */
+
+	private static final Class<?> EXTENDED_XA_RESOURCE_INTERFACE;
+
+	private static final Method EXTENDED_XA_RESOURCE_SET_READ_ONLY;
+
+	static
+	{
+		Class<?> extendedXAResource = null;
+		Method setReadOnly = null;
+
+		try
+		{
+			extendedXAResource = Class.forName("jakarta.transaction.xa.ExtendedXAResource");
+			setReadOnly = extendedXAResource.getMethod("setReadOnly", Xid.class);
+		}
+		catch (ClassNotFoundException | NoSuchMethodException | LinkageError e)
+		{
+			extendedXAResource = null;
+			setReadOnly = null;
+		}
+
+		EXTENDED_XA_RESOURCE_INTERFACE = extendedXAResource;
+		EXTENDED_XA_RESOURCE_SET_READ_ONLY = setReadOnly;
+	}
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionSynchronizationRegistryImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionSynchronizationRegistryImple.java
@@ -216,4 +216,8 @@ public class TransactionSynchronizationRegistryImple implements TransactionSynch
 
         return transactionImple;
     }
+
+    public boolean isReadOnly() {
+        return getTransactionImple().isReadOnly();
+    }
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/UserTransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/UserTransactionImple.java
@@ -34,4 +34,12 @@ public class UserTransactionImple extends BaseTransaction
     {
         return new Reference(this.getClass().getCanonicalName(), this.getClass().getCanonicalName(), null);
     }
+
+    public boolean isReadOnly()
+    {
+        TransactionImple tx = TransactionImple.getTransaction();
+
+        // if no transaction is associated with the current thread, return false
+        return (tx != null) && tx.isReadOnly();
+    }
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/utils/ReadOnlyTransactionSupport.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/utils/ReadOnlyTransactionSupport.java
@@ -1,0 +1,196 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.arjuna.ats.internal.jta.utils;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.Transactional;
+
+/**
+ * Reflective access to the read-only transaction API introduced in
+ * jakarta.transaction-api 2.0.2 ({@code TransactionManager#begin(boolean)},
+ * {@code Transaction#isReadOnly()}, {@code Transactional#isReadOnly()} and
+ * {@code TransactionSynchronizationRegistry#isReadOnly()}).
+ *
+ * Narayana is compiled against jakarta.transaction-api 2.0.1, which does not
+ * have any of that API, so it can never be referenced directly. All access
+ * goes through this class: when the API is not present on the classpath the
+ * read-only feature is simply unavailable and every query here reports
+ * {@code false}.
+ */
+public final class ReadOnlyTransactionSupport
+{
+    private static final Method TRANSACTIONAL_IS_READ_ONLY = getMethod(Transactional.class, "isReadOnly");
+
+    private static final Method TRANSACTION_IS_READ_ONLY = getMethod(Transaction.class, "isReadOnly");
+
+    private static final Method TSR_IS_READ_ONLY = getMethod(TransactionSynchronizationRegistry.class, "isReadOnly");
+
+    private static final Method TM_BEGIN_READ_ONLY = getMethod(TransactionManager.class, "begin", boolean.class);
+
+    private ReadOnlyTransactionSupport()
+    {
+    }
+
+    /**
+     * The value of the annotation's {@code isReadOnly} attribute, or false if
+     * the API in use does not have that attribute.
+     */
+    public static boolean isReadOnly (Transactional transactional)
+    {
+        if (TRANSACTIONAL_IS_READ_ONLY == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return (Boolean) TRANSACTIONAL_IS_READ_ONLY.invoke(transactional);
+        }
+        catch (InvocationTargetException e)
+        {
+            throw rethrowUnchecked(e.getCause());
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Whether the given transaction is read-only, or false if the API in use
+     * does not support read-only transactions.
+     */
+    public static boolean isReadOnly (Transaction tx) throws SystemException
+    {
+        if (TRANSACTION_IS_READ_ONLY == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return (Boolean) TRANSACTION_IS_READ_ONLY.invoke(tx);
+        }
+        catch (InvocationTargetException e)
+        {
+            if (e.getCause() instanceof SystemException)
+            {
+                throw (SystemException) e.getCause();
+            }
+
+            throw rethrowUnchecked(e.getCause());
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Whether the transaction bound to the given registry's thread is
+     * read-only, or false if the API in use does not support read-only
+     * transactions.
+     */
+    public static boolean isReadOnly (TransactionSynchronizationRegistry tsr)
+    {
+        if (TSR_IS_READ_ONLY == null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return (Boolean) TSR_IS_READ_ONLY.invoke(tsr);
+        }
+        catch (InvocationTargetException e)
+        {
+            throw rethrowUnchecked(e.getCause());
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Begin a transaction on the given transaction manager, read-only if
+     * requested. A read-only transaction can only be requested when the
+     * read-only API is present, otherwise NotSupportedException is thrown.
+     */
+    public static void begin (TransactionManager tm, boolean readOnly)
+            throws NotSupportedException, SystemException
+    {
+        if (!readOnly)
+        {
+            tm.begin();
+
+            return;
+        }
+
+        if (TM_BEGIN_READ_ONLY == null)
+        {
+            throw new NotSupportedException(
+                    "Read-only transactions require jakarta.transaction-api 2.0.2 or later");
+        }
+
+        try
+        {
+            TM_BEGIN_READ_ONLY.invoke(tm, true);
+        }
+        catch (InvocationTargetException e)
+        {
+            if (e.getCause() instanceof NotSupportedException)
+            {
+                throw (NotSupportedException) e.getCause();
+            }
+
+            if (e.getCause() instanceof SystemException)
+            {
+                throw (SystemException) e.getCause();
+            }
+
+            throw rethrowUnchecked(e.getCause());
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Method getMethod (Class<?> type, String name, Class<?>... parameterTypes)
+    {
+        try
+        {
+            return type.getMethod(name, parameterTypes);
+        }
+        catch (NoSuchMethodException e)
+        {
+            return null;
+        }
+    }
+
+    private static RuntimeException rethrowUnchecked (Throwable t)
+    {
+        if (t instanceof RuntimeException)
+        {
+            throw (RuntimeException) t;
+        }
+
+        if (t instanceof Error)
+        {
+            throw (Error) t;
+        }
+
+        throw new IllegalStateException(t);
+    }
+}

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/logging/jtaI18NLogger.java
@@ -612,6 +612,9 @@ public interface jtaI18NLogger {
     @LogMessage(level = WARN)
     public void warn_xa_rollback_optimization_deprecated();
 
+    @Message(id = 16156, value = "The transaction is read-only and has been rolled back", format = MESSAGE_FORMAT)
+    public String get_transaction_arjunacore_readonly();
+
     /*
      * Allocate new messages directly above this notice.
      * - id: use the next id number in sequence. Don't reuse ids.

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/basic/ReadOnlyTransactionTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/basic/ReadOnlyTransactionTest.java
@@ -1,0 +1,385 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.basic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.arjuna.ats.internal.arjuna.thread.ThreadActionData;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.UserTransactionImple;
+
+/**
+ * The only possible outcome of a read-only transaction is rollback: commit
+ * must roll the transaction back and throw RollbackException, enlisted
+ * resources must never see prepare/commit, and the readOnly flag must be
+ * visible through TransactionImple, UserTransactionImple and the
+ * TransactionSynchronizationRegistry.
+ *
+ * These tests use the concrete Narayana API (BaseTransaction.begin(boolean),
+ * TransactionImple.isReadOnly()) so they are valid whichever version of
+ * jakarta.transaction-api is on the classpath.
+ */
+public class ReadOnlyTransactionTest
+{
+    private TransactionManagerImple tm;
+
+    @Before
+    public void setUp ()
+    {
+        ThreadActionData.purgeActions();
+
+        tm = (TransactionManagerImple) com.arjuna.ats.jta.TransactionManager.transactionManager();
+    }
+
+    @Test
+    public void testDefaultBeginIsNotReadOnly () throws Exception
+    {
+        tm.begin();
+
+        assertFalse(((TransactionImple) tm.getTransaction()).isReadOnly());
+
+        tm.commit();
+
+        assertNull(tm.getTransaction());
+    }
+
+    @Test
+    public void testBeginReadOnly () throws Exception
+    {
+        tm.begin(true);
+
+        TransactionImple tx = (TransactionImple) tm.getTransaction();
+
+        assertTrue(tx.isReadOnly());
+        assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+
+        tm.rollback();
+    }
+
+    @Test
+    public void testCommitReadOnlyRollsBackAndDisassociates () throws Exception
+    {
+        tm.begin(true);
+
+        try
+        {
+            tm.commit();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+            assertTrue(ex.getMessage().contains("read-only"));
+        }
+
+        assertNull(tm.getTransaction());
+    }
+
+    @Test
+    public void testTransactionCommitReadOnly () throws Exception
+    {
+        TransactionImple tx = new TransactionImple(0, true);
+
+        assertTrue(tx.isReadOnly());
+
+        try
+        {
+            tx.commit();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+        }
+
+        assertEquals(Status.STATUS_ROLLEDBACK, tx.getStatus());
+
+        ThreadActionData.purgeActions();
+    }
+
+    @Test
+    public void testEnlistedResourceIsRolledBackNotCommitted () throws Exception
+    {
+        tm.begin(true);
+
+        RecordingXAResource xares = new RecordingXAResource();
+
+        assertTrue(tm.getTransaction().enlistResource(xares));
+
+        try
+        {
+            tm.commit();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+        }
+
+        assertTrue(xares.rolledBack);
+        assertFalse(xares.prepared);
+        assertFalse(xares.committed);
+
+        assertNull(tm.getTransaction());
+    }
+
+    @Test
+    public void testRollbackFailureIsSuppressed () throws Exception
+    {
+        FailingRollbackTransaction tx = new FailingRollbackTransaction();
+
+        try
+        {
+            tx.commitAndDisassociateForTest();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+            assertEquals(1, ex.getSuppressed().length);
+            assertEquals("rollback failed", ex.getSuppressed()[0].getMessage());
+        }
+
+        ThreadActionData.purgeActions();
+    }
+
+    @Test
+    public void testSynchronizationSeesRollback () throws Exception
+    {
+        tm.begin(true);
+
+        RecordingSynchronization sync = new RecordingSynchronization();
+
+        tm.getTransaction().registerSynchronization(sync);
+
+        try
+        {
+            tm.commit();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+        }
+
+        assertFalse(sync.beforeCompletionCalled);
+        assertEquals(Status.STATUS_ROLLEDBACK, sync.afterCompletionStatus);
+    }
+
+    @Test
+    public void testSetRollbackOnlyReadOnly () throws Exception
+    {
+        tm.begin(true);
+
+        tm.setRollbackOnly();
+
+        try
+        {
+            tm.commit();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+        }
+
+        assertNull(tm.getTransaction());
+    }
+
+    @Test
+    public void testExplicitRollbackUnchanged () throws Exception
+    {
+        tm.begin(true);
+
+        tm.rollback();
+
+        assertNull(tm.getTransaction());
+    }
+
+    @Test
+    public void testUserTransactionIsReadOnly () throws Exception
+    {
+        UserTransactionImple ut = new UserTransactionImple();
+
+        assertFalse(ut.isReadOnly());
+
+        ut.begin(true);
+
+        assertTrue(ut.isReadOnly());
+
+        try
+        {
+            ut.commit();
+
+            fail("commit of a read-only transaction must throw RollbackException");
+        }
+        catch (final RollbackException ex)
+        {
+        }
+
+        assertFalse(ut.isReadOnly());
+
+        ut.begin();
+
+        assertFalse(ut.isReadOnly());
+
+        ut.commit();
+    }
+
+    @Test
+    public void testSynchronizationRegistryIsReadOnly () throws Exception
+    {
+        TransactionSynchronizationRegistryImple tsr = new TransactionSynchronizationRegistryImple();
+
+        try
+        {
+            tsr.isReadOnly();
+
+            fail("isReadOnly with no transaction must throw IllegalStateException");
+        }
+        catch (final IllegalStateException ex)
+        {
+        }
+
+        tm.begin(true);
+
+        assertTrue(tsr.isReadOnly());
+
+        tm.rollback();
+
+        tm.begin();
+
+        assertFalse(tsr.isReadOnly());
+
+        tm.commit();
+    }
+
+    /**
+     * Rolls back for real, then reports a failure — so the suppression
+     * handling in commitAndDisassociate's read-only branch is exercised
+     * deterministically.
+     */
+    private static class FailingRollbackTransaction extends TransactionImple
+    {
+        FailingRollbackTransaction ()
+        {
+            super(0, true);
+        }
+
+        @Override
+        protected void rollbackAndDisassociate ()
+                throws IllegalStateException, SecurityException, jakarta.transaction.SystemException
+        {
+            super.rollbackAndDisassociate();
+
+            throw new IllegalStateException("rollback failed");
+        }
+
+        void commitAndDisassociateForTest () throws Exception
+        {
+            commitAndDisassociate();
+        }
+    }
+
+    private static class RecordingSynchronization implements jakarta.transaction.Synchronization
+    {
+        boolean beforeCompletionCalled;
+        int afterCompletionStatus = -1;
+
+        @Override
+        public void beforeCompletion ()
+        {
+            beforeCompletionCalled = true;
+        }
+
+        @Override
+        public void afterCompletion (int status)
+        {
+            afterCompletionStatus = status;
+        }
+    }
+
+    private static class RecordingXAResource implements XAResource
+    {
+        boolean prepared;
+        boolean committed;
+        boolean rolledBack;
+
+        @Override
+        public void start (Xid xid, int flags) throws XAException
+        {
+        }
+
+        @Override
+        public void end (Xid xid, int flags) throws XAException
+        {
+        }
+
+        @Override
+        public int prepare (Xid xid) throws XAException
+        {
+            prepared = true;
+
+            return XA_OK;
+        }
+
+        @Override
+        public void commit (Xid xid, boolean onePhase) throws XAException
+        {
+            committed = true;
+        }
+
+        @Override
+        public void rollback (Xid xid) throws XAException
+        {
+            rolledBack = true;
+        }
+
+        @Override
+        public void forget (Xid xid) throws XAException
+        {
+        }
+
+        @Override
+        public Xid[] recover (int flag) throws XAException
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isSameRM (XAResource xares) throws XAException
+        {
+            return false;
+        }
+
+        @Override
+        public int getTransactionTimeout () throws XAException
+        {
+            return 0;
+        }
+
+        @Override
+        public boolean setTransactionTimeout (int seconds) throws XAException
+        {
+            return false;
+        }
+    }
+}

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/utils/ReadOnlyTransactionSupportTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/utils/ReadOnlyTransactionSupportTest.java
@@ -1,0 +1,207 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.annotation.Annotation;
+
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.Status;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.Transactional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.arjuna.ats.internal.arjuna.thread.ThreadActionData;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.internal.jta.utils.ReadOnlyTransactionSupport;
+
+/**
+ * ReadOnlyTransactionSupport reflects on the jakarta.transaction interfaces,
+ * so its behaviour depends on the API version on the classpath: with the
+ * read-only API (jakarta.transaction-api 2.0.2+) it reports the real flags
+ * and can begin read-only transactions; without it every query degrades to
+ * false and a read-only begin is refused with NotSupportedException.
+ *
+ * Each test detects the API level at runtime and asserts the matching
+ * contract, so the suite stays green both before and after the API bump.
+ */
+public class ReadOnlyTransactionSupportTest
+{
+    /** True when the read-only API (2.0.2+) is on the classpath. */
+    private static final boolean READ_ONLY_API = hasMethod(Transactional.class, "isReadOnly");
+
+    private TransactionManagerImple tm;
+
+    @Before
+    public void setUp ()
+    {
+        ThreadActionData.purgeActions();
+
+        tm = (TransactionManagerImple) com.arjuna.ats.jta.TransactionManager.transactionManager();
+    }
+
+    @Test
+    public void testIsReadOnlyTransactional ()
+    {
+        // the literal's isReadOnly() returns true, but the shim only sees it
+        // when the Transactional interface itself declares the method
+        assertEquals(READ_ONLY_API, ReadOnlyTransactionSupport.isReadOnly(new ReadOnlyTransactionalLiteral()));
+    }
+
+    @Test
+    public void testIsReadOnlyTransaction () throws Exception
+    {
+        TransactionImple tx = new TransactionImple(0, true);
+
+        try
+        {
+            assertTrue(tx.isReadOnly());
+            assertEquals(READ_ONLY_API, ReadOnlyTransactionSupport.isReadOnly((Transaction) tx));
+        }
+        finally
+        {
+            tx.rollback();
+
+            // Transaction.rollback() does not pop the thread association
+            ThreadActionData.purgeActions();
+        }
+
+        tm.begin();
+
+        try
+        {
+            assertFalse(ReadOnlyTransactionSupport.isReadOnly(tm.getTransaction()));
+        }
+        finally
+        {
+            tm.rollback();
+        }
+    }
+
+    @Test
+    public void testIsReadOnlySynchronizationRegistry () throws Exception
+    {
+        TransactionSynchronizationRegistryImple tsr = new TransactionSynchronizationRegistryImple();
+
+        tm.begin(true);
+
+        try
+        {
+            assertTrue(tsr.isReadOnly());
+            assertEquals(READ_ONLY_API, ReadOnlyTransactionSupport.isReadOnly(tsr));
+        }
+        finally
+        {
+            tm.rollback();
+        }
+    }
+
+    @Test
+    public void testBeginNotReadOnlyDelegates () throws Exception
+    {
+        ReadOnlyTransactionSupport.begin(tm, false);
+
+        TransactionImple tx = (TransactionImple) tm.getTransaction();
+
+        assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+        assertFalse(tx.isReadOnly());
+
+        tm.commit();
+    }
+
+    @Test
+    public void testBeginReadOnly () throws Exception
+    {
+        if (READ_ONLY_API)
+        {
+            ReadOnlyTransactionSupport.begin(tm, true);
+
+            try
+            {
+                assertTrue(((TransactionImple) tm.getTransaction()).isReadOnly());
+            }
+            finally
+            {
+                tm.rollback();
+            }
+        }
+        else
+        {
+            try
+            {
+                ReadOnlyTransactionSupport.begin(tm, true);
+
+                fail("read-only begin without the read-only API must throw NotSupportedException");
+            }
+            catch (final NotSupportedException ex)
+            {
+                assertTrue(ex.getMessage().contains("2.0.2"));
+            }
+
+            assertNull(tm.getTransaction());
+        }
+    }
+
+    private static boolean hasMethod (Class<?> type, String name, Class<?>... parameterTypes)
+    {
+        try
+        {
+            type.getMethod(name, parameterTypes);
+
+            return true;
+        }
+        catch (NoSuchMethodException e)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * A Transactional literal whose isReadOnly() returns true. The method is
+     * deliberately not annotated with @Override so this compiles whether or
+     * not the interface declares it (it only does from 2.0.2).
+     */
+    private static class ReadOnlyTransactionalLiteral implements Transactional
+    {
+        @Override
+        public Class<? extends Annotation> annotationType ()
+        {
+            return Transactional.class;
+        }
+
+        @Override
+        public TxType value ()
+        {
+            return TxType.REQUIRED;
+        }
+
+        @Override
+        public Class[] rollbackOn ()
+        {
+            return new Class[] {};
+        }
+
+        @Override
+        public Class[] dontRollbackOn ()
+        {
+            return new Class[] {};
+        }
+
+        public boolean isReadOnly ()
+        {
+            return true;
+        }
+    }
+}

--- a/ArjunaJTS/integration/src/main/java/com/arjuna/ats/jbossatx/BaseTransactionManagerDelegate.java
+++ b/ArjunaJTS/integration/src/main/java/com/arjuna/ats/jbossatx/BaseTransactionManagerDelegate.java
@@ -70,6 +70,17 @@ public abstract class BaseTransactionManagerDelegate implements TransactionManag
     }
 
     /**
+     * Begin a transaction, optionally read-only, and associate it with the current thread.
+     * The underlying transaction manager determines whether read-only transactions are
+     * supported (JTA) or not (JTS, which throws NotSupportedException).
+     */
+    public void begin(boolean readOnly)
+        throws NotSupportedException, SystemException
+    {
+        transactionManager.begin(readOnly) ;
+    }
+
+    /**
      * Commit the current transaction and disassociate from the thread.
      */
     public void commit()

--- a/ArjunaJTS/integration/src/main/java/com/arjuna/ats/jbossatx/BaseTransactionManagerDelegate.java
+++ b/ArjunaJTS/integration/src/main/java/com/arjuna/ats/jbossatx/BaseTransactionManagerDelegate.java
@@ -17,6 +17,7 @@ import jakarta.transaction.Status;
 
 import org.jboss.tm.listener.TransactionTypeNotSupported;
 
+import com.arjuna.ats.internal.jta.utils.ReadOnlyTransactionSupport;
 import com.arjuna.ats.jbossatx.logging.jbossatxLogger;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
@@ -77,7 +78,9 @@ public abstract class BaseTransactionManagerDelegate implements TransactionManag
     public void begin(boolean readOnly)
         throws NotSupportedException, SystemException
     {
-        transactionManager.begin(readOnly) ;
+        // accessed reflectively: TransactionManager only declares begin(boolean)
+        // from jakarta.transaction-api 2.0.2, and narayana compiles against 2.0.1
+        ReadOnlyTransactionSupport.begin(transactionManager, readOnly) ;
     }
 
     /**

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/BaseTransaction.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/BaseTransaction.java
@@ -82,6 +82,15 @@ public class BaseTransaction
 		}
 	}
 
+	public void begin (boolean readOnly) throws jakarta.transaction.NotSupportedException,
+			jakarta.transaction.SystemException
+	{
+		if (readOnly) {
+			throw new NotSupportedException("JTS read-only transactions are not supported");
+		}
+		begin();
+	}
+
 	/**
 	 * We will never throw a HeuristicRollbackException because if we get a
 	 * HeuristicRollback from a resource, and can successfully rollback the
@@ -101,6 +110,11 @@ public class BaseTransaction
         }
 
 		TransactionImple theTransaction = TransactionImple.getTransaction();
+
+		if (theTransaction == null)
+			throw new IllegalStateException(
+					"BaseTransaction.commit - "
+							+ jtaxLogger.i18NLogger.get_jtax_transaction_jts_notxe());
 
 		try
 		{

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionImple.java
@@ -1878,6 +1878,12 @@ public class TransactionImple implements jakarta.transaction.Transaction,
         return Collections.EMPTY_MAP;
     }
 
+    public boolean isReadOnly()
+    {
+        // JTS transactions cannot be started in read-only mode
+        return false;
+    }
+
     protected AtomicTransaction _theTransaction;
 
 	private Hashtable _resources;

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionSynchronizationRegistryImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/TransactionSynchronizationRegistryImple.java
@@ -218,4 +218,11 @@ public class TransactionSynchronizationRegistryImple implements TransactionSynch
 
         return transactionImple;
     }
+
+    public boolean isReadOnly() {
+        // Validates that a transaction is active (throws IllegalStateException if not),
+        // then returns false since JTS does not support read-only transactions.
+        getTransactionImple();
+        return false;
+    }
 }

--- a/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/UserTransactionImple.java
+++ b/ArjunaJTS/jtax/classes/com/arjuna/ats/internal/jta/transaction/jts/UserTransactionImple.java
@@ -43,4 +43,9 @@ public class UserTransactionImple extends BaseTransaction
     {
         return new Reference(this.getClass().getCanonicalName(), this.getClass().getCanonicalName(), null);
     }
+
+    public boolean isReadOnly() {
+        // JTS does not support read-only transactions; any active transaction is always non-read-only.
+        return false;
+    }
 }

--- a/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/twophase/ReadOnlyTransactionUnitTest.java
+++ b/ArjunaJTS/jtax/tests/classes/com/hp/mwtests/ts/jta/jts/twophase/ReadOnlyTransactionUnitTest.java
@@ -1,0 +1,174 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.jts.twophase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.Status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.arjuna.ats.internal.arjuna.thread.ThreadActionData;
+import com.arjuna.ats.internal.jta.transaction.jts.TransactionImple;
+import com.arjuna.ats.internal.jta.transaction.jts.TransactionManagerImple;
+import com.arjuna.ats.internal.jta.transaction.jts.TransactionSynchronizationRegistryImple;
+import com.arjuna.ats.internal.jta.transaction.jts.UserTransactionImple;
+import com.arjuna.ats.internal.jts.ORBManager;
+import com.arjuna.orbportability.OA;
+import com.arjuna.orbportability.ORB;
+import com.arjuna.orbportability.RootOA;
+
+/**
+ * JTS does not support read-only transactions: begin(true) must be refused
+ * with NotSupportedException and isReadOnly() always reports false. These
+ * assertions hold whichever version of jakarta.transaction-api is on the
+ * classpath.
+ */
+public class ReadOnlyTransactionUnitTest
+{
+    @Test
+    public void testUserTransactionReadOnlyBeginRefused () throws Exception
+    {
+        ThreadActionData.purgeActions();
+
+        UserTransactionImple ut = new UserTransactionImple();
+
+        assertFalse(ut.isReadOnly());
+
+        try
+        {
+            ut.begin(true);
+
+            fail("JTS read-only begin must throw NotSupportedException");
+        }
+        catch (final NotSupportedException ex)
+        {
+        }
+
+        assertEquals(Status.STATUS_NO_TRANSACTION, ut.getStatus());
+    }
+
+    @Test
+    public void testUserTransactionBeginFalseBehavesLikeBegin () throws Exception
+    {
+        ThreadActionData.purgeActions();
+
+        UserTransactionImple ut = new UserTransactionImple();
+
+        ut.begin(false);
+
+        assertEquals(Status.STATUS_ACTIVE, ut.getStatus());
+        assertFalse(ut.isReadOnly());
+
+        ut.commit();
+
+        assertEquals(Status.STATUS_NO_TRANSACTION, ut.getStatus());
+    }
+
+    @Test
+    public void testTransactionManagerReadOnlyBeginRefused () throws Exception
+    {
+        ThreadActionData.purgeActions();
+
+        TransactionManagerImple tmi = new TransactionManagerImple();
+
+        try
+        {
+            tmi.begin(true);
+
+            fail("JTS read-only begin must throw NotSupportedException");
+        }
+        catch (final NotSupportedException ex)
+        {
+        }
+
+        assertNull(tmi.getTransaction());
+
+        tmi.begin(false);
+
+        assertFalse(((TransactionImple) tmi.getTransaction()).isReadOnly());
+
+        tmi.rollback();
+    }
+
+    @Test
+    public void testSynchronizationRegistryIsReadOnly () throws Exception
+    {
+        ThreadActionData.purgeActions();
+
+        TransactionSynchronizationRegistryImple tsr = new TransactionSynchronizationRegistryImple();
+
+        try
+        {
+            tsr.isReadOnly();
+
+            fail("isReadOnly with no transaction must throw IllegalStateException");
+        }
+        catch (final IllegalStateException ex)
+        {
+        }
+
+        TransactionManagerImple tmi = new TransactionManagerImple();
+
+        tmi.begin();
+
+        try
+        {
+            assertFalse(tsr.isReadOnly());
+        }
+        finally
+        {
+            tmi.rollback();
+        }
+    }
+
+    @Test
+    public void testCommitWithNoTransaction () throws Exception
+    {
+        ThreadActionData.purgeActions();
+
+        UserTransactionImple ut = new UserTransactionImple();
+
+        try
+        {
+            ut.commit();
+
+            fail("commit with no transaction must throw IllegalStateException");
+        }
+        catch (final IllegalStateException ex)
+        {
+        }
+    }
+
+    @Before
+    public void setUp () throws Exception
+    {
+        myORB = ORB.getInstance("test");
+        myOA = OA.getRootOA(myORB);
+
+        myORB.initORB(new String[] {}, null);
+        myOA.initOA();
+
+        ORBManager.setORB(myORB);
+        ORBManager.setPOA(myOA);
+    }
+
+    @After
+    public void tearDown () throws Exception
+    {
+        myOA.destroy();
+        myORB.shutdown();
+    }
+
+    private ORB myORB = null;
+    private RootOA myOA = null;
+}


### PR DESCRIPTION
https://github.com/jbosstm/narayana/issues/3023

Currently requires the newest Transactions (2.0.2-SNAPSHOT) which has been pushed to Sonatype Central. 

IBM Bob was used to generate some of this PR

CORE