### PR TITLE
[#2960] Add missing STATUS_COMMITTING to JTAHelper.stringForm()

### DIFF
--- a/ArjunaJTA/jta/classes/com/arjuna/ats/jta/utils/JTAHelper.java
+++ b/ArjunaJTA/jta/classes/com/arjuna/ats/jta/utils/JTAHelper.java
@@ -32,6 +32,8 @@ public class JTAHelper
             return "jakarta.transaction.Status.STATUS_PREPARING";
 	case jakarta.transaction.Status.STATUS_ROLLEDBACK:
 	    return "jakarta.transaction.Status.STATUS_ROLLEDBACK";
+	case jakarta.transaction.Status.STATUS_COMMITTING:
+            return "jakarta.transaction.Status.STATUS_COMMITTING";
 	case jakarta.transaction.Status.STATUS_ROLLING_BACK:
             return "jakarta.transaction.Status.STATUS_ROLLING_BACK";
 	case jakarta.transaction.Status.STATUS_UNKNOWN:

--- a/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/utils/UtilsUnitTest.java
+++ b/ArjunaJTA/jta/tests/classes/com/hp/mwtests/ts/jta/utils/UtilsUnitTest.java
@@ -58,6 +58,7 @@ public class UtilsUnitTest
         assertEquals(JTAHelper.stringForm(jakarta.transaction.Status.STATUS_PREPARED), "jakarta.transaction.Status.STATUS_PREPARED");
         assertEquals(JTAHelper.stringForm(jakarta.transaction.Status.STATUS_PREPARING), "jakarta.transaction.Status.STATUS_PREPARING");
         assertEquals(JTAHelper.stringForm(jakarta.transaction.Status.STATUS_ROLLEDBACK), "jakarta.transaction.Status.STATUS_ROLLEDBACK");
+        assertEquals(JTAHelper.stringForm(jakarta.transaction.Status.STATUS_COMMITTING), "jakarta.transaction.Status.STATUS_COMMITTING");
         assertEquals(JTAHelper.stringForm(jakarta.transaction.Status.STATUS_ROLLING_BACK), "jakarta.transaction.Status.STATUS_ROLLING_BACK");
         assertEquals(JTAHelper.stringForm(jakarta.transaction.Status.STATUS_UNKNOWN), "jakarta.transaction.Status.STATUS_UNKNOWN");
     }


### PR DESCRIPTION
CORE !AS_TESTS !RTS !JACOCO !XTS !QA_JTA !QA_JTS_OPENJDKORB !PERFORMANCE !DB_TESTS mysql db2 postgres oracle

