### PR TITLE
[#3050] Support ExtendedXAResource prepare/commit ordering (Jakarta Transactions 2.0.2)

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/resources/arjunacore/XAResourceRecord.java
@@ -31,6 +31,9 @@ import com.arjuna.ats.jta.xa.RecoverableXAConnection;
 import com.arjuna.ats.jta.xa.XidImple;
 import com.arjuna.common.internal.util.ClassloadingUtility;
 
+import jakarta.transaction.xa.CommitPriority;
+import jakarta.transaction.xa.ExtendedXAResource;
+import jakarta.transaction.xa.PreparePriority;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -126,6 +129,22 @@ public class XAResourceRecord extends AbstractRecord implements ExceptionDeferre
     }
 
     public Uid order() {
+        if (_theXAResource instanceof ExtendedXAResource) {
+            ExtendedXAResource extendedXAResource = (ExtendedXAResource) _theXAResource;
+            PreparePriority preparePriority = extendedXAResource.getPreparePriority();
+            if (preparePriority == PreparePriority.EXCLUSIVE_LAST) {
+                return BEFORE_END_XARESOURCE;
+            } else if (preparePriority == PreparePriority.EARLY) {
+                return START_XARESOURCE;
+            }
+            CommitPriority commitPriority = extendedXAResource.getCommitPriority();
+            if (commitPriority == CommitPriority.EXCLUSIVE_FIRST) {
+                return START_XARESOURCE;
+            } else if (commitPriority == CommitPriority.LATE) {
+                return BEFORE_END_XARESOURCE;
+            }
+        }
+
         if (_theXAResource instanceof FirstResource) {
             return START_XARESOURCE;
         } else if (_theXAResource instanceof LastResource) {
@@ -1209,6 +1228,14 @@ public class XAResourceRecord extends AbstractRecord implements ExceptionDeferre
     public static final int XACONNECTION = 0;
 
     private static final Uid START_XARESOURCE = Uid.minUid();
+
+    /**
+     * Ordering anchor for resources that must be prepared/committed just before the
+     * legacy LastResource (END_XARESOURCE) slot. Used for ExtendedXAResource with
+     * PreparePriority.EXCLUSIVE_LAST or CommitPriority.LATE.
+     */
+    private static final Uid BEFORE_END_XARESOURCE =
+            new Uid("7fffffffffffffff:7fffffffffffffff:7fffffff:7fffffff:7ffffffe");
 
     private static final Uid END_XARESOURCE = Uid.maxUid();
 

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionImple.java
@@ -21,6 +21,9 @@ import com.arjuna.ats.arjuna.coordinator.RecordType;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
 import jakarta.transaction.SystemException;
+import jakarta.transaction.xa.CommitPriority;
+import jakarta.transaction.xa.ExtendedXAResource;
+import jakarta.transaction.xa.PreparePriority;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -645,6 +648,12 @@ public class TransactionImple implements jakarta.transaction.Transaction,
                         AbstractRecord abstractRecord = createRecord(xaRes, params, xid);
                         String reasonForEnlistFailure = null;
                         if(abstractRecord != null) {
+                            try {
+                                checkExclusiveEnlistment(xaRes);
+                            } catch (SystemException ex) {
+                                markRollbackOnly();
+                                throw ex;
+                            }
                             xaRes.start(xid, xaStartNormal);
                             int addOutcome = _theTransaction.add(abstractRecord);
                             if(addOutcome == AddOutcome.AR_ADDED) {
@@ -762,20 +771,57 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 
             return false;
         }
-		catch (Exception e)
-		{
-			jtaLogger.i18NLogger.warn_failed_to_enlist_xa_resource(xaRes, e);
-			/*
-			 * Some exceptional condition arose and we probably could not enlist
-			 * the resouce. So, for safety mark the transaction as rollback
-			 * only.
-			 */
+        catch (SystemException e)
+        {
+            // Re-throw SystemException directly — callers (e.g. duplicate exclusive
+            // enlistment guard) need to receive it rather than have it swallowed.
+            throw e;
+        }
+        catch (Exception e)
+        {
+            jtaLogger.i18NLogger.warn_failed_to_enlist_xa_resource(xaRes, e);
+            /*
+             * Some exceptional condition arose and we probably could not enlist
+             * the resource. So, for safety mark the transaction as rollback
+             * only.
+             */
 
-			markRollbackOnly();
+            markRollbackOnly();
 
-			return false;
-		}
-	}
+            return false;
+        }
+    }
+
+    /**
+     * Enforces the spec requirement that at most one EXCLUSIVE_LAST and one EXCLUSIVE_FIRST resource
+     * may be enlisted in a single transaction. Must be called before xa_start.
+     *
+     * @throws SystemException if a second resource with the same exclusive priority is enlisted
+     */
+    private void checkExclusiveEnlistment(XAResource xaRes) throws SystemException {
+        if (!(xaRes instanceof ExtendedXAResource)) {
+            return;
+        }
+        ExtendedXAResource ext = (ExtendedXAResource) xaRes;
+        if (ext.getPreparePriority() == PreparePriority.EXCLUSIVE_LAST) {
+            synchronized (this) {
+                if (_hasExclusiveLast) {
+                    throw new SystemException(
+                            "TransactionImple.enlistResource - only one EXCLUSIVE_LAST resource may be enlisted per transaction");
+                }
+                _hasExclusiveLast = true;
+            }
+        }
+        if (ext.getCommitPriority() == CommitPriority.EXCLUSIVE_FIRST) {
+            synchronized (this) {
+                if (_hasExclusiveFirst) {
+                    throw new SystemException(
+                            "TransactionImple.enlistResource - only one EXCLUSIVE_FIRST resource may be enlisted per transaction");
+                }
+                _hasExclusiveFirst = true;
+            }
+        }
+    }
 
     /**
      * Attempt to create an AbstractRecord wrapping the given XAResource. Return null if this fails, or
@@ -1778,4 +1824,13 @@ public class TransactionImple implements jakarta.transaction.Transaction,
 			.getCommitMarkableResourceJNDINames();
 
 	private static final boolean STRICTJTA12DUPLICATEXAENDPROTOERR = jtaPropertyManager.getJTAEnvironmentBean().isStrictJTA12DuplicateXAENDPROTOErr();
+
+	private boolean _hasExclusiveLast = false;
+
+	private boolean _hasExclusiveFirst = false;
+
+	@Override
+	public boolean isReadOnly() throws jakarta.transaction.SystemException {
+		return false;
+	}
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionManagerImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionManagerImple.java
@@ -119,4 +119,9 @@ public class TransactionManagerImple extends BaseTransaction implements
 	{
 		return this;
 	}
+
+	@Override
+	public void begin(boolean isReadOnly) throws jakarta.transaction.NotSupportedException, jakarta.transaction.SystemException {
+		begin();
+	}
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionSynchronizationRegistryImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/TransactionSynchronizationRegistryImple.java
@@ -216,4 +216,14 @@ public class TransactionSynchronizationRegistryImple implements TransactionSynch
 
         return transactionImple;
     }
+
+    @Override
+    public boolean isReadOnly() {
+        TransactionImple tx = TransactionImple.getTransaction();
+        try {
+            return tx != null && tx.isReadOnly();
+        } catch (jakarta.transaction.SystemException e) {
+            return false;
+        }
+    }
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/UserTransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/UserTransactionImple.java
@@ -34,4 +34,15 @@ public class UserTransactionImple extends BaseTransaction
     {
         return new Reference(this.getClass().getCanonicalName(), this.getClass().getCanonicalName(), null);
     }
+
+    @Override
+    public void begin(boolean isReadOnly) throws jakarta.transaction.NotSupportedException, jakarta.transaction.SystemException {
+        begin();
+    }
+
+    @Override
+    public boolean isReadOnly() throws jakarta.transaction.SystemException {
+        TransactionImple tx = TransactionImple.getTransaction();
+        return tx != null && tx.isReadOnly();
+    }
 }

--- a/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/jca/TransactionImple.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/internal/jta/transaction/arjunacore/subordinate/jca/TransactionImple.java
@@ -105,4 +105,9 @@ public class TransactionImple
 	{
 		return ((SubordinateAtomicAction) _theTransaction).activated();
 	}
+
+	@Override
+	public boolean isReadOnly() throws jakarta.transaction.SystemException {
+		return false;
+	}
 }

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/extendedxaresource/ExtendedXAResourceOrderingTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/extendedxaresource/ExtendedXAResourceOrderingTest.java
@@ -1,0 +1,195 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.extendedxaresource;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.xa.CommitPriority;
+import jakarta.transaction.xa.PreparePriority;
+
+import org.junit.Test;
+
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for ExtendedXAResource prepare/commit ordering support (GitHub issue #3050).
+ *
+ * <p>Verifies that XAResourceRecord.order() correctly positions resources with
+ * EARLY/EXCLUSIVE_LAST prepare priorities and EXCLUSIVE_FIRST/LATE commit priorities
+ * ahead of or behind normal resources in the 2PC sequence.</p>
+ */
+public class ExtendedXAResourceOrderingTest {
+
+    /**
+     * A resource with PreparePriority.EARLY should be prepared before a NORMAL resource.
+     */
+    @Test
+    public void testEarlyPreparePriorityFirst() throws Exception {
+        List<String> log = new ArrayList<>();
+        TransactionManager tm = new TransactionManagerImple();
+        tm.begin();
+        Transaction tx = tm.getTransaction();
+
+        OrderingXAResource normal = new OrderingXAResource("normal",
+                PreparePriority.NORMAL, CommitPriority.NORMAL, log);
+        OrderingXAResource early = new OrderingXAResource("early",
+                PreparePriority.EARLY, CommitPriority.NORMAL, log);
+
+        // Enlist normal first, then early — early must still prepare first
+        assertTrue(tx.enlistResource(normal));
+        assertTrue(tx.enlistResource(early));
+
+        tm.commit();
+
+        int earlyPrepare = log.indexOf("early:prepare");
+        int normalPrepare = log.indexOf("normal:prepare");
+        assertTrue("EARLY resource should prepare before NORMAL",
+                earlyPrepare < normalPrepare);
+    }
+
+    /**
+     * A resource with PreparePriority.EXCLUSIVE_LAST should be prepared after all
+     * NORMAL resources.
+     */
+    @Test
+    public void testExclusiveLastPreparePriorityLast() throws Exception {
+        List<String> log = new ArrayList<>();
+        TransactionManager tm = new TransactionManagerImple();
+        tm.begin();
+        Transaction tx = tm.getTransaction();
+
+        OrderingXAResource exclusiveLast = new OrderingXAResource("exclusiveLast",
+                PreparePriority.EXCLUSIVE_LAST, CommitPriority.NORMAL, log);
+        OrderingXAResource normal = new OrderingXAResource("normal",
+                PreparePriority.NORMAL, CommitPriority.NORMAL, log);
+
+        // Enlist exclusive-last first — it must still prepare last
+        assertTrue(tx.enlistResource(exclusiveLast));
+        assertTrue(tx.enlistResource(normal));
+
+        tm.commit();
+
+        int exclusivePrepare = log.indexOf("exclusiveLast:prepare");
+        int normalPrepare = log.indexOf("normal:prepare");
+        assertTrue("EXCLUSIVE_LAST resource should prepare after NORMAL",
+                normalPrepare < exclusivePrepare);
+    }
+
+    /**
+     * A resource with CommitPriority.EXCLUSIVE_FIRST should be committed before
+     * NORMAL resources.
+     */
+    @Test
+    public void testExclusiveFirstCommitPriorityFirst() throws Exception {
+        List<String> log = new ArrayList<>();
+        TransactionManager tm = new TransactionManagerImple();
+        tm.begin();
+        Transaction tx = tm.getTransaction();
+
+        OrderingXAResource normal = new OrderingXAResource("normal",
+                PreparePriority.NORMAL, CommitPriority.NORMAL, log);
+        OrderingXAResource exclusiveFirst = new OrderingXAResource("exclusiveFirst",
+                PreparePriority.NORMAL, CommitPriority.EXCLUSIVE_FIRST, log);
+
+        assertTrue(tx.enlistResource(normal));
+        assertTrue(tx.enlistResource(exclusiveFirst));
+
+        tm.commit();
+
+        int exclusiveCommit = log.indexOf("exclusiveFirst:commit");
+        int normalCommit = log.indexOf("normal:commit");
+        assertTrue("EXCLUSIVE_FIRST resource should commit before NORMAL",
+                exclusiveCommit < normalCommit);
+    }
+
+    /**
+     * A resource with CommitPriority.LATE should be committed after NORMAL resources.
+     */
+    @Test
+    public void testLateCommitPriorityLast() throws Exception {
+        List<String> log = new ArrayList<>();
+        TransactionManager tm = new TransactionManagerImple();
+        tm.begin();
+        Transaction tx = tm.getTransaction();
+
+        OrderingXAResource late = new OrderingXAResource("late",
+                PreparePriority.NORMAL, CommitPriority.LATE, log);
+        OrderingXAResource normal = new OrderingXAResource("normal",
+                PreparePriority.NORMAL, CommitPriority.NORMAL, log);
+
+        // Enlist late first — it must still commit last
+        assertTrue(tx.enlistResource(late));
+        assertTrue(tx.enlistResource(normal));
+
+        tm.commit();
+
+        int lateCommit = log.indexOf("late:commit");
+        int normalCommit = log.indexOf("normal:commit");
+        assertTrue("LATE resource should commit after NORMAL",
+                normalCommit < lateCommit);
+    }
+
+    /**
+     * Enlisting a second EXCLUSIVE_LAST resource must throw SystemException.
+     */
+    @Test
+    public void testDuplicateExclusiveLastThrows() throws Exception {
+        TransactionManager tm = new TransactionManagerImple();
+        tm.begin();
+        Transaction tx = tm.getTransaction();
+
+        List<String> log = new ArrayList<>();
+        OrderingXAResource first = new OrderingXAResource("first",
+                PreparePriority.EXCLUSIVE_LAST, CommitPriority.NORMAL, log);
+        OrderingXAResource second = new OrderingXAResource("second",
+                PreparePriority.EXCLUSIVE_LAST, CommitPriority.NORMAL, log);
+
+        assertTrue(tx.enlistResource(first));
+
+        try {
+            tx.enlistResource(second);
+            fail("Expected SystemException when enlisting second EXCLUSIVE_LAST resource");
+        } catch (SystemException e) {
+            // expected
+        } finally {
+            tm.rollback();
+        }
+    }
+
+    /**
+     * Enlisting a second EXCLUSIVE_FIRST resource must throw SystemException.
+     */
+    @Test
+    public void testDuplicateExclusiveFirstThrows() throws Exception {
+        TransactionManager tm = new TransactionManagerImple();
+        tm.begin();
+        Transaction tx = tm.getTransaction();
+
+        List<String> log = new ArrayList<>();
+        OrderingXAResource first = new OrderingXAResource("first",
+                PreparePriority.NORMAL, CommitPriority.EXCLUSIVE_FIRST, log);
+        OrderingXAResource second = new OrderingXAResource("second",
+                PreparePriority.NORMAL, CommitPriority.EXCLUSIVE_FIRST, log);
+
+        assertTrue(tx.enlistResource(first));
+
+        try {
+            tx.enlistResource(second);
+            fail("Expected SystemException when enlisting second EXCLUSIVE_FIRST resource");
+        } catch (SystemException e) {
+            // expected
+        } finally {
+            tm.rollback();
+        }
+    }
+}

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/extendedxaresource/OrderingXAResource.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/extendedxaresource/OrderingXAResource.java
@@ -1,0 +1,103 @@
+/*
+   Copyright The Narayana Authors
+   SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.hp.mwtests.ts.jta.extendedxaresource;
+
+import jakarta.transaction.xa.CommitPriority;
+import jakarta.transaction.xa.ExtendedXAResource;
+import jakarta.transaction.xa.PreparePriority;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import java.util.List;
+
+/**
+ * Test XAResource that implements ExtendedXAResource and records the
+ * sequence of prepare/commit/rollback calls for assertion in tests.
+ */
+public class OrderingXAResource implements XAResource, ExtendedXAResource {
+
+    private final String name;
+    private final PreparePriority preparePriority;
+    private final CommitPriority commitPriority;
+    private final List<String> callLog;
+
+    public OrderingXAResource(String name, PreparePriority preparePriority,
+            CommitPriority commitPriority, List<String> callLog) {
+        this.name = name;
+        this.preparePriority = preparePriority;
+        this.commitPriority = commitPriority;
+        this.callLog = callLog;
+    }
+
+    @Override
+    public PreparePriority getPreparePriority() {
+        return preparePriority;
+    }
+
+    @Override
+    public CommitPriority getCommitPriority() {
+        return commitPriority;
+    }
+
+    @Override
+    public boolean setReadOnly(Xid xid) throws XAException {
+        return false;
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        callLog.add(name + ":prepare");
+        return XA_OK;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        callLog.add(name + ":commit");
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        callLog.add(name + ":rollback");
+    }
+
+    @Override
+    public void start(Xid xid, int flags) throws XAException {
+    }
+
+    @Override
+    public void end(Xid xid, int flags) throws XAException {
+    }
+
+    @Override
+    public Xid[] recover(int flags) throws XAException {
+        return new Xid[0];
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int seconds) throws XAException {
+        return false;
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return 60;
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xaResource) throws XAException {
+        return this == xaResource;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/boms/main/pom.xml
+++ b/boms/main/pom.xml
@@ -40,7 +40,7 @@
     <version.jakarta.platform.jakarta.jakartaee-api>10.0.0</version.jakarta.platform.jakarta.jakartaee-api>
     <version.jakarta.resource.jakarta-resource-api>2.1.0</version.jakarta.resource.jakarta-resource-api>
     <version.jakarta.servlet.jakarta-servlet-api>6.1.0</version.jakarta.servlet.jakarta-servlet-api>
-    <version.jakarta.transaction.jakarta-transaction-api>2.0.1</version.jakarta.transaction.jakarta-transaction-api>
+    <version.jakarta.transaction.jakarta-transaction-api>2.0.2-SNAPSHOT</version.jakarta.transaction.jakarta-transaction-api>
     <version.jakarta.ws.rs.jakarta-ws-rs-api>4.0.0</version.jakarta.ws.rs.jakarta-ws-rs-api>
     <version.jakarta.xml.bind.jakarta-xml-bind-api>4.0.5</version.jakarta.xml.bind.jakarta-xml-bind-api>
     <version.jakarta.xml.ws.jakarta.xml.ws-api>4.0.3</version.jakarta.xml.ws.jakarta.xml.ws-api>


### PR DESCRIPTION
issue #3050 

Implements Naranya support for [link](https://github.com/jakartaee/transactions/pull/259). Requires jakarta.transaction-api:2.0.2-SNAPSHOT — will update once upstream is released.
