### PR TITLE
[JBTM-576] : update excluded unit tests

### DIFF
--- a/ArjunaCore/arjuna/pom.xml
+++ b/ArjunaCore/arjuna/pom.xml
@@ -566,8 +566,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
-                <!-- stress tests are not unit tests -->
-                <exclude>**/LogStressTest2.java</exclude>
               </excludes>
               <systemProperties>
                 <property>
@@ -636,8 +634,6 @@
                 <exclude>**/RecoveryTransaction.java</exclude>
                 <exclude>**/UserDefFirst0Setup.java</exclude>
                 <exclude>**/CachedTest.java</exclude>
-                <!-- LogStressTest2 takes too long - needs moving to /qa -->
-                <exclude>**/LogStressTest2.java</exclude>
                 <!-- auxilairy code used by reaper test classes -->
                 <exclude>**/reaper/ReaperTestCaseControl.java</exclude>
               </excludes>
@@ -660,6 +656,27 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!--
+        Stress tests are excluded from the default build because they run for an
+        extended period (LogStressTest2 runs for ~4 hours). Activate this profile
+        to include them: mvn test -Pstress-tests
+      -->
+      <id>stress-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/LogStressTest2.java</include>
+              </includes>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/ArjunaJTS/jtax/pom.xml
+++ b/ArjunaJTS/jtax/pom.xml
@@ -226,7 +226,8 @@
                     <exclude>**/ExampleXAResource.java</exclude>
                     <exclude>**/JTSTestCase.java</exclude>
                     <exclude>**/LastOnePhaseResource.java</exclude>
-                    <exclude>**/implicit/**</exclude>
+                    <exclude>**/implicit/client/ImplicitClient.java</exclude>
+                    <exclude>**/implicit/server/ImplicitServer.java</exclude>
                   </excludes>
                   <reportsDirectory>${project.build.directory}/idlj-openjdk-surefire-reports</reportsDirectory>
                   <systemPropertyVariables combine.children="append">

--- a/ArjunaJTS/jtax/tests/classes/com/arjuna/ats/jtax/tests/implicit/client/ImplicitClient.java
+++ b/ArjunaJTS/jtax/tests/classes/com/arjuna/ats/jtax/tests/implicit/client/ImplicitClient.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.InputStreamReader;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.arjuna.ats.jta.TransactionManager;
@@ -21,6 +22,7 @@ import com.arjuna.orbportability.ORB;
 
 public class ImplicitClient
 {
+    @Ignore("Client/server test requiring a separate server JVM. Belongs in /qa integration test suite.")
     @Test
     public void test() throws Exception
     {

--- a/ArjunaJTS/jtax/tests/classes/com/arjuna/ats/jtax/tests/implicit/server/ImplicitServer.java
+++ b/ArjunaJTS/jtax/tests/classes/com/arjuna/ats/jtax/tests/implicit/server/ImplicitServer.java
@@ -10,6 +10,7 @@ package com.arjuna.ats.jtax.tests.implicit.server;
 import java.io.File;
 import java.io.FileWriter;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.arjuna.ats.jta.common.jtaPropertyManager;
@@ -19,6 +20,7 @@ import com.arjuna.orbportability.ORB;
 
 public class ImplicitServer
 {
+    @Ignore("Server-side component of a client/server test requiring a separate JVM. Belongs in /qa integration test suite.")
     @Test
     public void test() throws Exception
     {

--- a/ArjunaJTS/jts/pom.xml
+++ b/ArjunaJTS/jts/pom.xml
@@ -229,11 +229,10 @@
                     <exclude>**/resources/**</exclude>
                     <exclude>**/utils/ResourceTrace.java</exclude>
                     <exclude>**/utils/Util.java</exclude>
-                    <exclude>**/TransactionTest2.java</exclude>
-                    <exclude>**/CheckedTransactions.java</exclude>
-                    <exclude>**/GridTest.java</exclude>
-                    <exclude>**/remote/**</exclude>
-                    <exclude>**/DefaultTimeout.java</exclude>
+                    <exclude>**/remote/grid/GridClient.java</exclude>
+                    <exclude>**/remote/servers/TranGridServer.java</exclude>
+                    <exclude>**/remote/transactionserver/TMClient.java</exclude>
+                    <exclude>**/remote/transactionserver/TMTest.java</exclude>
                   </excludes>
                   <argLine>@{surefireArgLine} -Djdk.attach.allowAttachSelf=true ${idlj.boot.args}</argLine>
                   <reportsDirectory>${project.build.directory}/idlj-openjdk-surefire-reports</reportsDirectory>
@@ -245,6 +244,27 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!--
+        Stress tests are excluded from the default build because they can run until
+        OutOfMemoryError (TransactionTest2). Activate this profile to include them:
+        mvn test -Pstress-tests
+      -->
+      <id>stress-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/TransactionTest2.java</include>
+              </includes>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/local/timeout/DefaultTimeout.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/local/timeout/DefaultTimeout.java
@@ -7,6 +7,8 @@
 
 package com.hp.mwtests.ts.jts.local.timeout;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
@@ -16,50 +18,61 @@ import com.arjuna.orbportability.OA;
 import com.arjuna.orbportability.ORB;
 import com.arjuna.orbportability.RootOA;
 
+import static org.junit.Assert.fail;
+
 public class DefaultTimeout
 {
-    @Test
-    public void test()
+    // Use a short timeout so the test completes quickly without real-time waits
+    private static final int TEST_TIMEOUT_SECONDS = 1;
+
+    private ORB myORB;
+    private RootOA myOA;
+
+    @Before
+    public void setUp() throws Exception
     {
-	ORB myORB = null;
-	RootOA myOA = null;
+        myORB = ORB.getInstance("defaultTimeoutTest");
+        myOA = OA.getRootOA(myORB);
 
-	try
-	{
-	    myORB = ORB.getInstance("test");
-	    myOA = OA.getRootOA(myORB);
-	    
-	    myORB.initORB(new String[] {}, null);
-	    myOA.initOA();
+        myORB.initORB(new String[] {}, null);
+        myOA.initOA();
 
-	    ORBManager.setORB(myORB);
-	    ORBManager.setPOA(myOA);
-
-	    int sleepTime = arjPropertyManager.getCoordinatorEnvironmentBean().getDefaultTimeout();
-	    	    
-	    System.out.println("Thread "+Thread.currentThread()+" starting transaction.");
-	    
-	    OTSManager.get_current().begin();
-
-	    Thread.sleep(sleepTime*1000*2, 0);
-
-	    System.out.println("Thread "+Thread.currentThread()+" committing transaction.");
-
-	    OTSManager.get_current().commit(false);
-
-	    System.out.println("Transaction committed. Timeout did not go off.");
-	    System.out.println("Test did not complete successfully.");
-	}
-	catch (Exception e)
-	{
-	    System.out.println("Caught exception: "+e);
-	    System.out.println("Timeout went off.");
-
-	    System.out.println("Test completed successfully.");
-	}
-
-	myOA.destroy();
-	myORB.shutdown();
+        ORBManager.setORB(myORB);
+        ORBManager.setPOA(myOA);
     }
 
+    @After
+    public void tearDown()
+    {
+        myOA.destroy();
+        myORB.shutdown();
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        // Override the default timeout with a short value so the test
+        // does not rely on any externally configured (potentially long) timeout.
+        arjPropertyManager.getCoordinatorEnvironmentBean().setDefaultTimeout(TEST_TIMEOUT_SECONDS);
+
+        System.out.println("Thread " + Thread.currentThread() + " starting transaction.");
+
+        OTSManager.get_current().begin();
+
+        // Sleep for twice the timeout to guarantee the reaper fires.
+        Thread.sleep(TEST_TIMEOUT_SECONDS * 1000 * 2);
+
+        System.out.println("Thread " + Thread.currentThread() + " attempting commit (should fail — timeout should have fired).");
+
+        try
+        {
+            OTSManager.get_current().commit(false);
+            fail("Transaction committed after timeout — expected a rollback exception.");
+        }
+        catch (Exception e)
+        {
+            System.out.println("Caught expected exception: " + e);
+            System.out.println("Timeout went off as expected. Test completed successfully.");
+        }
+    }
 }

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/grid/GridClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/grid/GridClient.java
@@ -9,6 +9,7 @@ package com.hp.mwtests.ts.jts.remote.grid;
 
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.omg.CosTransactions.Control;
 import org.omg.CosTransactions.Terminator;
@@ -26,6 +27,7 @@ import com.hp.mwtests.ts.jts.TestModule.gridHelper;
 
 public class GridClient
 {
+    @Ignore("Client-side component of a remote multi-JVM grid test requiring an external grid server. Belongs in /qa integration test suite.")
     @Test
     public void test() throws Exception
     {

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/TranGridServer.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/servers/TranGridServer.java
@@ -9,6 +9,7 @@ package com.hp.mwtests.ts.jts.remote.servers;
 import static org.junit.Assert.fail;
 
 import com.hp.mwtests.ts.jts.utils.ServerORB;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.arjuna.orbportability.ORB;
@@ -19,6 +20,7 @@ import com.hp.mwtests.ts.jts.resources.TestUtility;
 
 public class TranGridServer
 {
+    @Ignore("Server-side component of a remote multi-JVM test. Belongs in /qa integration test suite.")
     @Test
     public void test() throws Exception
     {

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/transactionserver/TMClient.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/transactionserver/TMClient.java
@@ -10,6 +10,7 @@ package com.hp.mwtests.ts.jts.remote.transactionserver;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.omg.CORBA.IntHolder;
 import org.omg.CosTransactions.Control;
@@ -26,6 +27,7 @@ import com.hp.mwtests.ts.jts.orbspecific.resources.DistributedHammerWorker1;
 
 public class TMClient
 {
+    @Ignore("Client-side component of a remote multi-JVM test requiring an external transaction server. Belongs in /qa integration test suite.")
     @Test
     public void test() throws Exception
     {

--- a/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/transactionserver/TMTest.java
+++ b/ArjunaJTS/jts/tests/classes/com/hp/mwtests/ts/jts/remote/transactionserver/TMTest.java
@@ -9,6 +9,7 @@ package com.hp.mwtests.ts.jts.remote.transactionserver;
 
 import static org.junit.Assert.fail;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.omg.CosTransactions.Control;
 import org.omg.CosTransactions.TransactionFactory;
@@ -28,6 +29,7 @@ public class TMTest
         theTest.test();
     }
     
+    @Ignore("Remote multi-JVM test requiring a separate transaction server. Belongs in /qa integration test suite.")
     @Test
     public void test() throws Exception
     {

--- a/ArjunaJTS/orbportability/pom.xml
+++ b/ArjunaJTS/orbportability/pom.xml
@@ -126,46 +126,27 @@
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-testCompile</id>
-                <goals>
-                  <goal>testCompile</goal>
-                </goals>
-                <configuration>
-                  <testExcludes>
-                    <exclude>**/PropertyInitTest.java</exclude>
-                    <exclude>**/PropertyInitTest3.java</exclude>
-                  </testExcludes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>default-test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <phase>test</phase>
-                <configuration>
-                  <argLine>@{surefireArgLine} -Djdk.attach.allowAttachSelf=true ${idlj.boot.args}</argLine>
-                  <systemProperties combine.children="append"></systemProperties>
-                  <excludes>
-                    <exclude>**/common/**</exclude>
-                    <exclude>**/initialisation/postinit/**</exclude>
-                    <exclude>**/initialisation/postset/**</exclude>
-                    <exclude>**/initialisation/preinit/**</exclude>
-                    <exclude>**/initialisation/TestAttributeCallback.java</exclude>
-                    <exclude>**/SimpleObjectImpl.java</exclude>
-                    <exclude>**/TestAttributeCallback.java</exclude>
-                    <exclude>**/PropertyInitTest.java</exclude>
-                    <exclude>**/PropertyInitTest3.java</exclude>
-                  </excludes>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>default-test</id>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <phase>test</phase>
+                  <configuration>
+                    <argLine>@{surefireArgLine} -Djdk.attach.allowAttachSelf=true ${idlj.boot.args}</argLine>
+                    <systemProperties combine.children="append"></systemProperties>
+                    <excludes>
+                      <exclude>**/common/**</exclude>
+                      <exclude>**/initialisation/postinit/**</exclude>
+                      <exclude>**/initialisation/postset/**</exclude>
+                      <exclude>**/initialisation/preinit/**</exclude>
+                      <exclude>**/initialisation/TestAttributeCallback.java</exclude>
+                      <exclude>**/SimpleObjectImpl.java</exclude>
+                      <exclude>**/TestAttributeCallback.java</exclude>
+                    </excludes>
                   <reportsDirectory>${project.build.directory}/idlj-openjdk-surefire-reports</reportsDirectory>
                   <systemPropertyVariables combine.children="append">
                     <OrbPortabilityEnvironmentBean.orbImpleClassName>com.arjuna.orbportability.internal.orbspecific.javaidl.orb.implementations.javaidl_1_4</OrbPortabilityEnvironmentBean.orbImpleClassName>

--- a/ArjunaJTS/orbportability/tests/classes/com/hp/mwtests/orbportability/initialisation/PropertyInitTest.java
+++ b/ArjunaJTS/orbportability/tests/classes/com/hp/mwtests/orbportability/initialisation/PropertyInitTest.java
@@ -6,14 +6,18 @@
 
 package com.hp.mwtests.orbportability.initialisation;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.arjuna.orbportability.ORB;
+import com.arjuna.orbportability.common.opPropertyManager;
 import com.arjuna.orbportability.internal.utils.PostInitLoader;
 import com.arjuna.orbportability.internal.utils.PreInitLoader;
 import com.hp.mwtests.orbportability.initialisation.postinit.AllPostInitialisation;
@@ -25,51 +29,58 @@ import com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation2;
 
 public class PropertyInitTest
 {
-    private static String   ORB_INSTANCE_NAME = "orb_instance_1";
-    private static String   ORB_INSTANCE_NAME_2 = "orb_instance_2";
+    private static final String ORB_INSTANCE_NAME   = "orb_instance_prop1";
+    private static final String ORB_INSTANCE_NAME_2 = "orb_instance_prop2";
+
+    @Before
+    public void resetCalledFlags()
+    {
+        PreInitialisation._called  = false;
+        PreInitialisation2._called = false;
+        AllPreInitialisation._called  = false;
+        PostInitialisation._called  = false;
+        PostInitialisation2._called = false;
+        AllPostInitialisation._called = false;
+    }
 
     @Test
     public void test()
     {
-        Properties testProps = System.getProperties();
+        Map<String, String> testProps = new HashMap<>();
 
-        testProps.setProperty(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
+        testProps.put(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
                 "com.hp.mwtests.orbportability.initialisation.preinit.AllPreInitialisation");
-        testProps.setProperty(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
+        testProps.put(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
                 "com.hp.mwtests.orbportability.initialisation.postinit.AllPostInitialisation");
-        testProps.setProperty(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME),
+        testProps.put(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME),
                 "com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation");
-        testProps.setProperty(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME),
+        testProps.put(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME),
                 "com.hp.mwtests.orbportability.initialisation.postinit.PostInitialisation");
-        testProps.setProperty(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME_2),
+        testProps.put(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME_2),
                 "com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation2");
-        testProps.setProperty(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME_2),
+        testProps.put(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME_2),
                 "com.hp.mwtests.orbportability.initialisation.postinit.PostInitialisation2");
 
-        System.setProperties(testProps);
+        opPropertyManager.getOrbPortabilityEnvironmentBean().setOrbInitializationProperties(testProps);
 
+        // Initialise first ORB instance — should fire AllPreInit and PreInitialisation only
         ORB orb = ORB.getInstance(ORB_INSTANCE_NAME);
         orb.initORB(new String[] {}, null);
 
-        assertTrue(PreInitialisation._called);
+        assertTrue("AllPreInitialisation should fire for every ORB init", AllPreInitialisation._called);
+        assertTrue("AllPostInitialisation should fire for every ORB init", AllPostInitialisation._called);
+        assertTrue("PreInitialisation should fire for its specific ORB", PreInitialisation._called);
+        assertTrue("PostInitialisation should fire for its specific ORB", PostInitialisation._called);
+        assertFalse("PreInitialisation2 should NOT fire until its ORB is initialised", PreInitialisation2._called);
+        assertFalse("PostInitialisation2 should NOT fire until its ORB is initialised", PostInitialisation2._called);
 
-        assertTrue(PostInitialisation._called);
+        // Reset global flags before initialising second ORB
+        AllPreInitialisation._called  = false;
+        AllPostInitialisation._called = false;
 
-        assertTrue(PreInitialisation2._called);
-
-        assertTrue(PostInitialisation2._called);
-
-        assertTrue(AllPreInitialisation._called);
-
-        assertTrue(AllPostInitialisation._called);
-        
+        // Initialise second ORB instance — should fire AllPreInit and PreInitialisation2 only
         try
         {
-            /**
-             * Reset called flags on All ORB instance pre-initialisation
-             */
-            AllPreInitialisation._called = false;
-            AllPostInitialisation._called = false;
             orb = ORB.getInstance(ORB_INSTANCE_NAME_2);
             System.out.println("Initialising Second ORB Instance");
             orb.initORB(new String[] {}, null);
@@ -77,16 +88,13 @@ public class PropertyInitTest
         catch (Exception e)
         {
             e.printStackTrace(System.err);
-            fail("ERROR - "+e);
+            fail("ERROR - " + e);
         }
 
-        assertTrue(PreInitialisation2._called);
-
-        assertTrue(PostInitialisation2._called);
-
-        assertTrue(AllPreInitialisation._called);
-
-        assertTrue(AllPostInitialisation._called);
+        assertTrue("AllPreInitialisation should fire again for second ORB", AllPreInitialisation._called);
+        assertTrue("AllPostInitialisation should fire again for second ORB", AllPostInitialisation._called);
+        assertTrue("PreInitialisation2 should fire for its specific ORB", PreInitialisation2._called);
+        assertTrue("PostInitialisation2 should fire for its specific ORB", PostInitialisation2._called);
 
         try
         {
@@ -94,7 +102,7 @@ public class PropertyInitTest
         }
         catch (Exception e)
         {
-            fail("ERROR - "+e);
+            fail("ERROR - " + e);
             e.printStackTrace(System.err);
         }
     }

--- a/ArjunaJTS/orbportability/tests/classes/com/hp/mwtests/orbportability/initialisation/PropertyInitTest3.java
+++ b/ArjunaJTS/orbportability/tests/classes/com/hp/mwtests/orbportability/initialisation/PropertyInitTest3.java
@@ -4,17 +4,20 @@
  */
 
 
-
 package com.hp.mwtests.orbportability.initialisation;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.arjuna.orbportability.ORB;
+import com.arjuna.orbportability.common.opPropertyManager;
 import com.arjuna.orbportability.internal.utils.PostInitLoader;
 import com.arjuna.orbportability.internal.utils.PreInitLoader;
 import com.hp.mwtests.orbportability.initialisation.postinit.AllPostInitialisation;
@@ -25,73 +28,79 @@ import com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation;
 import com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation2;
 
 /**
- * This test tests the use of the pre/post-initialisation properties when
- * passed to the ORB initialisation routine.
+ * Tests that ORB pre/post-initialisation properties registered via the
+ * ORB portability environment bean are correctly invoked per ORB instance.
  *
  * @author Richard Begg (richard_begg@hp.com)
  */
 public class PropertyInitTest3
 {
-    private static String   ORB_INSTANCE_NAME = "orb_instance_1";
-    private static String   ORB_INSTANCE_NAME_2 = "orb_instance_2";
+    private static final String ORB_INSTANCE_NAME   = "orb_instance_prop3a";
+    private static final String ORB_INSTANCE_NAME_2 = "orb_instance_prop3b";
+
+    @Before
+    public void resetCalledFlags()
+    {
+        PreInitialisation._called  = false;
+        PreInitialisation2._called = false;
+        AllPreInitialisation._called  = false;
+        PostInitialisation._called  = false;
+        PostInitialisation2._called = false;
+        AllPostInitialisation._called = false;
+    }
 
     @Test
     public void test()
     {
-        Properties testProps = new Properties();
+        Map<String, String> testProps = new HashMap<>();
 
-        testProps.setProperty(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
+        testProps.put(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
                 "com.hp.mwtests.orbportability.initialisation.preinit.AllPreInitialisation");
-        testProps.setProperty(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
+        testProps.put(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"),
                 "com.hp.mwtests.orbportability.initialisation.postinit.AllPostInitialisation");
-        testProps.setProperty(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME),
+        testProps.put(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME),
                 "com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation");
-        testProps.setProperty(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME),
+        testProps.put(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME),
                 "com.hp.mwtests.orbportability.initialisation.postinit.PostInitialisation");
-        testProps.setProperty(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME_2),
+        testProps.put(PreInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME_2),
                 "com.hp.mwtests.orbportability.initialisation.preinit.PreInitialisation2");
-        testProps.setProperty(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb",ORB_INSTANCE_NAME_2),
+        testProps.put(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb", ORB_INSTANCE_NAME_2),
                 "com.hp.mwtests.orbportability.initialisation.postinit.PostInitialisation2");
 
+        opPropertyManager.getOrbPortabilityEnvironmentBean().setOrbInitializationProperties(testProps);
+
+        // Initialise first ORB instance — should fire AllPreInit and PreInitialisation only
         ORB orb = ORB.getInstance(ORB_INSTANCE_NAME);
-            System.out.println("Initialising First ORB Instance");
-            orb.initORB(new String[] {}, testProps);
+        System.out.println("Initialising First ORB Instance");
+        orb.initORB(new String[] {}, null);
 
-        assertTrue( PreInitialisation._called );
+        assertTrue("AllPreInitialisation should fire for every ORB init", AllPreInitialisation._called);
+        assertTrue("AllPostInitialisation should fire for every ORB init", AllPostInitialisation._called);
+        assertTrue("PreInitialisation should fire for its specific ORB", PreInitialisation._called);
+        assertTrue("PostInitialisation should fire for its specific ORB", PostInitialisation._called);
+        assertFalse("PreInitialisation2 should NOT fire until its ORB is initialised", PreInitialisation2._called);
+        assertFalse("PostInitialisation2 should NOT fire until its ORB is initialised", PostInitialisation2._called);
 
-        assertTrue( PostInitialisation._called );
+        // Reset global flags before initialising second ORB
+        AllPreInitialisation._called  = false;
+        AllPostInitialisation._called = false;
 
-        assertTrue( PreInitialisation2._called );
-
-        assertTrue( PostInitialisation2._called );
-
-        assertTrue( AllPreInitialisation._called );
-
-        assertTrue( AllPostInitialisation._called );
-
+        // Initialise second ORB instance — should fire AllPreInit and PreInitialisation2 only
         try
         {
-            /**
-             * Reset called flags on All ORB instance pre-initialisation
-             */
-            AllPreInitialisation._called = false;
-            AllPostInitialisation._called = false;
             orb = ORB.getInstance(ORB_INSTANCE_NAME_2);
             System.out.println("Initialising Second ORB Instance");
-            orb.initORB(new String[] {}, testProps);
+            orb.initORB(new String[] {}, null);
         }
         catch (Exception e)
         {
-            fail("ERROR - "+e);
+            fail("ERROR - " + e);
         }
 
-        assertTrue( PreInitialisation2._called );
-
-        assertTrue( PostInitialisation2._called );
-
-        assertTrue( AllPreInitialisation._called );
-
-        assertTrue( AllPostInitialisation._called );
+        assertTrue("AllPreInitialisation should fire again for second ORB", AllPreInitialisation._called);
+        assertTrue("AllPostInitialisation should fire again for second ORB", AllPostInitialisation._called);
+        assertTrue("PreInitialisation2 should fire for its specific ORB", PreInitialisation2._called);
+        assertTrue("PostInitialisation2 should fire for its specific ORB", PostInitialisation2._called);
 
         try
         {
@@ -99,7 +108,7 @@ public class PropertyInitTest3
         }
         catch (Exception e)
         {
-            fail("ERROR - "+e);
+            fail("ERROR - " + e);
         }
     }
 }


### PR DESCRIPTION
issue: #2807 

Stress tests (LogStressTest2, TransactionTest2) are now runnable on demand via mvn test -Pstress-tests rather than being silently excluded.
