### PR TITLE
Add release.yml for changelog configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+changelog:
+  categories:
+    - title: Contributions from the Narayana community
+      labels:
+        - '*'
+      exclude:
+        authors:
+          - dependabot
+          - dependabot[bot]
+    - title: Dependencies updates
+      labels:
+        - dependencies


### PR DESCRIPTION
Customize the changelog to separate community's contributions from dependabot's changes in 2 different categories.